### PR TITLE
feat(tools): add `quant_run` — server-side indicator script execution

### DIFF
--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -33,6 +33,7 @@ mod dca;
 mod fundamental;
 mod market;
 mod portfolio;
+mod quant;
 mod quote;
 mod sharelist;
 mod statement;
@@ -1412,6 +1413,19 @@ impl Longbridge {
             sharelist::sharelist_popular(&mctx, p)
         })
         .await
+    }
+
+    /// Run a quant indicator script against historical K-line data on the server.
+    #[tool(
+        description = "Run a quant indicator script against historical K-line data on the server. Executes the script server-side and returns the computed indicator/plot values as JSON. The script language is compatible with PineScript V6 syntax (minor exceptions may apply). Periods: 1m, 5m, 15m, 30m, 1h, day, week, month, year (default: day). The optional input flag accepts a JSON array matching the order of input.*() calls in the script, e.g. \"[14,2.0]\"."
+    )]
+    async fn quant_run(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<quant::RunScriptParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("quant_run", || quant::run_script(&mctx, p)).await
     }
 }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1417,7 +1417,7 @@ impl Longbridge {
 
     /// Run a quant indicator script against historical K-line data on the server.
     #[tool(
-        description = "Run a quant indicator script against historical K-line data on the server. Executes the script server-side and returns the computed indicator/plot values as JSON. The script language is compatible with PineScript V6 syntax (minor exceptions may apply). Periods: 1m, 5m, 15m, 30m, 1h, day, week, month, year (default: day). The optional input flag accepts a JSON array matching the order of input.*() calls in the script, e.g. \"[14,2.0]\"."
+        description = "Run a quant indicator script against historical K-line data on the server. Executes the script server-side and returns the computed indicator/plot values as JSON. The script language is compatible with PineScript V6 syntax (minor exceptions may apply). Periods: 1m, 5m, 15m, 30m, 1h, day, week, month, year (default: day). The optional input parameter accepts a JSON array matching the order of input.*() calls in the script, e.g. \"[14,2.0]\"."
     )]
     async fn quant_run(
         &self,

--- a/src/tools/quant.rs
+++ b/src/tools/quant.rs
@@ -1,0 +1,110 @@
+use rmcp::ErrorData as McpError;
+use rmcp::model::CallToolResult;
+use rmcp::schemars::JsonSchema;
+use rmcp::serde::Deserialize;
+use time::Time;
+
+use crate::counter::symbol_to_counter_id;
+use crate::tools::support::http_client::http_post_tool;
+use crate::tools::support::parse;
+
+/// Parameters for `quant_run_script`.
+///
+/// Mirrors `longbridge quant run` (longbridge-terminal CLI). Fields, order
+/// and per-field doc strings are kept aligned with the CLI definition so
+/// users see the same descriptions in either client.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RunScriptParam {
+    /// Symbol in <CODE>.<MARKET> format, e.g. TSLA.US 700.HK
+    pub symbol: String,
+    /// K-line period: 1m 5m 15m 30m 1h day week month year (default: day)
+    #[serde(default = "default_period")]
+    pub period: String,
+    /// Start date (YYYY-MM-DD) for the K-line range
+    pub start: String,
+    /// End date (YYYY-MM-DD) for the K-line range
+    pub end: String,
+    /// Script text. Inline indicator script source (PineScript V6 compatible).
+    pub script: Option<String>,
+    /// Script input values as a JSON array, e.g. "[14,2.0]". Must match the order of input.*() calls in the script.
+    pub input: Option<String>,
+}
+
+fn default_period() -> String {
+    "day".to_string()
+}
+
+/// Map CLI period string to the numeric `line_type` expected by the API.
+fn period_to_line_type(period: &str) -> Result<i32, McpError> {
+    match period {
+        "1m" | "minute" => Ok(1),
+        "5m" => Ok(5),
+        "15m" => Ok(15),
+        "30m" => Ok(30),
+        "1h" | "60m" | "hour" => Ok(60),
+        "day" | "d" | "1d" => Ok(1000),
+        "week" | "w" => Ok(2000),
+        "month" | "m" | "1mo" => Ok(3000),
+        "year" | "y" => Ok(4000),
+        _ => Err(McpError::invalid_params(
+            format!("Unknown period '{period}'. Use: 1m 5m 15m 30m 1h day week month year"),
+            None,
+        )),
+    }
+}
+
+/// Run a quant indicator script against historical K-line data on the server.
+pub async fn run_script(
+    mctx: &crate::tools::McpContext,
+    p: RunScriptParam,
+) -> Result<CallToolResult, McpError> {
+    let counter_id = symbol_to_counter_id(&p.symbol);
+    let line_type = period_to_line_type(&p.period)?;
+
+    let start_dt = parse::parse_date(&p.start)?
+        .with_time(Time::MIDNIGHT)
+        .assume_utc();
+    let end_time_of_day = Time::from_hms(23, 59, 59).expect("23:59:59 is a valid time-of-day");
+    let end_dt = parse::parse_date(&p.end)?
+        .with_time(end_time_of_day)
+        .assume_utc();
+    let start_time = start_dt.unix_timestamp();
+    let end_time = end_dt.unix_timestamp();
+
+    let script = p.script.unwrap_or_default();
+    if script.trim().is_empty() {
+        return Err(McpError::invalid_params(
+            "script is required and must be non-empty",
+            None,
+        ));
+    }
+
+    // Validate and normalise input_json: default to empty array.
+    let input_json = match p.input {
+        Some(s) => {
+            let v: serde_json::Value = serde_json::from_str(&s).map_err(|e| {
+                McpError::invalid_params(format!("input must be a valid JSON array: {e}"), None)
+            })?;
+            if !v.is_array() {
+                return Err(McpError::invalid_params(
+                    "input must be a JSON array, e.g. \"[14,2.0]\"",
+                    None,
+                ));
+            }
+            s
+        }
+        None => "[]".to_string(),
+    };
+
+    let body = serde_json::json!({
+        "counter_id": counter_id,
+        "start_time": start_time,
+        "end_time": end_time,
+        "script": script,
+        "input_json": input_json,
+        "line_type": line_type,
+    });
+
+    let client = mctx.create_http_client();
+    http_post_tool(&client, "/v1/quant/run_script", body).await
+}

