### PR TITLE
chore: Improve `finance_calendar` tool parameter documentation

### DIFF
--- a/src/tools/calendar.rs
+++ b/src/tools/calendar.rs
@@ -7,20 +7,21 @@ use crate::tools::support::http_client::http_get_tool;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct FinanceCalendarParam {
-    /// Market code: HK, US, CN, SG. Omit to query across all markets.
-    pub market: Option<String>,
-    /// Start date (yyyy-mm-dd)
-    pub start: String,
-    /// End date (yyyy-mm-dd)
-    pub end: String,
-    /// Event category:
-    /// - "financial": earnings/financial results announcements
-    /// - "report": scheduled financial report release dates
-    /// - "dividend": dividend ex-dates and payment dates
-    /// - "ipo": IPO listing dates
-    /// - "macrodata": macroeconomic data releases (GDP, CPI, etc.)
-    /// - "closed": market holiday / trading halt dates
+    /// Event category. One of:
+    /// - "report": earnings reports (includes financial statements)
+    /// - "dividend": dividend announcements
+    /// - "split": stock splits and reverse splits (share consolidations)
+    /// - "ipo": upcoming IPO listings
+    /// - "macrodata": macro economic data releases (CPI, NFP, rate decisions, etc.)
+    /// - "closed": market closure days
     pub category: String,
+    /// Start date in YYYY-MM-DD format (inclusive)
+    pub start: String,
+    /// End date in YYYY-MM-DD format (inclusive)
+    pub end: String,
+    /// Optional market filter. One of: HK, US, CN, SG, JP, UK, DE, AU.
+    /// Omit to include all markets.
+    pub market: Option<String>,
 }
 
 pub async fn finance_calendar(

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1295,7 +1295,7 @@ impl Longbridge {
     #[tool(
         title = "Financial Calendar",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
-        description = "Get finance calendar events. category: financial/report/dividend/ipo/macrodata/closed"
+        description = "Get finance calendar events by category and date range. category: report (earnings + financials) / dividend / split (splits & reverse splits) / ipo / macrodata (CPI, NFP, rate decisions) / closed (market holidays). market: HK/US/CN/SG/JP/UK/DE/AU (optional)."
     )]
     async fn finance_calendar(
         &self,


### PR DESCRIPTION
## Summary

- Reorder `FinanceCalendarParam` fields: `category` first (primary selector), then date range, then optional `market`
- Expand `category` field doc with plain-language descriptions for each value:
  - `report` — earnings reports (includes financial statements)
  - `dividend` — dividend announcements
  - `split` — stock splits **and** reverse splits (share consolidations)
  - `ipo` — upcoming IPO listings
  - `macrodata` — macro economic data releases (CPI, NFP, rate decisions, etc.)
  - `closed` — market closure days
- Remove deprecated `financial` from category list (it's included automatically under `report`)
- Clarify `market` is optional and list all supported codes: HK, US, CN, SG, JP, UK, DE, AU
- Update tool-level description in `mod.rs` to reflect the same information

🤖 Generated with [Claude Code](https://claude.com/claude-code)