### PR TITLE
chore: add MCP server discovery label to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 RUN cargo build --release
 
 FROM debian:bookworm-slim
+LABEL io.modelcontextprotocol.server.name="com.longbridge/mcp"
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Add `io.modelcontextprotocol.server.name` OCI label to Dockerfile for MCP server discovery