### PR TITLE
fix: timestamp conversion + bump to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-mcp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longbridge-mcp"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [dependencies]

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.longbridge/mcp",
   "description": "US/HK markets — 110 tools: real-time quotes, options, orders, fundamentals, alerts, DCA & portfolio",
-  "version": "0.1.12",
+  "version": "0.2.1",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.1.12",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.2.1",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",

--- a/src/tools/calendar.rs
+++ b/src/tools/calendar.rs
@@ -3,7 +3,7 @@ use rmcp::model::CallToolResult;
 use rmcp::schemars::JsonSchema;
 use rmcp::serde::Deserialize;
 
-use crate::tools::support::http_client::http_get_tool;
+use crate::tools::support::http_client::http_get_tool_unix;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct FinanceCalendarParam {
@@ -39,5 +39,11 @@ pub async fn finance_calendar(
         market_upper = m.to_uppercase();
         params.push(("markets[]", market_upper.as_str()));
     }
-    http_get_tool(&client, "/v1/quote/finance_calendar", &params).await
+    http_get_tool_unix(
+        &client,
+        "/v1/quote/finance_calendar",
+        &params,
+        &["list.*.infos.*.datetime"],
+    )
+    .await
 }

--- a/src/tools/ipo.rs
+++ b/src/tools/ipo.rs
@@ -4,7 +4,7 @@ use rmcp::schemars::JsonSchema;
 use rmcp::serde::Deserialize;
 
 use crate::counter::symbol_to_counter_id;
-use crate::tools::support::http_client::http_get_tool;
+use crate::tools::support::http_client::{http_get_tool, http_get_tool_unix};
 
 fn make_result(json: String) -> CallToolResult {
     let structured = serde_json::from_str::<serde_json::Value>(&json).ok();
@@ -81,7 +81,7 @@ pub async fn ipo_subscriptions(
 /// Show the IPO calendar (all upcoming and recent IPOs).
 pub async fn ipo_calendar(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
-    http_get_tool(&client, "/v1/ipo/calendar", &[]).await
+    http_get_tool_unix(&client, "/v1/ipo/calendar", &[], &["timestamp"]).await
 }
 
 /// List recently listed IPO stocks (HK and US).

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -222,7 +222,7 @@ impl Longbridge {
     #[tool(
         title = "Security Static Info",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
-        description = "Get basic information of securities (name, exchange, type, lot_size)"
+        description = "Get basic information of securities (name_cn, name_en, exchange, type, lot_size)"
     )]
     async fn static_info(
         &self,
@@ -283,7 +283,7 @@ impl Longbridge {
         title = "Order Book Depth",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::DepthResponse>(),
-        description = "Get order book depth (bid/ask levels)"
+        description = "Get order book depth (asks/bids arrays with price, volume, order_count)"
     )]
     async fn depth(
         &self,

--- a/src/tools/portfolio.rs
+++ b/src/tools/portfolio.rs
@@ -118,7 +118,7 @@ pub async fn profit_analysis(
     merged.insert("sublist".to_owned(), sublist);
 
     let mut value = serde_json::Value::Object(merged);
-    convert_unix_paths(&mut value, &["end_time", "trade_update_time"]);
+    convert_unix_paths(&mut value, &["start_time", "end_time", "trade_update_time"]);
 
     Ok(CallToolResult::success(vec![Content::text(
         value.to_string(),


### PR DESCRIPTION
## Summary

- **version**: bump `Cargo.toml` and `server.json` to `0.2.1`
- **calendar**: switch `finance_calendar` to `http_get_tool_unix` — converts `list[].infos[].datetime` from unix to ISO 8601
- **ipo**: convert `ipo_calendar` `timestamp` field to ISO 8601
- **portfolio**: add `start_time` to `profit_analysis` unix path conversion (was missing alongside `end_time`)
- **mod**: fix `static_info` description (`name` → `name_cn, name_en`) and `depth` description (`bid/ask` → `asks/bids`)

## Test plan

- [x] `cargo build` passes
- [x] Full 128-tool test suite: PASS 95 / WARN 2 / SKIP 31 / FAIL 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)