### PR TITLE
feat: add --stdio mode for Glama directory scanner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ longbridge = { git = "https://github.com/longbridge/openapi.git" }
 rmcp = { version = "1.4", features = [
     "server",
     "transport-streamable-http-server",
+    "transport-io",
     "macros",
 ] }
 axum = { version = "0.8", features = ["macros"] }

--- a/scripts/glama-start.sh
+++ b/scripts/glama-start.sh
@@ -1,16 +1,4 @@
 #!/bin/sh
-# Start the Longbridge MCP HTTP server in background
-longbridge-mcp --bind 0.0.0.0:8000 --base-url http://localhost:8000 &
-
-# Wait up to 10 s for the health endpoint to respond
-for i in $(seq 1 10); do
-    if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
-        break
-    fi
-    sleep 1
-done
-
-# Replace this shell with mcp-proxy pointing at our HTTP server.
-# The outer mcp-proxy (invoked with --) will talk to this stdio process,
-# which forwards to the HTTP server.
-exec mcp-proxy http://localhost:8000/mcp
+# Glama uses mcp-proxy which expects a stdio MCP process.
+# Our binary now supports --stdio mode directly.
+exec longbridge-mcp --stdio

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,13 @@ struct Cli {
     /// TLS private key file (PEM format)
     #[arg(long)]
     tls_key: Option<PathBuf>,
+
+    /// Run as a stdio MCP server instead of HTTP.
+    /// Exposes tools/list without authentication for directory scanners
+    /// (e.g. Glama).  tools/call will return auth errors for upstream
+    /// calls that require credentials.
+    #[arg(long)]
+    stdio: bool,
 }
 
 /// Resolved configuration (CLI > config file > defaults)
@@ -137,6 +144,24 @@ async fn main() -> anyhow::Result<()> {
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("failed to install rustls crypto provider");
+
+    // stdio mode: serve via stdin/stdout for directory scanners like Glama.
+    // tools/list works without credentials; tools/call returns auth errors.
+    if std::env::args().any(|a| a == "--stdio") {
+        init_logging(None);
+        let tools = crate::tools::list_tools();
+        tracing::info!(count = tools.len(), "stdio mode: tools available");
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        let transport = AsyncRwTransport::<rmcp::RoleServer, _, _>::new(
+            tokio::io::stdin(),
+            tokio::io::stdout(),
+        );
+        rmcp::serve_server(crate::tools::Longbridge, transport)
+            .await
+            .ok();
+        return Ok(());
+    }
+
     let config = load_config();
     init_logging(config.log_dir.as_ref());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,13 @@ async fn main() -> anyhow::Result<()> {
     // stdio mode: serve via stdin/stdout for directory scanners like Glama.
     // tools/list works without credentials; tools/call returns auth errors.
     if std::env::args().any(|a| a == "--stdio") {
-        init_logging(None);
+        // In stdio mode stdout is the MCP transport; send all logs to stderr.
+        let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_writer(std::io::stderr)
+            .init();
         let tools = crate::tools::list_tools();
         tracing::info!(count = tools.len(), "stdio mode: tools available");
         use rmcp::transport::async_rw::AsyncRwTransport;
@@ -156,9 +162,9 @@ async fn main() -> anyhow::Result<()> {
             tokio::io::stdin(),
             tokio::io::stdout(),
         );
-        rmcp::serve_server(crate::tools::Longbridge, transport)
-            .await
-            .ok();
+        if let Ok(service) = rmcp::serve_server(crate::tools::Longbridge, transport).await {
+            service.waiting().await.ok();
+        }
         return Ok(());
     }
 


### PR DESCRIPTION
## What

Adds a `--stdio` transport mode so Glama's build system can scan the server's tool definitions without needing a real OAuth token.

```
# New flag — does not affect the existing HTTP server in any way
longbridge-mcp --stdio
```

When `--stdio` is passed the binary:
1. Listens for MCP JSON-RPC messages on **stdin**
2. Responds on **stdout** (logs go to **stderr**, keeping stdout clean)
3. Holds the server alive via `RunningService::waiting()` until stdin closes

`tools/list` works fully without credentials. `tools/call` returns auth errors for any upstream calls that require a Longbridge token — which is expected and acceptable for a directory scanner.

## Why

Glama's build system wraps every server with `mcp-proxy --`, which expects a **stdio** MCP process. Our server is an HTTP server, so the wrapper always timed out or errored. This flag bridges that gap with minimal code (~20 lines in `main.rs`).

## What doesn't change

The existing HTTP server path is completely untouched — no behaviour change when running without `--stdio`.

## Files changed

| File | Change |
|---|---|
| `src/main.rs` | `--stdio` flag → rmcp `AsyncRwTransport` over stdin/stdout; logs explicitly routed to stderr |
| `Cargo.toml` | enable rmcp `transport-io` feature |
| `scripts/glama-start.sh` | simplified: `exec longbridge-mcp --stdio` |

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-features --all-targets` — 0 warnings  
- [x] `cargo test` — 48 passed
- [x] HTTP mode: `--bind 0.0.0.0:8001` starts normally, `/health` 200, `/mcp/tools.json` 109 tools
- [x] stdio mode: `initialize` + `tools/list` returns 109 tools with title / annotations / outputSchema all present; stdout is pure JSON-RPC, logs on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)