### PR TITLE
chore: bump version to 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-mcp"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longbridge-mcp"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 
 [dependencies]

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.longbridge/mcp",
   "description": "US/HK markets — 110 tools: real-time quotes, options, orders, fundamentals, alerts, DCA & portfolio",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.1.9",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.1.10",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",


### PR DESCRIPTION
Bumps `Cargo.toml`, `Cargo.lock`, `server.json` (`version` and `packages[0].identifier` image tag) from `0.1.9` to `0.1.10`.

## What's in 0.1.10 (since v0.1.9)

- **#19** `feat(tools): add quant_run` — server-side indicator script execution against historical K-line data
- **#20** `feat(scopes): expose OAuth scope groupings via /mcp/scopes.json` — also bundled into `/mcp/tools.json`
- **#21** `feat(i18n): localize tool & scope descriptions for Chinese MCP clients` — zh-CN / zh-HK translations served under the new `locales` node

## Test plan

- [x] `cargo build` — clean
- [x] `Cargo.lock` regenerated to track 0.1.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)