### PR TITLE
feat(scopes): expose OAuth scope groupings via /mcp/scopes.json (and inline in /mcp/tools.json)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,6 +2821,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1", features = [
     "signal",
 ] }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 schemars = "1"
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/scopes.json
+++ b/scopes.json
@@ -1,0 +1,75 @@
+{
+  "scopes": [
+    {
+      "id": "4",
+      "name": "Watchlist",
+      "name_locales": {
+        "zh-CN": "自选列表",
+        "zh-HK": "自選列表"
+      },
+      "tools": [
+        "create_watchlist_group",
+        "delete_watchlist_group",
+        "security_list",
+        "update_watchlist_group",
+        "watchlist"
+      ]
+    },
+    {
+      "id": "6",
+      "name": "Account & Positions",
+      "name_locales": {
+        "zh-CN": "账户资产与资金明细查询",
+        "zh-HK": "賬戶資產與資金明細查詢"
+      },
+      "tools": [
+        "account_balance",
+        "cash_flow",
+        "fund_positions",
+        "margin_ratio",
+        "profit_analysis",
+        "profit_analysis_detail",
+        "statement_export",
+        "statement_list",
+        "stock_positions"
+      ]
+    },
+    {
+      "id": "10",
+      "name": "Trade Order Lookup",
+      "name_locales": {
+        "zh-CN": "交易查询",
+        "zh-HK": "交易查詢"
+      },
+      "tools": [
+        "dca_history",
+        "dca_list",
+        "dca_stats",
+        "estimate_max_purchase_quantity",
+        "history_executions",
+        "history_orders",
+        "order_detail",
+        "today_executions",
+        "today_orders"
+      ]
+    },
+    {
+      "id": "11",
+      "name": "Trade Execution",
+      "name_locales": {
+        "zh-CN": "交易下单",
+        "zh-HK": "交易下單"
+      },
+      "tools": [
+        "cancel_order",
+        "dca_create",
+        "dca_pause",
+        "dca_resume",
+        "dca_stop",
+        "dca_update",
+        "replace_order",
+        "submit_order"
+      ]
+    }
+  ]
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -10,9 +10,34 @@ use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, Stream
 use crate::tools::{self, Longbridge};
 
 async fn tools_json() -> axum::Json<&'static serde_json::Value> {
-    static TOOLS_JSON: std::sync::LazyLock<serde_json::Value> =
-        std::sync::LazyLock::new(|| serde_json::json!({ "tools": tools::list_tools() }));
+    static TOOLS_JSON: std::sync::LazyLock<serde_json::Value> = std::sync::LazyLock::new(|| {
+        // Build the response object so `tools` is emitted first, then merge
+        // every top-level key from scopes.json (currently `scopes`) after it.
+        // Relies on serde_json's `preserve_order` feature to keep this order.
+        let mut out = serde_json::Map::new();
+        out.insert(
+            "tools".to_string(),
+            serde_json::to_value(tools::list_tools()).expect("tool list must be JSON-serialisable"),
+        );
+        let scopes: serde_json::Value = serde_json::from_str(include_str!("../../scopes.json"))
+            .expect("scopes.json must be valid JSON");
+        if let serde_json::Value::Object(scopes_map) = scopes {
+            for (k, v) in scopes_map {
+                // Live tool list always wins over any `tools` in scopes.json.
+                out.entry(k).or_insert(v);
+            }
+        }
+        serde_json::Value::Object(out)
+    });
     axum::Json(&*TOOLS_JSON)
+}
+
+async fn scopes_json() -> axum::Json<&'static serde_json::Value> {
+    static SCOPES_JSON: std::sync::LazyLock<serde_json::Value> = std::sync::LazyLock::new(|| {
+        serde_json::from_str(include_str!("../../scopes.json"))
+            .expect("scopes.json must be valid JSON")
+    });
+    axum::Json(&*SCOPES_JSON)
 }
 
 async fn health() -> axum::http::StatusCode {
@@ -51,8 +76,9 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         axum::routing::get(crate::metrics::metrics_handler),
     );
 
