### PR TITLE
feat(serialize): exclude aaic and account_channel fields from JSON output

### DIFF
--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -3,7 +3,7 @@
 //! - Fields ending with `_at` containing i64/u64 -> RFC3339 UTC string
 //! - Field `counter_id` (string) -> renamed to `symbol`, value converted
 //! - Field `counter_ids` (array of strings) -> renamed to `symbols`, each converted
-//! - Fields `aaic` and `account_channel` -> excluded from output entirely
+//! - Fields `aaid` and `account_channel` -> value set to null
 //!
 //! Zero intermediate allocation for SDK types (`to_tool_json`).
 
@@ -166,7 +166,7 @@ pub(crate) enum FieldKind {
     Timestamp,
     CounterId,
     CounterIds,
-    Excluded,
+    Nullified,
 }
 
 pub(crate) fn classify_field(snake_name: &str) -> FieldKind {
@@ -176,8 +176,8 @@ pub(crate) fn classify_field(snake_name: &str) -> FieldKind {
         FieldKind::CounterId
     } else if snake_name.ends_with("_at") {
         FieldKind::Timestamp
-    } else if matches!(snake_name, "aaic" | "account_channel") {
-        FieldKind::Excluded
+    } else if matches!(snake_name, "aaid" | "account_channel") {
+        FieldKind::Nullified
     } else {
         FieldKind::Normal
     }
@@ -507,31 +507,31 @@ mod tests {
     }
 
     #[test]
-    fn excluded_fields_aaic_and_account_channel() {
+    fn nullified_fields_to_tool_json() {
         #[derive(Serialize)]
         struct Data {
-            aaic: String,
+            aaid: String,
             account_channel: String,
             name: String,
         }
-        let d = Data {
-            aaic: "some_value".to_string(),
-            account_channel: "channel".to_string(),
-            name: "keep_me".to_string(),
-        };
-        let json = to_tool_json(&d).unwrap();
-        assert!(!json.contains("aaic"), "got: {json}");
-        assert!(!json.contains("account_channel"), "got: {json}");
-        assert!(json.contains("\"name\":\"keep_me\""), "got: {json}");
+        let json = to_tool_json(&Data {
+            aaid: "20975338".to_string(),
+            account_channel: "lb_papertrading".to_string(),
+            name: "keep".to_string(),
+        })
+        .unwrap();
+        assert!(json.contains("\"aaid\":null"), "got: {json}");
+        assert!(json.contains("\"account_channel\":null"), "got: {json}");
+        assert!(json.contains("\"name\":\"keep\""), "got: {json}");
     }
 
     #[test]
-    fn excluded_fields_via_transform_json() {
-        let input: serde_json::Value =
-            serde_json::from_str(r#"{"aaic":"x","accountChannel":"ch","price":1.5}"#).unwrap();
-        let output = to_tool_json(&input).unwrap();
-        assert!(!output.contains("aaic"), "got: {output}");
-        assert!(!output.contains("account_channel"), "got: {output}");
-        assert!(output.contains("\"price\""), "got: {output}");
+    fn nullified_fields_transform_json() {
+        let raw = r#"{"planId":"1","aaid":"999","accountChannel":"lb","market":"US"}"#;
+        let output = transform_json(raw.as_bytes()).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(v["aaid"], serde_json::Value::Null);
+        assert_eq!(v["account_channel"], serde_json::Value::Null);
+        assert_eq!(v["plan_id"], "1");
     }
 }

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -3,6 +3,7 @@
 //! - Fields ending with `_at` containing i64/u64 -> RFC3339 UTC string
 //! - Field `counter_id` (string) -> renamed to `symbol`, value converted
 //! - Field `counter_ids` (array of strings) -> renamed to `symbols`, each converted
+//! - Fields `aaic` and `account_channel` -> excluded from output entirely
 //!
 //! Zero intermediate allocation for SDK types (`to_tool_json`).
 
@@ -165,6 +166,7 @@ pub(crate) enum FieldKind {
     Timestamp,
     CounterId,
     CounterIds,
+    Excluded,
 }
 
 pub(crate) fn classify_field(snake_name: &str) -> FieldKind {
@@ -174,6 +176,8 @@ pub(crate) fn classify_field(snake_name: &str) -> FieldKind {
         FieldKind::CounterId
     } else if snake_name.ends_with("_at") {
         FieldKind::Timestamp
+    } else if matches!(snake_name, "aaic" | "account_channel") {
+        FieldKind::Excluded
     } else {
         FieldKind::Normal
     }
@@ -500,5 +504,34 @@ mod tests {
         let before = v.clone();
         convert_unix_paths(&mut v, &["missing", "a.b.c"]);
         assert_eq!(v, before);
+    }
+
+    #[test]
+    fn excluded_fields_aaic_and_account_channel() {
+        #[derive(Serialize)]
+        struct Data {
+            aaic: String,
+            account_channel: String,
+            name: String,
+        }
+        let d = Data {
+            aaic: "some_value".to_string(),
+            account_channel: "channel".to_string(),
+            name: "keep_me".to_string(),
+        };
+        let json = to_tool_json(&d).unwrap();
+        assert!(!json.contains("aaic"), "got: {json}");
+        assert!(!json.contains("account_channel"), "got: {json}");
+        assert!(json.contains("\"name\":\"keep_me\""), "got: {json}");
+    }
+
+    #[test]
+    fn excluded_fields_via_transform_json() {
+        let input: serde_json::Value =
+            serde_json::from_str(r#"{"aaic":"x","accountChannel":"ch","price":1.5}"#).unwrap();
+        let output = to_tool_json(&input).unwrap();
+        assert!(!output.contains("aaic"), "got: {output}");
+        assert!(!output.contains("account_channel"), "got: {output}");
+        assert!(output.contains("\"price\""), "got: {output}");
     }
 }

--- a/src/serialize/transform.rs
+++ b/src/serialize/transform.rs
@@ -224,16 +224,16 @@ impl<M: SerializeMap> SerializeMap for TransformMap<M> {
         let snake = to_snake_case(&raw);
         let kind = classify_field(&snake);
         self.current_kind = kind;
-        if kind == FieldKind::Excluded {
-            return Ok(());
-        }
         let out = output_key(&snake, kind);
         self.inner.serialize_key(out.as_ref())
     }
 
     fn serialize_value<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
         match self.current_kind {
-            FieldKind::Excluded => Ok(()),
+            FieldKind::Nullified => {
+                let _ = serde_json::to_value(value);
+                self.inner.serialize_value(&None::<()>)
+            }
             FieldKind::Timestamp => self.inner.serialize_value(&TimestampValue { value }),
             FieldKind::CounterId => self.inner.serialize_value(&CounterIdValue { value }),
             FieldKind::CounterIds => self.inner.serialize_value(&CounterIdsValue { value }),
@@ -261,13 +261,10 @@ impl<M: SerializeMap> SerializeStruct for TransformStructAsMap<M> {
     ) -> Result<(), Self::Error> {
         let snake = to_snake_case(key);
         let kind = classify_field(&snake);
-        if kind == FieldKind::Excluded {
-            return Ok(());
-        }
         let out_key = output_key(&snake, kind);
         self.inner.serialize_key(out_key.as_ref())?;
         match kind {
-            FieldKind::Excluded => unreachable!("handled above"),
+            FieldKind::Nullified => self.inner.serialize_value(&None::<()>),
             FieldKind::Timestamp => self.inner.serialize_value(&TimestampValue { value }),
             FieldKind::CounterId => self.inner.serialize_value(&CounterIdValue { value }),
             FieldKind::CounterIds => self.inner.serialize_value(&CounterIdsValue { value }),
@@ -296,11 +293,12 @@ impl<M: SerializeMap> SerializeStructVariant for TransformStructVariantAsMap<M> 
     ) -> Result<(), Self::Error> {
         let snake = to_snake_case(key);
         let kind = classify_field(&snake);
-        if kind == FieldKind::Excluded {
-            return Ok(());
-        }
         let out_key = output_key(&snake, kind).into_owned();
-        let val = serde_json::to_value(value).map_err(ser::Error::custom)?;
+        let val = if kind == FieldKind::Nullified {
+            serde_json::Value::Null
+        } else {
+            serde_json::to_value(value).map_err(ser::Error::custom)?
+        };
         self.fields.push((out_key, val));
         Ok(())
     }

--- a/src/serialize/transform.rs
+++ b/src/serialize/transform.rs
@@ -224,12 +224,16 @@ impl<M: SerializeMap> SerializeMap for TransformMap<M> {
         let snake = to_snake_case(&raw);
         let kind = classify_field(&snake);
         self.current_kind = kind;
+        if kind == FieldKind::Excluded {
+            return Ok(());
+        }
         let out = output_key(&snake, kind);
         self.inner.serialize_key(out.as_ref())
     }
 
     fn serialize_value<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
         match self.current_kind {
+            FieldKind::Excluded => Ok(()),
             FieldKind::Timestamp => self.inner.serialize_value(&TimestampValue { value }),
             FieldKind::CounterId => self.inner.serialize_value(&CounterIdValue { value }),
             FieldKind::CounterIds => self.inner.serialize_value(&CounterIdsValue { value }),
@@ -257,9 +261,13 @@ impl<M: SerializeMap> SerializeStruct for TransformStructAsMap<M> {
     ) -> Result<(), Self::Error> {
         let snake = to_snake_case(key);
         let kind = classify_field(&snake);
+        if kind == FieldKind::Excluded {
+            return Ok(());
+        }
         let out_key = output_key(&snake, kind);
         self.inner.serialize_key(out_key.as_ref())?;
         match kind {
+            FieldKind::Excluded => unreachable!("handled above"),
             FieldKind::Timestamp => self.inner.serialize_value(&TimestampValue { value }),
             FieldKind::CounterId => self.inner.serialize_value(&CounterIdValue { value }),
             FieldKind::CounterIds => self.inner.serialize_value(&CounterIdsValue { value }),
@@ -288,6 +296,9 @@ impl<M: SerializeMap> SerializeStructVariant for TransformStructVariantAsMap<M> 
     ) -> Result<(), Self::Error> {
         let snake = to_snake_case(key);
         let kind = classify_field(&snake);
+        if kind == FieldKind::Excluded {
+            return Ok(());
+        }
         let out_key = output_key(&snake, kind).into_owned();
         let val = serde_json::to_value(value).map_err(ser::Error::custom)?;
         self.fields.push((out_key, val));


### PR DESCRIPTION
## Task #3 — 参考这个过滤，我们需要在 MCP 的 JSON 结果里面排除 aaic, account_channel

Auto-generated by Endless workspace.

Phase: `dev`