### PR TITLE
chore: update Glama maintainer wuxsoft → hogan-yuan

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "maintainers": [
-    "wuxsoft",
+    "hogan-yuan",
     "huacnlee"
   ]
 }


### PR DESCRIPTION
GitHub username changed from `wuxsoft` to `hogan-yuan`. Updates `glama.json` so the new username has admin access to the Glama listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)