### PR TITLE
chore: add Glama wrapper script for stdio-to-HTTP bridging

### DIFF
--- a/scripts/glama-start.sh
+++ b/scripts/glama-start.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Start the Longbridge MCP HTTP server in background
+longbridge-mcp --bind 0.0.0.0:8000 --base-url http://localhost:8000 &
+
+# Wait up to 10 s for the health endpoint to respond
+for i in $(seq 1 10); do
+    if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+# Replace this shell with mcp-proxy pointing at our HTTP server.
+# The outer mcp-proxy (invoked with --) will talk to this stdio process,
+# which forwards to the HTTP server.
+exec mcp-proxy http://localhost:8000/mcp


### PR DESCRIPTION
Glama's build system invokes servers via `mcp-proxy --` which expects a **stdio** MCP process. Since `longbridge-mcp` is an HTTP server, this script bridges the gap:

1. Starts the HTTP server in the background
2. Waits up to 10 s for `/health` to respond  
3. `exec`s `mcp-proxy http://localhost:8000/mcp` — replacing itself with an stdio↔HTTP proxy

Data flow inside Glama's container:
```
Glama scanner → [stdio] → outer mcp-proxy -- glama-start.sh
                                               └→ [stdio] → inner mcp-proxy (exec'd)
                                                              └→ [HTTP] → longbridge-mcp :8000
```

**Glama config update needed:**  
CMD arguments: `["/app/scripts/glama-start.sh"]`  
Build steps: add `chmod +x /app/scripts/glama-start.sh` at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)