### PR TITLE
fix(output_schema): align typed schemas with actual SDK serialize output

### DIFF
--- a/src/tools/output.rs
+++ b/src/tools/output.rs
@@ -53,20 +53,21 @@ pub struct MarginRatioResponse {
     pub fm_factor: String,
 }
 
-/// Returned by `stock_positions`. Top-level wraps a `channels` array
-/// (one per linked broker channel), each carrying its own positions list.
+/// Returned by `stock_positions`. Top-level wraps a `list` array
+/// (one entry per linked broker channel), each carrying its own positions.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct StockPositionsResponse {
-    /// Position channels (one per broker channel).
-    pub channels: Vec<StockPositionChannel>,
+    /// Position channels — one entry per broker channel.
+    pub list: Vec<StockPositionChannel>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct StockPositionChannel {
-    /// Broker channel identifier.
-    pub account_channel: String,
+    /// Broker channel identifier. Always emitted as `null` for privacy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_channel: Option<String>,
     /// Stock positions held in this channel.
-    pub positions: Vec<StockPosition>,
+    pub stock_info: Vec<StockPosition>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -94,15 +95,16 @@ pub struct StockPosition {
 /// `StockPositionsResponse`, but with fund-specific position fields.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct FundPositionsResponse {
-    pub channels: Vec<FundPositionChannel>,
+    pub list: Vec<FundPositionChannel>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct FundPositionChannel {
-    /// Broker channel identifier.
-    pub account_channel: String,
+    /// Broker channel identifier. Always emitted as `null` for privacy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_channel: Option<String>,
     /// Fund positions held in this channel.
-    pub positions: Vec<FundPosition>,
+    pub fund_info: Vec<FundPosition>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -144,7 +146,7 @@ pub struct MarketTemperatureResponse {
     /// Market sentiment indicator (0-100).
     pub sentiment: i32,
     /// Snapshot timestamp (RFC3339).
-    pub updated_at: String,
+    pub timestamp: String,
 }
 
 /// Returned by `history_market_temperature`.
@@ -154,6 +156,7 @@ pub struct HistoryMarketTemperatureResponse {
     #[serde(rename = "type")]
     pub granularity: String,
     /// Per-period samples in chronological order.
+    #[serde(rename = "list")]
     pub records: Vec<MarketTemperatureResponse>,
 }
 


### PR DESCRIPTION
Follow-up to #24 — audit of the 13 typed output schemas against the SDK source caught **6 places** where the declared shape didn't match what `tool_json` actually emits, plus one `account_channel` nullability fix.

## Bugs fixed

| Schema | Before (in #24) | After (this PR) | Why |
|---|---|---|---|
| `StockPositionsResponse` | `channels: [...]` | `list: [...]` | SDK uses `#[serde(rename = "list")]` |
| `FundPositionsResponse` | `channels: [...]` | `list: [...]` | same |
| `StockPositionChannel` | `positions: [...]` | `stock_info: [...]` | SDK uses `#[serde(rename = "stock_info")]` |
| `FundPositionChannel` | `positions: [...]` | `fund_info: [...]` | SDK uses `#[serde(rename = "fund_info")]` |
| `StockPositionChannel.account_channel` `FundPositionChannel.account_channel` | `String` | `Option<String>` | `to_tool_json` overwrites this field to `null` for privacy regardless of upstream value |
| `MarketTemperatureResponse.updated_at` | — | `timestamp` | The SDK field name is `timestamp`; `alias = "updated_at"` only takes effect on **deserialize**, not serialize |
| `HistoryMarketTemperatureResponse.records` | `records: [...]` | `list: [...]` | SDK uses `#[serde(rename = "list")]` |

## Audit method

Cross-referenced each declared schema against:
1. The SDK type source (`longbridge::trade::types::*`, `longbridge::quote::types::*`, etc.) — pulled directly from `~/.cargo/git/checkouts/openapi-*/rust/src/`
2. The `serde_utils::*` custom serializers (decimals stringify, enums via `collect_str`, RFC3339 timestamps, `Option` nullability rules)
3. The local `to_tool_json` transform (snake_case + `_at`-i64-to-RFC3339 + `counter_id` → `symbol` rename + `aaid` / `account_channel` → `null`)

## Verified clean (no changes needed)

- `OrderIdResponse` (`{order_id}`)
- `StatementUrlResponse` (`{url}`)
- `EstimateMaxQtyResponse` (`{cash_max_qty, margin_max_qty}`)
- `MarginRatioResponse` (`{im_factor, mm_factor, fm_factor}`)
- `DepthResponse` (`{bids, asks}` with `{position, price, volume, order_num}` per level)
- `BrokersResponse` (`{bid_brokers, ask_brokers}`)
- `CapitalDistributionResponse` (`{timestamp, capital_in, capital_out}`)
- `TradingDaysResponse` (`{trading_days, half_trading_days}`)
- `OrderDetailResponse` (25 documented fields; commission/fee tail covered by JSON Schema's default `additionalProperties: true`)

## Test plan

- [x] `cargo +nightly fmt` clean
- [x] `cargo build` clean
- [x] `cargo clippy --all-features --all-targets` — 0 warnings
- [x] `cargo test` — 48 passed
- [x] Live `GET /mcp/tools.json` confirms each fixed schema now emits the corrected field names (`list`, `stock_info`, `fund_info`, `timestamp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)