### PR TITLE
fix(auth): also serve server-card under /mcp prefix + bump 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-mcp"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longbridge-mcp"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 
 [dependencies]

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.longbridge/mcp",
   "description": "US/HK markets — 110 tools: real-time quotes, options, orders, fundamentals, alerts, DCA & portfolio",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.1.8",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.1.9",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -31,10 +31,18 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         )
         .with_state(state.clone());
 
-    let server_card_route = Router::new().route(
-        "/.well-known/mcp/server-card.json",
-        axum::routing::get(metadata::server_card),
-    );
+    // Serve the static server card at both the host-root path Smithery's docs
+    // specify and the `/mcp/`-prefixed path (some upstream gateways only forward
+    // `/mcp/*` to this service, so the prefixed copy is a fallback).
+    let server_card_route = Router::new()
+        .route(
+            "/.well-known/mcp/server-card.json",
+            axum::routing::get(metadata::server_card),
+        )
+        .route(
+            "/mcp/.well-known/mcp/server-card.json",
+            axum::routing::get(metadata::server_card),
+        );
 
     let health_route = Router::new().route("/health", axum::routing::get(health));
 


### PR DESCRIPTION
## Summary

Adds a fallback path \`/mcp/.well-known/mcp/server-card.json\` so the static MCP server card stays reachable even when the upstream API gateway only forwards \`/mcp/*\` to this service.

Bumps version 0.1.8 → 0.1.9.

## Why

Following PR #11, the host-root path works locally but **fails on prod**:

\`\`\`
$ curl https://openapi.longbridge.com/.well-known/mcp/server-card.json
{"code":404000,"message":"api not found","data":null}
\`\`\`

The Longbridge API gateway has an explicit allowlist that only forwards specific \`.well-known/*\` paths (e.g. \`oauth-protected-resource\`) to this service; \`.well-known/mcp/*\` isn't in the allowlist yet. The gateway team is being asked to add the rule, but in the meantime mounting the same handler under \`/mcp/\` (which the gateway already forwards) gives Smithery and other directory scanners a working URL.

## What changed

- **\`src/auth/mod.rs\`**: \`server_card_route\` now exposes the same handler at two paths:
  \`/.well-known/mcp/server-card.json\` (canonical, per Smithery docs)
  \`/mcp/.well-known/mcp/server-card.json\` (gateway fallback)
- **\`Cargo.toml\` / \`Cargo.lock\` / \`server.json\`**: 0.1.8 → 0.1.9 (incl. OCI image tag in \`packages[0].identifier\`)

Both routes are registered at the top-level router **before** the \`nest_service(\"/mcp\", ...)\` mount, so they bypass the auth middleware (verified locally — \`/mcp\` POST still returns 401).

## Test plan

Local smoke (port 8000, no auth header):

\`\`\`
$ curl -s http://127.0.0.1:8000/.well-known/mcp/server-card.json | jq '{name: .serverInfo.name, version: .serverInfo.version, auth: .authentication, tools: (.tools | length)}'
{
  "name": "Longbridge MCP",
  "version": "0.1.9",
  "auth": {"required": true, "schemes": ["oauth2"]},
  "tools": 108
}

$ curl -s http://127.0.0.1:8000/mcp/.well-known/mcp/server-card.json | jq '.serverInfo.name'
"Longbridge MCP"

$ curl -X POST -o /dev/null -w '%{http_code}\\n' -H 'Accept: application/json, text/event-stream' http://127.0.0.1:8000/mcp
401
\`\`\`

- [x] cargo +nightly fmt
- [x] cargo check --all-features --all-targets
- [x] cargo clippy --all-features --all-targets (no warnings)
- [x] both server-card paths return 200 with correct JSON locally
- [x] /mcp POST still returns 401 (auth middleware untouched)

## Rollout

After merge:
1. Build & push \`ghcr.io/longbridge/longbridge-mcp:0.1.9\`
2. Deploy to \`openapi.longbridge.com\`
3. Verify: \`curl https://openapi.longbridge.com/mcp/.well-known/mcp/server-card.json | jq .serverInfo\`
4. Re-run \`smithery mcp publish https://openapi.longbridge.com/mcp -n longbridge-official/longbridge-mcp\`
5. Re-publish to Official MCP Registry: \`mcp-publisher publish\` (server.json now references 0.1.9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)