### PR TITLE
feat: add sharelist, DCA, and option volume tools from v0.17.0

### DIFF
--- a/src/tools/dca.rs
+++ b/src/tools/dca.rs
@@ -1,0 +1,178 @@
+use rmcp::ErrorData as McpError;
+use rmcp::model::CallToolResult;
+use rmcp::schemars::JsonSchema;
+use rmcp::serde::Deserialize;
+
+use crate::counter::symbol_to_counter_id;
+use crate::tools::http_client::{http_get_tool, http_post_tool};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DcaListParam {
+    /// Page number (1-based)
+    pub page: u32,
+    /// Number of results per page
+    pub limit: u32,
+    /// Filter by status: "Active", "Suspended", "Finished" (optional)
+    pub status: Option<String>,
+    /// Filter by symbol, e.g. "TSLA.US" (optional)
+    pub symbol: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DcaCreateParam {
+    /// Security symbol, e.g. "TSLA.US"
+    pub symbol: String,
+    /// Amount per investment (as string, e.g. "100.00")
+    pub per_invest_amount: String,
+    /// Investment frequency: "daily", "weekly", "monthly"
+    pub invest_frequency: String,
+    /// Day of week for weekly plans (0=Sunday … 6=Saturday, optional)
+    pub invest_day_of_week: Option<String>,
+    /// Day of month for monthly plans (1-31, optional)
+    pub invest_day_of_month: Option<String>,
+    /// Allow margin financing: 0 = no, 1 = yes
+    pub allow_margin_finance: u32,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DcaUpdateParam {
+    /// DCA plan ID
+    pub plan_id: String,
+    /// New amount per investment (optional)
+    pub per_invest_amount: Option<String>,
+    /// New investment frequency (optional): "daily", "weekly", "monthly"
+    pub invest_frequency: Option<String>,
+    /// Day of week for weekly plans (optional)
+    pub invest_day_of_week: Option<String>,
+    /// Day of month for monthly plans (optional)
+    pub invest_day_of_month: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DcaToggleParam {
+    /// DCA plan ID
+    pub plan_id: String,
+    /// New status: "Suspended" (pause) or "Active" (resume)
+    pub status: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DcaRecordsParam {
+    /// DCA plan ID
+    pub plan_id: String,
+    /// Page number (1-based)
+    pub page: u32,
+    /// Number of results per page
+    pub limit: u32,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DcaStatisticsParam {
+    /// Filter by symbol, e.g. "TSLA.US" (optional)
+    pub symbol: Option<String>,
+}
+
+pub async fn dca_list(
+    mctx: &crate::tools::McpContext,
+    p: DcaListParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let page_str = p.page.to_string();
+    let limit_str = p.limit.to_string();
+    let cid = p.symbol.as_deref().map(symbol_to_counter_id);
+    let mut params: Vec<(&str, &str)> =
+        vec![("page", page_str.as_str()), ("limit", limit_str.as_str())];
+    if let Some(s) = p.status.as_deref() {
+        params.push(("status", s));
+    }
+    if let Some(ref c) = cid {
+        params.push(("counter_id", c.as_str()));
+    }
+    http_get_tool(&client, "/v1/dailycoins/query", &params).await
+}
+
+pub async fn dca_create(
+    mctx: &crate::tools::McpContext,
+    p: DcaCreateParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let cid = symbol_to_counter_id(&p.symbol);
+    let mut body = serde_json::json!({
+        "counter_id": cid,
+        "per_invest_amount": p.per_invest_amount,
+        "invest_frequency": p.invest_frequency,
+        "allow_margin_finance": p.allow_margin_finance,
+    });
+    if let Some(v) = p.invest_day_of_week {
+        body["invest_day_of_week"] = serde_json::Value::String(v);
+    }
+    if let Some(v) = p.invest_day_of_month {
+        body["invest_day_of_month"] = serde_json::Value::String(v);
+    }
+    http_post_tool(&client, "/v1/dailycoins/create", body).await
+}
+
+pub async fn dca_update(
+    mctx: &crate::tools::McpContext,
+    p: DcaUpdateParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let mut body = serde_json::json!({ "plan_id": p.plan_id });
+    if let Some(v) = p.per_invest_amount {
+        body["per_invest_amount"] = serde_json::Value::String(v);
+    }
+    if let Some(v) = p.invest_frequency {
+        body["invest_frequency"] = serde_json::Value::String(v);
+    }
+    if let Some(v) = p.invest_day_of_week {
+        body["invest_day_of_week"] = serde_json::Value::String(v);
+    }
+    if let Some(v) = p.invest_day_of_month {
+        body["invest_day_of_month"] = serde_json::Value::String(v);
+    }
+    http_post_tool(&client, "/v1/dailycoins/update", body).await
+}
+
+pub async fn dca_toggle(
+    mctx: &crate::tools::McpContext,
+    p: DcaToggleParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let body = serde_json::json!({
+        "plan_id": p.plan_id,
+        "status": p.status,
+    });
+    http_post_tool(&client, "/v1/dailycoins/toggle", body).await
+}
+
+pub async fn dca_records(
+    mctx: &crate::tools::McpContext,
+    p: DcaRecordsParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let page_str = p.page.to_string();
+    let limit_str = p.limit.to_string();
+    http_get_tool(
+        &client,
+        "/v1/dailycoins/query-records",
+        &[
+            ("plan_id", p.plan_id.as_str()),
+            ("page", page_str.as_str()),
+            ("limit", limit_str.as_str()),
+        ],
+    )
+    .await
+}
+
+pub async fn dca_statistics(
+    mctx: &crate::tools::McpContext,
+    p: DcaStatisticsParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let cid = p.symbol.as_deref().map(symbol_to_counter_id);
+    let mut params: Vec<(&str, &str)> = Vec::new();
+    if let Some(ref c) = cid {
+        params.push(("counter_id", c.as_str()));
+    }
+    http_get_tool(&client, "/v1/dailycoins/statistic", &params).await
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -29,12 +29,14 @@ where
 mod alert;
 mod calendar;
 mod content;
+mod dca;
 mod fundamental;
 pub mod http_client;
 mod market;
 mod parse;
 mod portfolio;
 mod quote;
+mod sharelist;
 mod statement;
 mod trade;
 
@@ -113,11 +115,20 @@ pub fn list_tools() -> Vec<rmcp::model::Tool> {
     Longbridge::tool_router().list_all()
 }
 
+use crate::tools::dca::{
+    DcaCreateParam, DcaListParam, DcaRecordsParam, DcaStatisticsParam, DcaToggleParam,
+    DcaUpdateParam,
+};
 use crate::tools::quote::{
     CalcIndexesParam, CandlesticksParam, CreateWatchlistGroupParam, DeleteWatchlistGroupParam,
     HistoryCandlesticksByDateParam, HistoryCandlesticksByOffsetParam, MarketDateRangeParam,
-    MarketParam, SecurityListParam, SymbolCountParam, SymbolDateParam, SymbolParam, SymbolsParam,
-    UpdateWatchlistGroupParam, WarrantListParam,
+    MarketParam, OptionVolumeDailyParam, OptionVolumeParam, SecurityListParam, ShortPositionsParam,
+    SymbolCountParam, SymbolDateParam, SymbolParam, SymbolsParam, UpdateWatchlistGroupParam,
+    WarrantListParam,
+};
+use crate::tools::sharelist::{
+    SharelistCreateParam, SharelistIdParam, SharelistItemsParam, SharelistListParam,
+    SharelistPopularParam,
 };
 use crate::tools::trade::{
     CashFlowParam, EstimateMaxQtyParam, HistoryOrdersParam, OrderIdParam, ReplaceOrderParam,
@@ -1150,6 +1161,209 @@ impl Longbridge {
     ) -> Result<CallToolResult, McpError> {
         let mctx = extract_context(&ctx)?;
         measured_tool_call("statement_export", || statement::statement_export(&mctx, p)).await
+    }
+
+    /// Get US short interest positions for a symbol.
+    #[tool(
+        description = "Get US short interest data for a symbol (short_shares, short_rate, days_cover, avg_daily_vol). count: 1-100"
+    )]
+    async fn short_positions(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<ShortPositionsParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("short_positions", || quote::short_positions(&mctx, p)).await
+    }
+
+    /// Get option volume stats (call/put volume and put/call ratio).
+    #[tool(
+        description = "Get option volume statistics for an underlying symbol (call volume, put volume, put/call ratio)"
+    )]
+    async fn option_volume_stats(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<OptionVolumeParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("option_volume_stats", || {
+            quote::option_volume_stats(&mctx, p)
+        })
+        .await
+    }
+
+    /// Get daily option volume history.
+    #[tool(
+        description = "Get daily option volume history for an underlying symbol (total volume, call/put volume, open interest)"
+    )]
+    async fn option_volume_daily(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<OptionVolumeDailyParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("option_volume_daily", || {
+            quote::option_volume_daily(&mctx, p)
+        })
+        .await
+    }
+
+    /// List sharelists (own and/or subscribed).
+    #[tool(
+        description = "List sharelists (public watchlists). include_self: include own lists (default true), subscription: include subscribed lists"
+    )]
+    async fn sharelist_list(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<SharelistListParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("sharelist_list", || sharelist::sharelist_list(&mctx, p)).await
+    }
+
+    /// Get sharelist detail.
+    #[tool(description = "Get sharelist detail including constituent stocks and quotes")]
+    async fn sharelist_detail(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<SharelistIdParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("sharelist_detail", || sharelist::sharelist_detail(&mctx, p)).await
+    }
+
+    /// Create a sharelist.
+    #[tool(description = "Create a new sharelist (public watchlist)")]
+    async fn sharelist_create(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<SharelistCreateParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("sharelist_create", || sharelist::sharelist_create(&mctx, p)).await
+    }
+
+    /// Delete a sharelist.
+    #[tool(description = "Delete a sharelist by id")]
+    async fn sharelist_delete(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<SharelistIdParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("sharelist_delete", || sharelist::sharelist_delete(&mctx, p)).await
+    }
+
+    /// Add stocks to a sharelist.
+    #[tool(description = "Add securities to a sharelist by symbol")]
+    async fn sharelist_add_items(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<SharelistItemsParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("sharelist_add_items", || {
+            sharelist::sharelist_add_items(&mctx, p)
+        })
+        .await
+    }
+
+    /// Remove stocks from a sharelist.
+    #[tool(description = "Remove securities from a sharelist by symbol")]
+    async fn sharelist_remove_items(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<SharelistItemsParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("sharelist_remove_items", || {
+            sharelist::sharelist_remove_items(&mctx, p)
+        })
+        .await
+    }
+
+    /// Get popular sharelists.
+    #[tool(description = "Get trending/popular sharelists")]
+    async fn sharelist_popular(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<SharelistPopularParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("sharelist_popular", || {
+            sharelist::sharelist_popular(&mctx, p)
+        })
+        .await
+    }
+
+    /// List recurring investment (DCA) plans.
+    #[tool(description = "List recurring investment plans. status: Active/Suspended/Finished")]
+    async fn dca_list(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<DcaListParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("dca_list", || dca::dca_list(&mctx, p)).await
+    }
+
+    /// Create a recurring investment (DCA) plan.
+    #[tool(
+        description = "Create a recurring investment plan. invest_frequency: daily/weekly/monthly"
+    )]
+    async fn dca_create(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<DcaCreateParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("dca_create", || dca::dca_create(&mctx, p)).await
+    }
+
+    /// Update a recurring investment (DCA) plan.
+    #[tool(description = "Update an existing recurring investment plan")]
+    async fn dca_update(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<DcaUpdateParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("dca_update", || dca::dca_update(&mctx, p)).await
+    }
+
+    /// Toggle (pause/resume) a recurring investment plan.
+    #[tool(
+        description = "Pause or resume a recurring investment plan. status: Suspended (pause) or Active (resume)"
+    )]
+    async fn dca_toggle(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<DcaToggleParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("dca_toggle", || dca::dca_toggle(&mctx, p)).await
+    }
+
+    /// Get execution records for a recurring investment plan.
+    #[tool(description = "Get execution records (history) for a recurring investment plan")]
+    async fn dca_records(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<DcaRecordsParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("dca_records", || dca::dca_records(&mctx, p)).await
+    }
+
+    /// Get recurring investment statistics.
+    #[tool(description = "Get recurring investment statistics (total invested, profit/loss)")]
+    async fn dca_statistics(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<DcaStatisticsParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("dca_statistics", || dca::dca_statistics(&mctx, p)).await
     }
 }
 

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -6,7 +6,9 @@ use rmcp::model::CallToolResult;
 use rmcp::schemars::JsonSchema;
 use rmcp::serde::Deserialize;
 
