### PR TITLE
fix: resolve Cursor connection failures and structuredContent spec violation

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -4,7 +4,7 @@ pub mod middleware;
 use std::sync::Arc;
 
 use axum::Router;
-use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::session::never::NeverSessionManager;
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 
 use crate::tools::{self, Longbridge};
@@ -127,8 +127,10 @@ pub fn create_router(state: Arc<AppState>) -> Router {
 
     let mcp_service = StreamableHttpService::new(
         move || Ok(Longbridge),
-        Arc::new(LocalSessionManager::default()),
-        StreamableHttpServerConfig::default().disable_allowed_hosts(),
+        Arc::new(NeverSessionManager::default()),
+        StreamableHttpServerConfig::default()
+            .with_stateful_mode(false)
+            .disable_allowed_hosts(),
     );
 
     // Auth middleware layer: extracts Bearer token into extensions

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -62,7 +62,9 @@ fn tool_result(json: String) -> CallToolResult {
     // MCP spec §tool-result: a tool that declares an `outputSchema` MUST
     // return `structuredContent`. We populate it for every response so the
     // invariant holds regardless of which tools gain a schema in the future.
-    let structured = serde_json::from_str::<serde_json::Value>(&json).ok();
+    let structured = serde_json::from_str::<serde_json::Value>(&json)
+        .ok()
+        .filter(serde_json::Value::is_object);
     let mut result = CallToolResult::success(vec![Content::text(json)]);
     result.structured_content = structured;
     result


### PR DESCRIPTION
## Summary

- Switch MCP server to stateless mode to fix session-not-found errors on multi-instance deployments
- Fix `structuredContent` type violation that caused Cursor to reject array tool responses

## Fix 1 — Stateless mode (`src/auth/mod.rs`)

**Root cause**: The server is designed for stateless multi-instance deployment, but was using `stateful_mode: true` (the rmcp default) with an in-memory `LocalSessionManager`. Under a load balancer, sessions created on Instance A are unknown to Instance B, triggering a failure chain in Cursor:

1. POST with cached `Mcp-Session-Id` → **404 Session not found** (session lives on another instance)
2. Cursor falls back to legacy SSE V1 protocol (GET without session ID) → **400 Session ID is required**

Claude Code and Codex are unaffected because they re-initialize on every connection rather than caching session IDs.

**Fix**: Replace `LocalSessionManager` with `NeverSessionManager` and set `stateful_mode(false)`. The `Mcp-Session-Id` header is completely ignored in stateless mode; each POST is handled independently with no session state.

## Fix 2 — `structuredContent` type (`src/tools/mod.rs`)

**Root cause**: `tool_result` unconditionally assigned the parsed JSON value to `structured_content`. Tools returning `Vec<T>` (e.g. `quote`, `static_info`, `trades`, `candlesticks`, `participants`) serialize to a JSON array. The MCP spec requires `structuredContent` to be a JSON **object** (record); Cursor validates this strictly and rejects array values with:

```
Invalid input: expected record, received array
```

**Fix**: Added `.filter(serde_json::Value::is_object)` so `structured_content` is only set for JSON object responses. Array responses leave it as `None`, which is valid per spec. The fix is centralized in `tool_result` and covers all tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)