### PR TITLE
chore: add glama.json to claim Glama listing ownership

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "wuxsoft",
+    "huacnlee"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds \`glama.json\` at the repo root, identifying the GitHub usernames that have permission to maintain the https://glama.ai/mcp/servers/longbridge/longbridge-mcp listing on Glama.

Once merged, going through the **Claim ownership** flow on the Glama listing picks up this file. After that, the listed maintainers can:

- Update the server's display name, description, etc. on Glama
- Configure the Docker image
- Access usage reports
- Receive notifications of reviews

## Reference

Schema: https://glama.ai/mcp/schemas/server.json
Background: https://glama.ai/blog/2025-07-08-what-is-glamajson

## Test plan

- [x] JSON is valid (\`python3 -c 'import json; json.load(open(\"glama.json\"))'\`)
- [x] After merge, run Claim ownership at https://glama.ai/mcp/servers/longbridge/longbridge-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)