-    let tools_route: Router =
-        Router::new().route("/mcp/tools.json", axum::routing::get(tools_json));
+    let tools_route: Router = Router::new()
+        .route("/mcp/tools.json", axum::routing::get(tools_json))
+        .route("/mcp/scopes.json", axum::routing::get(scopes_json));
 
     let mcp_service = StreamableHttpService::new(
         move || Ok(Longbridge),


### PR DESCRIPTION
## Summary

Adds a static **`scopes.json`** at repo root and exposes it via two new touch points:

| Endpoint | Returns |
|---|---|
| `GET /mcp/scopes.json` | The scope file as-is (~1 KB) |
| `GET /mcp/tools.json` | The live tool list **followed by** the scope groupings — single fetch carries both |

## Why this matters for MCP clients & AI agents

Today a calling agent has no signal about which of the 108 tools require *trading* permissions vs which are just public market-data reads. That forces one of two bad choices:

1. **Ask for the most permissive scope upfront** — bad UX; user sees scary "trade execution" consent screen even when they only wanted a quote
2. **Try a tool, fail, re-prompt** — wastes a round-trip and confuses the model

With `scopes.json` available pre-flight, an MCP client can:

- Show "Connect (read-only)" vs "Connect (trade)" buttons cleanly
- Pre-warn the model: *"these tools will fail without scope `11`"*
- Render scope-grouped tool pickers in chat UIs (`watchlist`-y stuff together, `submit_order`-y stuff behind a confirm step)
- Programmatically check before exposing trade-execution tools to lower-trust agents

## The grouping

4 scopes covering **31 of 108 tools**. The remaining 77 (quotes, fundamentals, calendars, news, alerts, sharelist, content, etc.) need no special scope — they're omitted from the `scopes` array and remain in the top-level `tools` array.

| `id` | EN | 中文 | tools |
|---|---|---|---|
| `4` | Watchlist | 自选列表 | 5 (`watchlist`, `create/update/delete_watchlist_group`, `security_list`) |
| `6` | Account & Positions | 账户资产与资金明细查询 | 9 (`account_balance`, `stock/fund_positions`, `cash_flow`, `margin_ratio`, `profit_analysis*`, `statement_*`) |
| `10` | Trade Order Lookup | 交易查询 | 9 (`today/history_orders`, `today/history_executions`, `order_detail`, `estimate_max_purchase_quantity`, DCA reads) |
| `11` | Trade Execution | 交易下单 | 8 (`submit/cancel/replace_order`, DCA writes) |

Scope IDs and groupings track Longbridge's existing OAuth scope IDs (visible in `/.well-known/oauth-protected-resource`'s `scopes_supported` field). Scopes `5` (市场情绪) and `7` (资讯与公告) are left ungrouped on purpose — those tools are accessible with the basic openapi scope.

## Implementation

- `scopes.json` — file at repo root, hand-curated mapping (no duplication with code; cross-checked against `Longbridge::tool_router().list_all()` so nothing is missing or stale)
- `src/auth/mod.rs`:
  - New `scopes_json` handler that `include_str!`s the file at compile time and `LazyLock`-parses on first request
  - Existing `tools_json` handler now starts from a fresh map, inserts live `tools` first, then merges scopes.json's top-level keys (live tool list always wins on a key collision)
- `Cargo.toml` — `serde_json = { features = ["preserve_order"] }` so `tools` reliably appears before `scopes` in the merged response

## Live verification

```text
GET /mcp/tools.json    → 200, ~50 KB
   keys (in order):     ["tools", "scopes"]
   tools:               108 items
   scopes:              4 groupings (5+9+9+8 tools)

GET /mcp/scopes.json   → 200, ~1 KB
   keys:                ["scopes"]

GET /health            → 200
POST /mcp (no auth)    → 401 + WWW-Authenticate: Bearer resource_metadata=...
```

## Test plan

- [x] `cargo +nightly fmt` clean
- [x] `cargo clippy --all-features --all-targets` — 0 warnings
- [x] `cargo test` — 46 passed
- [x] Live `curl` verifies both endpoints + ordering + size + cross-reference of 108 tool names
- [x] `serde_json` round-trip of `scopes.json` succeeds at startup (would `expect`-panic on malformed JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)