--- a/src/tools/quant.rs
+++ b/src/tools/quant.rs
@@ -8,23 +8,21 @@ use crate::counter::symbol_to_counter_id;
 use crate::tools::support::http_client::http_post_tool;
 use crate::tools::support::parse;
 
-/// Parameters for `quant_run_script`.
-///
-/// Mirrors `longbridge quant run` (longbridge-terminal CLI). Fields, order
-/// and per-field doc strings are kept aligned with the CLI definition so
-/// users see the same descriptions in either client.
+/// Parameters for running an indicator script against historical K-line data:
+/// target symbol, date range, K-line period, the script source itself, and
+/// optional script inputs.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct RunScriptParam {
-    /// Symbol in <CODE>.<MARKET> format, e.g. TSLA.US 700.HK
+    /// Symbol in <CODE>.<MARKET> format, e.g. TSLA.US, 700.HK
     pub symbol: String,
-    /// K-line period: 1m 5m 15m 30m 1h day week month year (default: day)
+    /// K-line period: 1m, 5m, 15m, 30m, 1h, day, week, month, year (default: day)
     #[serde(default = "default_period")]
     pub period: String,
     /// Start date (YYYY-MM-DD) for the K-line range
     pub start: String,
     /// End date (YYYY-MM-DD) for the K-line range
     pub end: String,
