### PR TITLE
feat(auth): serve static MCP server card for directory scanners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-mcp"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longbridge-mcp"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/logo.png" alt="Longbridge" width="120" height="120">
+  <img src="https://raw.githubusercontent.com/longbridge/longbridge-mcp/main/docs/logo.png" alt="Longbridge" width="120" height="120">
 </p>
 
 <h1 align="center">Longbridge MCP Server</h1>

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.longbridge/mcp",
   "description": "US/HK markets — 110 tools: real-time quotes, options, orders, fundamentals, alerts, DCA & portfolio",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.1.7",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.1.8",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",

--- a/src/auth/metadata.rs
+++ b/src/auth/metadata.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use axum::extract::State;
 use axum::response::Json;
@@ -26,4 +26,47 @@ pub async fn protected_resource_metadata(
         authorization_servers: vec![longbridge_oauth_url()],
         scopes_supported: vec!["openapi".to_string()],
     })
+}
+
+#[derive(Serialize)]
+struct ServerInfoCard {
+    name: &'static str,
+    version: &'static str,
+}
+
+#[derive(Serialize)]
+struct AuthCard {
+    required: bool,
+    schemes: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ServerCard {
+    #[serde(rename = "serverInfo")]
+    server_info: ServerInfoCard,
+    authentication: AuthCard,
+    tools: Vec<rmcp::model::Tool>,
+}
+
+static SERVER_CARD: LazyLock<ServerCard> = LazyLock::new(|| ServerCard {
+    server_info: ServerInfoCard {
+        name: "Longbridge MCP Server",
+        version: env!("CARGO_PKG_VERSION"),
+    },
+    authentication: AuthCard {
+        required: true,
+        schemes: vec!["oauth2"],
+    },
+    tools: crate::tools::list_tools(),
+});
+
+/// Static MCP server card served at `/.well-known/mcp/server-card.json`.
+///
+/// Lets directory scanners (e.g. Smithery) discover server metadata and the
+/// full tool list without performing the authenticated `tools/list` probe.
+/// Declaring `authentication.schemes = ["oauth2"]` signals that the client
+/// should follow the RFC 9728 protected-resource-metadata flow rather than
+/// attempting Dynamic Client Registration directly.
+pub async fn server_card() -> Json<&'static ServerCard> {
+    Json(&*SERVER_CARD)
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -31,6 +31,11 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         )
         .with_state(state.clone());
 
+    let server_card_route = Router::new().route(
+        "/.well-known/mcp/server-card.json",
+        axum::routing::get(metadata::server_card),
+    );
+
     let health_route = Router::new().route("/health", axum::routing::get(health));
 
     let metrics_route = Router::new().route(
@@ -60,6 +65,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
 
     Router::new()
         .merge(metadata_routes)
+        .merge(server_card_route)
         .merge(health_route)
         .merge(metrics_route)
         .merge(tools_route)


### PR DESCRIPTION
## Summary

- Adds `GET /.well-known/mcp/server-card.json` returning `serverInfo`, `authentication` scheme and the full tool list (built from `tools::list_tools()`, cached in a `LazyLock`).
- Mounts the route outside the `/mcp` auth middleware so scanners don't get 401'd.
- Bumps version to 0.1.8 (+ `server.json` `version` and OCI `identifier` tag).

Unblocks Smithery directory scanning. Smithery was looping on our OAuth server's Dynamic Client Registration endpoint (RFC 7591 non-conformance: 200 instead of 201, missing `client_secret` in response body). A static server card declaring `authentication.schemes = ["oauth2"]` lets Smithery skip DCR entirely and fall back to its Client ID Metadata Document flow.

## What the endpoint returns

```json
{
  "serverInfo": {
    "name": "Longbridge MCP Server",
    "version": "0.1.8"
  },
  "authentication": {
    "required": true,
    "schemes": ["oauth2"]
  },
  "tools": [
    { "name": "account_balance", "description": "...", "inputSchema": { ... } },
    ...
  ]
}
```