### PR TITLE
feat: add `/mcp/tools.json` endpoint

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -7,7 +7,20 @@ use axum::Router;
 use rmcp::transport::streamable_http_server::StreamableHttpService;
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 
-use crate::tools::Longbridge;
+use crate::tools::{self, Longbridge};
+
+async fn tools_json() -> axum::Json<serde_json::Value> {
+    let tools = tools::list_tools()
+        .into_iter()
+        .map(|t| {
+            serde_json::json!({
+                "name": t.name,
+                "description": t.description,
+            })
+        })
+        .collect::<Vec<_>>();
+    axum::Json(serde_json::json!({ "tools": tools }))
+}
 
 pub struct AppState {
     pub base_url: String,
@@ -25,6 +38,9 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         "/metrics",
         axum::routing::get(crate::metrics::metrics_handler),
     );
+
+    let tools_route: Router =
+        Router::new().route("/mcp/tools.json", axum::routing::get(tools_json));
 
     let mcp_service = StreamableHttpService::new(
         move || Ok(Longbridge),
@@ -46,5 +62,6 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     Router::new()
         .merge(metadata_routes)
         .merge(metrics_route)
+        .merge(tools_route)
         .nest_service("/mcp", mcp_with_auth)
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -10,15 +10,7 @@ use rmcp::transport::streamable_http_server::session::local::LocalSessionManager
 use crate::tools::{self, Longbridge};
 
 async fn tools_json() -> axum::Json<serde_json::Value> {
-    let tools = tools::list_tools()
-        .into_iter()
-        .map(|t| {
-            serde_json::json!({
-                "name": t.name,
-                "description": t.description,
-            })
-        })
-        .collect::<Vec<_>>();
+    let tools = tools::list_tools();
     axum::Json(serde_json::json!({ "tools": tools }))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,13 @@ async fn main() -> anyhow::Result<()> {
     let app =
         auth::create_router(app_state.clone()).layer(tower_http::cors::CorsLayer::permissive());
 
+    let tools = crate::tools::list_tools();
+    tracing::info!(
+        count = tools.len(),
+        url = format!("{}/mcp/tools.json", config.base_url),
+        "tools available"
+    );
+
     if let (Some(cert), Some(key)) = (&config.tls_cert, &config.tls_key) {
         let tls_config = axum_server::tls_rustls::RustlsConfig::from_pem_file(cert, key).await?;
         let handle = axum_server::Handle::new();

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -84,6 +84,11 @@ pub fn create_config(token: &str) -> Arc<longbridge::Config> {
     )
 }
 
+/// Returns all registered MCP tools sorted by name.
+pub fn list_tools() -> Vec<rmcp::model::Tool> {
+    Longbridge::tool_router().list_all()
+}
+
 pub fn create_http_client(token: &str) -> longbridge::httpclient::HttpClient {
     longbridge::httpclient::HttpClient::new(longbridge::httpclient::HttpClientConfig::from_oauth(
         longbridge::oauth::OAuth::from_token(token),
@@ -101,7 +106,7 @@ use crate::tools::trade::{
     SubmitOrderParam,
 };
 
-#[tool_router]
+#[tool_router(vis = "pub(crate)")]
 impl Longbridge {
     /// Get current UTC time in RFC3339 format.
     #[tool(description = "Get current UTC time")]


### PR DESCRIPTION
## Summary

- Add `GET /mcp/tools.json` endpoint (no auth required) that returns all registered MCP tool names and descriptions as JSON
- Expose `tool_router` with `pub(crate)` visibility via `#[tool_router(vis = "pub(crate)")]`
- Add `tools::list_tools()` public helper backed by `ToolRouter::list_all()`
- Log tool count and URL on server startup

## Test plan

- [ ] Start server and verify startup log shows `tools available count=N url=.../mcp/tools.json`
- [ ] `curl http://localhost:8000/mcp/tools.json` returns JSON with `tools` array containing name/description for each tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)