### PR TITLE
feat(tools): expose more SDK options as MCP parameters

### DIFF
--- a/src/tools/calendar.rs
+++ b/src/tools/calendar.rs
@@ -7,7 +7,7 @@ use crate::tools::support::http_client::http_get_tool;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct FinanceCalendarParam {
-    /// Market code: HK, US, CN, SG
+    /// Market code: HK, US, CN, SG. Omit to query across all markets.
     pub market: Option<String>,
     /// Start date (yyyy-mm-dd)
     pub start: String,

--- a/src/tools/content.rs
+++ b/src/tools/content.rs
@@ -5,7 +5,7 @@ use rmcp::schemars::JsonSchema;
 use rmcp::serde::Deserialize;
 
 use crate::error::Error;
-use crate::tools::support::tolerant::tolerant_option_vec_string;
+use crate::tools::support::tolerant::{tolerant_option_i32, tolerant_option_vec_string};
 use crate::tools::tool_json;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -22,21 +22,37 @@ pub struct TopicIdParam {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct TopicCreateParam {
-    /// Topic title
+    /// Topic title. Required when topic_type is "article", optional for "post".
     pub title: String,
-    /// Topic body content
+    /// Topic body. "post" type is plain text only; "article" type accepts Markdown.
     pub body: String,
-    /// Related security symbols
+    /// Related security symbols, e.g. ["700.HK", "TSLA.US"] (max 10).
     #[serde(default, deserialize_with = "tolerant_option_vec_string")]
     pub symbols: Option<Vec<String>>,
+    /// Topic type: "post" (default, plain text) or "article" (Markdown, title required).
+    pub topic_type: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct TopicCreateReplyParam {
-    /// Topic ID to reply to
+    /// Topic ID to reply to.
     pub topic_id: String,
-    /// Reply body content
+    /// Reply body (plain text only).
     pub body: String,
+    /// Optional parent reply ID for nested replies. Get IDs from `topic_replies`. Omit for a top-level reply.
+    pub reply_to_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TopicRepliesParam {
+    /// Topic ID.
+    pub topic_id: String,
+    /// Page number, 1-based (default: 1).
+    #[serde(default, deserialize_with = "tolerant_option_i32")]
+    pub page: Option<i32>,
+    /// Records per page, 1-50 (default: 20).
+    #[serde(default, deserialize_with = "tolerant_option_i32")]
+    pub size: Option<i32>,
 }
 
 pub async fn news(
@@ -71,11 +87,15 @@ pub async fn topic_detail(
 
 pub async fn topic_replies(
     mctx: &crate::tools::McpContext,
-    p: TopicIdParam,
+    p: TopicRepliesParam,
 ) -> Result<CallToolResult, McpError> {
     let ctx = ContentContext::new(mctx.create_config());
+    let opts = longbridge::content::ListTopicRepliesOptions {
+        page: p.page,
+        size: p.size,
+    };
     let result = ctx
-        .list_topic_replies(p.topic_id, Default::default())
+        .list_topic_replies(p.topic_id, opts)
         .await
         .map_err(Error::longbridge)?;
     tool_json(&result)
@@ -89,7 +109,7 @@ pub async fn topic_create(
     let opts = longbridge::content::CreateTopicOptions {
         title: p.title,
         body: p.body,
-        topic_type: None,
+        topic_type: p.topic_type,
         tickers: p.symbols,
         hashtags: None,
     };
@@ -104,7 +124,7 @@ pub async fn topic_create_reply(
     let ctx = ContentContext::new(mctx.create_config());
     let opts = longbridge::content::CreateReplyOptions {
         body: p.body,
-        reply_to_id: None,
+        reply_to_id: p.reply_to_id,
     };
     let result = ctx
         .create_topic_reply(p.topic_id, opts)

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -224,11 +224,13 @@ impl Longbridge {
     }
 
     /// Get intraday line data.
-    #[tool(description = "Get intraday minute-by-minute price/volume data")]
+    #[tool(
+        description = "Get intraday minute-by-minute price/volume data. trade_sessions: \"intraday\" (default, regular hours) or \"all\" (include pre-market and post-market)"
+    )]
     async fn intraday(
         &self,
         ctx: RequestContext<RoleServer>,
-        Parameters(p): Parameters<SymbolParam>,
+        Parameters(p): Parameters<quote::IntradayParam>,
     ) -> Result<CallToolResult, McpError> {
         let mctx = extract_context(&ctx)?;
         measured_tool_call("intraday", || quote::intraday(&mctx, p)).await
@@ -484,13 +486,16 @@ impl Longbridge {
     }
 
     /// Get account balance.
-    #[tool(description = "Get account cash balance and asset summary")]
+    #[tool(
+        description = "Get account cash balance and asset summary. Pass currency (e.g. \"USD\", \"HKD\") to filter; omit to return all currencies."
+    )]
     async fn account_balance(
         &self,
         ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<trade::AccountBalanceParam>,
     ) -> Result<CallToolResult, McpError> {
         let mctx = extract_context(&ctx)?;
-        measured_tool_call("account_balance", || trade::account_balance(&mctx)).await
+        measured_tool_call("account_balance", || trade::account_balance(&mctx, p)).await
     }
 
     /// Get stock positions.
@@ -525,13 +530,14 @@ impl Longbridge {
     }
 
     /// Get today's orders.
-    #[tool(description = "Get orders placed today")]
+    #[tool(description = "Get orders placed today. Pass symbol to filter; omit to return all.")]
     async fn today_orders(
         &self,
         ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<trade::TodayOrdersParam>,
     ) -> Result<CallToolResult, McpError> {
         let mctx = extract_context(&ctx)?;
-        measured_tool_call("today_orders", || trade::today_orders(&mctx)).await
+        measured_tool_call("today_orders", || trade::today_orders(&mctx, p)).await
     }
 
     /// Get order detail.
@@ -557,13 +563,16 @@ impl Longbridge {
     }
 
     /// Get today's trade executions.
-    #[tool(description = "Get today's trade executions (fills)")]
+    #[tool(
+        description = "Get today's trade executions (fills). Pass symbol or order_id to filter; omit both to return all."
+    )]
     async fn today_executions(
         &self,
         ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<trade::TodayExecutionsParam>,
     ) -> Result<CallToolResult, McpError> {
         let mctx = extract_context(&ctx)?;
-        measured_tool_call("today_executions", || trade::today_executions(&mctx)).await
+        measured_tool_call("today_executions", || trade::today_executions(&mctx, p)).await
     }
 
     /// Get historical orders (not including today).
@@ -1102,18 +1111,22 @@ impl Longbridge {
     }
 
     /// Get topic replies.
-    #[tool(description = "Get replies to a discussion topic")]
+    #[tool(
+        description = "Get replies to a discussion topic, paginated (page default 1, size default 20, range 1-50)"
+    )]
     async fn topic_replies(
         &self,
         ctx: RequestContext<RoleServer>,
-        Parameters(p): Parameters<content::TopicIdParam>,
+        Parameters(p): Parameters<content::TopicRepliesParam>,
     ) -> Result<CallToolResult, McpError> {
         let mctx = extract_context(&ctx)?;
         measured_tool_call("topic_replies", || content::topic_replies(&mctx, p)).await
     }
 
     /// Create a discussion topic.
-    #[tool(description = "Create a new discussion topic")]
+    #[tool(
+        description = "Create a new discussion topic. topic_type=\"post\" (default) is plain text; \"article\" requires a non-empty title and accepts Markdown body."
+    )]
     async fn topic_create(
         &self,
         ctx: RequestContext<RoleServer>,
@@ -1124,7 +1137,9 @@ impl Longbridge {
     }
 
     /// Reply to a discussion topic.
-    #[tool(description = "Create a reply to a discussion topic")]
+    #[tool(
+        description = "Create a reply to a discussion topic. Pass reply_to_id to nest under another reply; omit for a top-level reply."
+    )]
     async fn topic_create_reply(
         &self,
         ctx: RequestContext<RoleServer>,

--- a/src/tools/portfolio.rs
+++ b/src/tools/portfolio.rs
@@ -10,9 +10,9 @@ use crate::tools::support::http_client::{http_get_tool, http_get_tool_unix};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ProfitAnalysisParam {
-    /// Start date (yyyy-mm-dd), optional
+    /// Start date (yyyy-mm-dd). Must be paired with `end`; passing only one returns empty results.
     pub start: Option<String>,
-    /// End date (yyyy-mm-dd), optional
+    /// End date (yyyy-mm-dd). Must be paired with `start`; passing only one returns empty results.
     pub end: Option<String>,
 }
 
@@ -20,9 +20,9 @@ pub struct ProfitAnalysisParam {
 pub struct ProfitAnalysisDetailParam {
     /// Security symbol, e.g. "700.HK"
     pub symbol: String,
-    /// Start date (yyyy-mm-dd), optional
+    /// Start date (yyyy-mm-dd). Must be paired with `end`; passing only one returns empty results.
     pub start: Option<String>,
-    /// End date (yyyy-mm-dd), optional
+    /// End date (yyyy-mm-dd). Must be paired with `start`; passing only one returns empty results.
     pub end: Option<String>,
 }
 

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -30,6 +30,14 @@ pub struct SymbolParam {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct IntradayParam {
+    /// Security symbol, e.g. "700.HK"
+    pub symbol: String,
+    /// Trade sessions to include: "intraday" (default, regular hours only) or "all" (include pre-market and post-market).
+    pub trade_sessions: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct SymbolCountParam {
     pub symbol: String,
     /// Maximum number of results (max 1000)
@@ -270,11 +278,15 @@ pub async fn trades(
 
 pub async fn intraday(
     mctx: &crate::tools::McpContext,
-    p: SymbolParam,
+    p: IntradayParam,
 ) -> Result<CallToolResult, McpError> {
+    let sessions = match p.trade_sessions.as_deref() {
+        Some(s) => parse::parse_trade_sessions(s)?,
+        None => longbridge::quote::TradeSessions::Intraday,
+    };
     let (ctx, _) = QuoteContext::new(mctx.create_config());
     let result = ctx
-        .intraday(p.symbol, longbridge::quote::TradeSessions::Intraday)
+        .intraday(p.symbol, sessions)
         .await
         .map_err(Error::longbridge)?;
     tool_json(&result)

--- a/src/tools/sharelist.rs
+++ b/src/tools/sharelist.rs
@@ -24,9 +24,9 @@ pub struct SharelistIdParam {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SharelistCreateParam {
-    /// List name
+    /// List name (also used as description if `description` is omitted).
     pub name: String,
-    /// List description (optional)
+    /// List description. Defaults to `name` when omitted.
     pub description: Option<String>,
 }
 

--- a/src/tools/statement.rs
+++ b/src/tools/statement.rs
@@ -12,11 +12,11 @@ use crate::tools::tool_json;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct StatementListParam {
-    /// Statement type: "daily" or "monthly"
+    /// Statement type: "daily" (default) or "monthly".
     pub statement_type: Option<String>,
-    /// Start date (yyyy-mm-dd), optional
+    /// Start date (yyyy-mm-dd). Defaults to 30 days ago for "daily" or 12 months ago for "monthly".
     pub start_date: Option<String>,
-    /// Number of records to return
+    /// Number of records to return. Defaults to 30 for "daily" or 12 for "monthly".
     #[serde(default, deserialize_with = "tolerant_option_i32")]
     pub limit: Option<i32>,
 }

--- a/src/tools/trade.rs
+++ b/src/tools/trade.rs
@@ -1,4 +1,4 @@
-use longbridge::trade::TradeContext;
+use longbridge::trade::{GetTodayExecutionsOptions, GetTodayOrdersOptions, TradeContext};
 use rmcp::ErrorData as McpError;
 use rmcp::model::CallToolResult;
 use rmcp::schemars::JsonSchema;
@@ -13,6 +13,26 @@ pub use crate::tools::quote::SymbolParam;
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct OrderIdParam {
     pub order_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AccountBalanceParam {
+    /// Filter by currency code (e.g. "USD", "HKD"). Omit to return all currencies.
+    pub currency: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TodayOrdersParam {
+    /// Filter by symbol, e.g. "700.HK". Omit to return all today's orders.
+    pub symbol: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TodayExecutionsParam {
+    /// Filter by symbol, e.g. "700.HK".
+    pub symbol: Option<String>,
+    /// Filter by a specific order_id.
+    pub order_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -93,9 +113,15 @@ pub struct EstimateMaxQtyParam {
     pub price: Option<String>,
 }
 
-pub async fn account_balance(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
+pub async fn account_balance(
+    mctx: &crate::tools::McpContext,
+    p: AccountBalanceParam,
+) -> Result<CallToolResult, McpError> {
     let (ctx, _) = TradeContext::new(mctx.create_config());
-    let result = ctx.account_balance(None).await.map_err(Error::longbridge)?;
+    let result = ctx
+        .account_balance(p.currency.as_deref())
+        .await
+        .map_err(Error::longbridge)?;
     tool_json(&result)
 }
 
@@ -123,9 +149,16 @@ pub async fn margin_ratio(
     tool_json(&result)
 }
 
-pub async fn today_orders(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
+pub async fn today_orders(
+    mctx: &crate::tools::McpContext,
+    p: TodayOrdersParam,
+) -> Result<CallToolResult, McpError> {
+    let mut opts = GetTodayOrdersOptions::new();
+    if let Some(symbol) = p.symbol {
+        opts = opts.symbol(symbol);
+    }
     let (ctx, _) = TradeContext::new(mctx.create_config());
-    let result = ctx.today_orders(None).await.map_err(Error::longbridge)?;
+    let result = ctx.today_orders(opts).await.map_err(Error::longbridge)?;
     tool_json(&result)
 }
 
@@ -152,10 +185,20 @@ pub async fn cancel_order(
     Ok(tool_result("order cancelled".to_string()))
 }
 
-pub async fn today_executions(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
+pub async fn today_executions(
+    mctx: &crate::tools::McpContext,
+    p: TodayExecutionsParam,
+) -> Result<CallToolResult, McpError> {
+    let mut opts = GetTodayExecutionsOptions::new();
+    if let Some(symbol) = p.symbol {
+        opts = opts.symbol(symbol);
+    }
+    if let Some(order_id) = p.order_id {
+        opts = opts.order_id(order_id);
+    }
     let (ctx, _) = TradeContext::new(mctx.create_config());
     let result = ctx
-        .today_executions(None)
+        .today_executions(opts)
         .await
         .map_err(Error::longbridge)?;
     tool_json(&result)


### PR DESCRIPTION
## Summary

Several MCP tools previously hardcoded SDK option fields to `None`, hiding capabilities the `longbridge-terminal` CLI already exposes. This PR surfaces them as optional MCP parameters so MCP clients reach feature parity with the CLI.

## New optional fields

| Tool | Added field(s) | Why it matters |
|---|---|---|
| `topic_create` | `topic_type` | Choose between plain-text `post` and Markdown `article` |
| `topic_create_reply` | `reply_to_id` | Post nested replies (reply-to-reply) |
| `topic_replies` | `page`, `size` | Paginate (default 1 / 20, range 1-50) |
| `account_balance` | `currency` | Filter to a single currency (USD, HKD, …) |
| `today_orders` | `symbol` | Filter today's orders by symbol |
| `today_executions` | `symbol`, `order_id` | Filter today's fills |
| `intraday` | `trade_sessions` | Access pre-market / post-market data via `"all"` |

## Doc-only clarifications (P2)

Default values and pairing constraints are now documented in the field-level `#[schemars(description)]` for:

- `sharelist_create.name` / `description` — `description` defaults to `name` if omitted
- `statement_list.statement_type` / `start_date` / `limit` — smart defaults documented
- `profit_analysis.start` / `end` and `profit_analysis_detail.start` / `end` — must be paired
- `finance_calendar.market` — omit to query across all markets

## Verification

- `cargo check --all-features --all-targets` ✓
- `cargo clippy --all-features --all-targets` ✓ (no warnings)
- `cargo +nightly fmt` ✓
- `cargo test --all-features` ✓ (46/46)
- Diffed `tools.json` between local and prod: only the expected 7 new fields appear; **no fields lost** (no regression).
- Live regression on a running server with paper-trading creds:
  - `topic_replies` pagination verified on a 5-comment topic — page=1/page=2 returned distinct reply IDs.
  - `account_balance currency=USD` returned USD-only data.
  - `intraday trade_sessions=all` returned data normally.
  - `today_orders` / `today_executions` accept new filters and return correctly (empty for paper account).

## Test plan

- [ ] Pull the branch and confirm `cargo build` succeeds
- [ ] Restart the server and verify `GET /mcp/tools.json` shows the new fields in each tool's `inputSchema.properties`
- [ ] Call `topic_replies` with `page` / `size` against a real topic to confirm pagination works
- [ ] Call `account_balance` with `currency=USD` to confirm filtering
- [ ] Call `intraday` with `trade_sessions=all` to confirm pre/post-market data is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)