-    /// Script text. Inline indicator script source (PineScript V6 compatible).
+    /// Indicator script source (PineScript V6 syntax).
     pub script: Option<String>,
     /// Script input values as a JSON array, e.g. "[14,2.0]". Must match the order of input.*() calls in the script.
     pub input: Option<String>,


### PR DESCRIPTION
## Summary

Adds the `quant_run` MCP tool, a thin wrapper over Longbridge's `POST /v1/quant/run_script` endpoint. MCP clients (Claude Desktop, Claude Code, Cursor, Cline, Windsurf, etc.) can now ask the model to run an indicator script against any historical K-line range and get the computed plot/indicator series back as JSON — no client-side script runtime, no local data fetch + recompute round-trip.

This brings the MCP server in line with the new `longbridge quant run` CLI subcommand introduced in [longbridge-terminal#118](https://github.com/longbridge/longbridge-terminal/pull/118).

## Why this matters for AI/MCP usage

Quant indicator computation is one of the highest-value things you can ask an LLM to set up: the user describes a strategy in natural language, the model writes a few lines of script, and now — with this tool — actually executes it on real historical data without leaving the chat. Previously the model could only talk *about* an indicator; it couldn't see the values.

## Tool

| | |
|---|---|
| **Name** | `quant_run` |
| **Endpoint** | `POST /v1/quant/run_script` |
| **Auth** | Standard OAuth Bearer (no extra scope beyond basic openapi) |

## Parameters

| Param | Required | Type | Notes |
|-------|----------|------|-------|
| `symbol` | ✅ | string | `<CODE>.<MARKET>` format, e.g. `TSLA.US`, `700.HK` |
| `start` | ✅ | string | YYYY-MM-DD (range start, inclusive — UTC midnight) |
| `end` | ✅ | string | YYYY-MM-DD (range end, inclusive — UTC 23:59:59) |
| `period` | — | string | Default `day`. Supports `1m, 5m, 15m, 30m, 1h, day, week, month, year` plus CLI aliases (`1d` / `hour` / `m` / `y`) |
| `script` | — | string | Indicator script source. Empty/missing rejected at runtime. |
| `input` | — | string | JSON-array string matching the order of `input.*()` calls in the script, e.g. `"[14,2.0]"` |

## Validation behaviors (so the model can recover gracefully)

| Bad input | Error returned |
|---|---|
| Missing `symbol`/`start`/`end` | `missing field 'X'` |
| Unknown `period` | ``Unknown period 'X'. Use: 1m 5m 15m 30m 1h day week month year`` |
| `input` not a JSON array | `input must be a JSON array, e.g. "[14,2.0]"` |
| Empty/missing `script` | `script is required and must be non-empty` |
| Symbol not resolvable | Falls through to upstream API error |

Symbol → counter_id resolution reuses the existing `symbol_to_counter_id` helper (handles US ETF detection).

## Implementation notes

- New module `src/tools/quant.rs` (~110 lines)
- Reuses existing `support::http_client::http_post_tool` — no new deps
- Period→line_type mapping copied verbatim from the CLI:
  `1m=1, 5m=5, 15m=15, 30m=30, 1h=60, day=1000, week=2000, month=3000, year=4000`
- Param schema, field order and per-field doc strings track the CLI Run subcommand. CLI-only phrasings (stdin fallback, "input flag", "Inline" qualifier) are stripped so the JSON Schema served to MCP clients reads cleanly.

## Test plan

- [x] `cargo +nightly fmt` clean
- [x] `cargo clippy --all-features --all-targets` — 0 warnings
- [x] `cargo test` — 46 passed
- [x] Live `POST /mcp tools/call` validates each error path:
   - missing `end` → 400 with field name
   - `period="banana"` → enum-list error
   - `input="42"` → "must be a JSON array"
   - missing `script` → "script is required and must be non-empty"
   - valid call with fake token → upstream 401 (proves the request body shape is correct end-to-end)
- [ ] End-to-end with a real OAuth token (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)