### PR TITLE
feat(glama): add --stdio mode for Glama directory scanner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ longbridge = { git = "https://github.com/longbridge/openapi.git" }
 rmcp = { version = "1.4", features = [
     "server",
     "transport-streamable-http-server",
+    "transport-io",
     "macros",
 ] }
 axum = { version = "0.8", features = ["macros"] }

--- a/scripts/glama-start.sh
+++ b/scripts/glama-start.sh
@@ -1,16 +1,4 @@
 #!/bin/sh
-# Start the Longbridge MCP HTTP server in background
-longbridge-mcp --bind 0.0.0.0:8000 --base-url http://localhost:8000 &
-
-# Wait up to 10 s for the health endpoint to respond
-for i in $(seq 1 10); do
-    if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
-        break
-    fi
-    sleep 1
-done
-
-# Replace this shell with mcp-proxy pointing at our HTTP server.
-# The outer mcp-proxy (invoked with --) will talk to this stdio process,
-# which forwards to the HTTP server.
-exec mcp-proxy http://localhost:8000/mcp
+# Glama uses mcp-proxy which expects a stdio MCP process.
+# Our binary now supports --stdio mode directly.
+exec longbridge-mcp --stdio

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,13 @@ struct Cli {
     /// TLS private key file (PEM format)
     #[arg(long)]
     tls_key: Option<PathBuf>,
+
+    /// Run as a stdio MCP server instead of HTTP.
+    /// Exposes tools/list without authentication for directory scanners
+    /// (e.g. Glama).  tools/call will return auth errors for upstream
+    /// calls that require credentials.
+    #[arg(long)]
+    stdio: bool,
 }
 
 /// Resolved configuration (CLI > config file > defaults)
@@ -137,6 +144,24 @@ async fn main() -> anyhow::Result<()> {
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("failed to install rustls crypto provider");
+
+    // stdio mode: serve via stdin/stdout for directory scanners like Glama.
+    // tools/list works without credentials; tools/call returns auth errors.
+    if std::env::args().any(|a| a == "--stdio") {
+        init_logging(None);
+        let tools = crate::tools::list_tools();
+        tracing::info!(count = tools.len(), "stdio mode: tools available");
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        let transport = AsyncRwTransport::<rmcp::RoleServer, _, _>::new(
+            tokio::io::stdin(),
+            tokio::io::stdout(),
+        );
+        rmcp::serve_server(crate::tools::Longbridge, transport)
+            .await
+            .ok();
+        return Ok(());
+    }
+
     let config = load_config();
     init_logging(config.log_dir.as_ref());
 


### PR DESCRIPTION
Glama's build system invokes servers via mcp-proxy which expects a stdio MCP process. This branch adds minimal stdio transport support so the Glama release can scan tool definitions without touching the production HTTP server or main branch.

Changes:
- src/main.rs: --stdio flag starts an rmcp stdio server (AsyncRwTransport over stdin/stdout). tools/list works without credentials; tools/call returns auth errors as expected.
- Cargo.toml: enable rmcp transport-io feature
- scripts/glama-start.sh: simplified to exec longbridge-mcp --stdio

This branch is intentionally NOT merged to main. Pin the Glama Dockerfile build to the HEAD commit of this branch.