### PR TITLE
feat(tools): remove analyst-estimates MCP tool

### DIFF
--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -340,14 +340,6 @@ pub struct ValuationRankParam {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct AnalystEstimatesParam {
-    /// Security symbol, e.g. "AAPL.US"
-    pub symbol: String,
-    /// Estimate item: "EPS" (default), "REV", "NET_PROFIT", "EBITDA"
-    pub item: Option<String>,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
 pub struct InstitutionRatingIndustryRankParam {
     /// Security symbol, e.g. "AAPL.US"
     pub symbol: String,
@@ -417,22 +409,6 @@ pub async fn valuation_rank(
             "ps.*.timestamp",
             "dvd.*.timestamp",
         ],
-    )
-    .await
-}
-
-/// Get analyst consensus estimates for a security.
-pub async fn analyst_estimates(
-    mctx: &crate::tools::McpContext,
-    p: AnalystEstimatesParam,
-) -> Result<CallToolResult, McpError> {
-    let client = mctx.create_http_client();
-    let cid = symbol_to_counter_id(&p.symbol);
-    let item = p.item.unwrap_or_else(|| "EPS".to_string()).to_uppercase();
-    http_get_tool(
-        &client,
-        "/v1/quote/estimates",
-        &[("counter_id", cid.as_str()), ("item", item.as_str())],
     )
     .await
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1203,7 +1203,7 @@ impl Longbridge {
     #[tool(
         title = "Operating Performance",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
-        description = "Get company operating metrics"
+        description = "Get company operating metrics. Only supports HK stocks."
     )]
     async fn operating(
         &self,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2099,24 +2099,6 @@ impl Longbridge {
         measured_tool_call("valuation_rank", || fundamental::valuation_rank(&mctx, p)).await
     }
 
-    /// Get analyst consensus estimates for a security.
-    #[tool(
-        title = "Analyst Estimates",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
-        description = "Get analyst consensus estimates (EPS, revenue, net profit, EBITDA) for a security. item: EPS (default), REV, NET_PROFIT, EBITDA."
-    )]
-    async fn analyst_estimates(
-        &self,
-        ctx: RequestContext<RoleServer>,
-        Parameters(p): Parameters<fundamental::AnalystEstimatesParam>,
-    ) -> Result<CallToolResult, McpError> {
-        let mctx = extract_context(&ctx)?;
-        measured_tool_call("analyst_estimates", || {
-            fundamental::analyst_estimates(&mctx, p)
-        })
-        .await
-    }
-
     /// Get institution rating history for a security.
     #[tool(
         title = "Institution Rating History",


### PR DESCRIPTION
## Summary

Ref https://github.com/longbridge/developers/pull/982

- 删除 `AnalystEstimatesParam` struct
- 删除 `fundamental::analyst_estimates` 函数
- 删除对应的 MCP tool `analyst_estimates`

## Test plan

- [ ] 确认编译无错误
- [ ] 确认其他 MCP tools 功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)