### PR TITLE
docs(readme): add Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <p align="center">
   <a href="https://registry.modelcontextprotocol.io/v0/servers/com.longbridge%2Fmcp"><img alt="Official MCP Registry" src="https://img.shields.io/badge/MCP%20Registry-com.longbridge%2Fmcp-0a66c2"></a>
+  <a href="https://smithery.ai/servers/longbridge-official/longbridge-mcp"><img alt="Smithery" src="https://smithery.ai/badge/longbridge-official/longbridge-mcp"></a>
   <a href="https://github.com/longbridge/longbridge-mcp/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-blue"></a>
   <a href="https://longbridge.com"><img alt="Longbridge" src="https://img.shields.io/badge/brokerage-Longbridge-ffe000?labelColor=000"></a>
 </p>


### PR DESCRIPTION
## Summary
- Add Smithery registry badge to README header alongside the existing MCP Registry / License / Longbridge badges.

## Test plan
- [x] Confirm badge image renders on Smithery's CDN
- [ ] Verify badge displays correctly once merged on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)