+use crate::counter::symbol_to_counter_id;
 use crate::error::Error;
+use crate::tools::http_client::http_get_tool;
 use crate::tools::parse;
 use crate::tools::{tool_json, tool_result};
 
@@ -587,4 +589,89 @@ pub async fn security_list(
         .await
         .map_err(Error::longbridge)?;
     tool_json(&result)
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ShortPositionsParam {
+    /// Security symbol, e.g. "TSLA.US"
+    pub symbol: String,
+    /// Number of records to retrieve (1-100)
+    pub count: u32,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct OptionVolumeParam {
+    /// Underlying security symbol, e.g. "TSLA.US"
+    pub symbol: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct OptionVolumeDailyParam {
+    /// Underlying security symbol, e.g. "TSLA.US"
+    pub symbol: String,
+    /// Number of daily records to retrieve
+    pub count: u32,
+}
+
+pub async fn short_positions(
+    mctx: &crate::tools::McpContext,
+    p: ShortPositionsParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let cid = symbol_to_counter_id(&p.symbol);
+    let page_size = p.count.clamp(1, 100).to_string();
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        .to_string();
+    http_get_tool(
+        &client,
+        "/v1/quote/short-positions/us",
+        &[
+            ("counter_id", cid.as_str()),
+            ("last_timestamp", ts.as_str()),
+            ("page_size", page_size.as_str()),
+        ],
+    )
+    .await
+}
+
+pub async fn option_volume_stats(
+    mctx: &crate::tools::McpContext,
+    p: OptionVolumeParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let cid = symbol_to_counter_id(&p.symbol);
+    http_get_tool(
+        &client,
+        "/v1/quote/option-volume-stats",
+        &[("underlying_counter_id", cid.as_str())],
+    )
+    .await
+}
+
+pub async fn option_volume_daily(
+    mctx: &crate::tools::McpContext,
+    p: OptionVolumeDailyParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let cid = symbol_to_counter_id(&p.symbol);
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        .to_string();
+    let line_num = p.count.to_string();
+    http_get_tool(
+        &client,
+        "/v1/quote/option-volume-stats/daily",
+        &[
+            ("counter_id", cid.as_str()),
+            ("timestamp", ts.as_str()),
+            ("line_num", line_num.as_str()),
+            ("direction", "1"),
+        ],
+    )
+    .await
 }

--- a/src/tools/sharelist.rs
+++ b/src/tools/sharelist.rs
@@ -1,0 +1,139 @@
+use rmcp::ErrorData as McpError;
+use rmcp::model::CallToolResult;
+use rmcp::schemars::JsonSchema;
+use rmcp::serde::Deserialize;
+
+use crate::counter::symbol_to_counter_id;
+use crate::tools::http_client::{http_delete_tool, http_get_tool, http_post_tool};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SharelistListParam {
+    /// Maximum number of results
+    pub size: Option<u32>,
+    /// Include own sharelists (default true)
+    pub include_self: Option<bool>,
+    /// Include subscribed sharelists (default false)
+    pub subscription: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SharelistIdParam {
+    /// Sharelist ID
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SharelistCreateParam {
+    /// Sharelist name
+    pub name: String,
+    /// Description (optional)
+    pub description: Option<String>,
+    /// Cover image URL (optional)
+    pub cover: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SharelistItemsParam {
+    /// Sharelist ID
+    pub id: String,
+    /// Security symbols, e.g. ["700.HK", "AAPL.US"]
+    pub symbols: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SharelistPopularParam {
+    /// Maximum number of results
+    pub size: Option<u32>,
+}
+
+pub async fn sharelist_list(
+    mctx: &crate::tools::McpContext,
+    p: SharelistListParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let size_str = p.size.map(|s| s.to_string());
+    let mut params: Vec<(&str, &str)> = Vec::new();
+    if let Some(ref s) = size_str {
+        params.push(("size", s.as_str()));
+    }
+    if p.include_self.unwrap_or(true) {
+        params.push(("self", "true"));
+    }
+    if p.subscription.unwrap_or(false) {
+        params.push(("subscription", "true"));
+    }
+    http_get_tool(&client, "/v1/sharelists", &params).await
+}
+
+pub async fn sharelist_detail(
+    mctx: &crate::tools::McpContext,
+    p: SharelistIdParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let path = format!("/v1/sharelists/{}", p.id);
+    http_get_tool(
+        &client,
+        &path,
+        &[("constituent", "true"), ("quote", "true")],
+    )
+    .await
+}
+
+pub async fn sharelist_create(
+    mctx: &crate::tools::McpContext,
+    p: SharelistCreateParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let mut body = serde_json::json!({ "name": p.name });
+    if let Some(desc) = p.description {
+        body["description"] = serde_json::Value::String(desc);
+    }
+    if let Some(cover) = p.cover {
+        body["cover"] = serde_json::Value::String(cover);
+    }
+    http_post_tool(&client, "/v1/sharelists", body).await
+}
+
+pub async fn sharelist_delete(
+    mctx: &crate::tools::McpContext,
+    p: SharelistIdParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let path = format!("/v1/sharelists/{}", p.id);
+    http_delete_tool(&client, &path, serde_json::Value::Null).await
+}
+
+pub async fn sharelist_add_items(
+    mctx: &crate::tools::McpContext,
+    p: SharelistItemsParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let path = format!("/v1/sharelists/{}/items", p.id);
+    let counter_ids: Vec<String> = p.symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
+    let body = serde_json::json!({ "counter_ids": counter_ids.join(",") });
+    http_post_tool(&client, &path, body).await
+}
+
+pub async fn sharelist_remove_items(
+    mctx: &crate::tools::McpContext,
+    p: SharelistItemsParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let path = format!("/v1/sharelists/{}/items", p.id);
+    let counter_ids: Vec<String> = p.symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
+    let body = serde_json::json!({ "counter_ids": counter_ids.join(",") });
+    http_delete_tool(&client, &path, body).await
+}
+
+pub async fn sharelist_popular(
+    mctx: &crate::tools::McpContext,
+    p: SharelistPopularParam,
+) -> Result<CallToolResult, McpError> {
+    let client = mctx.create_http_client();
+    let size_str = p.size.map(|s| s.to_string());
+    let mut params: Vec<(&str, &str)> = Vec::new();
+    if let Some(ref s) = size_str {
+        params.push(("size", s.as_str()));
+    }
+    http_get_tool(&client, "/v1/sharelists/popular", &params).await
+}


### PR DESCRIPTION
## Summary

- **3 quote tools**: `short_positions` (US short interest), `option_volume_stats` (call/put ratio), `option_volume_daily` (daily option volume history)
- **7 sharelist tools**: full CRUD for sharelists — list, detail, create, delete, add/remove items, popular
- **6 DCA tools**: recurring investment plan management — list, create, update, toggle (pause/resume), records, statistics

All tools follow existing HTTP client patterns (`http_get_tool` / `http_post_tool` / `http_delete_tool`) with symbol→counter_id conversion via `symbol_to_counter_id()`. Total tool count: 90 → 106.

Based on [longbridge-terminal v0.17.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.0).

## Test plan

- [x] `cargo check` — compiles clean
- [x] `cargo clippy --all-features --all-targets` — zero warnings
- [x] `cargo +nightly fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)