### PR TITLE
feat: forward incoming HTTP headers to upstream Longbridge services

### DIFF
--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -111,6 +111,8 @@ impl McpContext {
                 longbridge::oauth::OAuth::from_token(&self.token),
             ),
         );
+        // NOTE: This is very important for passing headers to upstream Longbridge services.
+        // Do not remove this unless you have a good reason and know exactly which headers to forward instead.
         for (key, value) in &self.extra_headers {
             client = client.header(key.as_str(), value.as_str());
         }
@@ -175,6 +177,15 @@ fn base64url_decode(input: &str) -> Option<Vec<u8>> {
     Some(out)
 }
 
+fn collect_headers(headers: &axum::http::HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            Some((name.as_str().to_string(), value.to_str().ok()?.to_string()))
+        })
+        .collect()
+}
+
 fn extract_context(ctx: &RequestContext<RoleServer>) -> Result<McpContext, McpError> {
     let parts = ctx
         .extensions
@@ -189,18 +200,12 @@ fn extract_context(ctx: &RequestContext<RoleServer>) -> Result<McpContext, McpEr
         .get("accept-language")
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
-    let extra_headers: Vec<(String, String)> = parts
-        .headers
-        .iter()
-        .filter_map(|(name, value)| {
-            Some((name.as_str().to_string(), value.to_str().ok()?.to_string()))
-        })
-        .collect();
-    tracing::debug!(headers = ?extra_headers, "forwarding headers to upstream");
     Ok(McpContext {
         token: token.0.clone(),
         language,
-        extra_headers,
+        // NOTE: This is very important for passing headers to upstream Longbridge services.
+        // Do not remove this unless you have a good reason and know exactly which headers to forward instead.
+        extra_headers: collect_headers(&parts.headers),
     })
 }
 
@@ -2319,3 +2324,51 @@ impl Longbridge {
     instructions = "Longbridge OpenAPI MCP Server - provides market data, trading, and financial analysis tools"
 )]
 impl ServerHandler for Longbridge {}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{HeaderMap, HeaderName, HeaderValue};
+
+    use super::collect_headers;
+
+    #[test]
+    fn collects_all_valid_headers() {
+        let mut map = HeaderMap::new();
+        map.insert(
+            HeaderName::from_static("x-custom"),
+            HeaderValue::from_static("hello"),
+        );
+        map.insert(
+            HeaderName::from_static("accept-language"),
+            HeaderValue::from_static("zh-CN"),
+        );
+        let headers = collect_headers(&map);
+        assert!(headers.iter().any(|(k, v)| k == "x-custom" && v == "hello"));
+        assert!(
+            headers
+                .iter()
+                .any(|(k, v)| k == "accept-language" && v == "zh-CN")
+        );
+    }
+
+    #[test]
+    fn skips_non_utf8_values() {
+        let mut map = HeaderMap::new();
+        map.insert(
+            HeaderName::from_static("x-valid"),
+            HeaderValue::from_static("ok"),
+        );
+        map.insert(
+            HeaderName::from_static("x-binary"),
+            HeaderValue::from_bytes(&[0x80, 0x81]).unwrap(),
+        );
+        let headers = collect_headers(&map);
+        assert!(headers.iter().any(|(k, v)| k == "x-valid" && v == "ok"));
+        assert!(!headers.iter().any(|(k, _)| k == "x-binary"));
+    }
+
+    #[test]
+    fn empty_map_returns_empty() {
+        assert!(collect_headers(&HeaderMap::new()).is_empty());
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -82,6 +82,8 @@ where
 pub struct McpContext {
     pub token: String,
     pub language: Option<String>,
+    /// Extra headers to forward to upstream Longbridge services.
+    pub extra_headers: Vec<(String, String)>,
 }
 
 impl McpContext {
@@ -104,11 +106,15 @@ impl McpContext {
     }
 
     pub fn create_http_client(&self) -> longbridge::httpclient::HttpClient {
-        longbridge::httpclient::HttpClient::new(
+        let mut client = longbridge::httpclient::HttpClient::new(
             longbridge::httpclient::HttpClientConfig::from_oauth(
                 longbridge::oauth::OAuth::from_token(&self.token),
             ),
-        )
+        );
+        for (key, value) in &self.extra_headers {
+            client = client.header(key.as_str(), value.as_str());
+        }
+        client
     }
 
     /// Extracts `account_channel` from the JWT bearer token's `sub` claim.
@@ -183,9 +189,18 @@ fn extract_context(ctx: &RequestContext<RoleServer>) -> Result<McpContext, McpEr
         .get("accept-language")
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
+    let extra_headers: Vec<(String, String)> = parts
+        .headers
+        .iter()
+        .filter_map(|(name, value)| {
+            Some((name.as_str().to_string(), value.to_str().ok()?.to_string()))
+        })
+        .collect();
+    tracing::debug!(headers = ?extra_headers, "forwarding headers to upstream");
     Ok(McpContext {
         token: token.0.clone(),
         language,
+        extra_headers,
     })
 }
 


### PR DESCRIPTION
## Summary

- Add `extra_headers: Vec<(String, String)>` to `McpContext` to carry all incoming request headers
- In `create_http_client()`, chain `.header()` calls to attach extra headers to every upstream REST request
- In `extract_context()`, collect all headers from the MCP request (skipping non-UTF-8 values)
- Add a `tracing::debug!` log line to verify forwarded headers during development

## Notes

- `longbridge::Config` in the current dependency version (`485cf02`) has no `header()` method, so WebSocket-based SDK clients (`QuoteContext`, `TradeContext`) do not yet receive the extra headers — only `HttpClient`-based REST calls are affected
- The MCP `Accept: application/json, text/event-stream` header will be forwarded to upstream; if upstream returns 406, filtering out the `accept` header is the minimal fix needed

## Test plan

- [ ] Start server with `RUST_LOG=longbridge_mcp=debug`
- [ ] Send a request with a custom header (`X-My-Custom: hello`) plus `Accept: application/json, text/event-stream`
- [ ] Confirm the debug log shows the custom header in the forwarded list

🤖 Generated with [Claude Code](https://claude.com/claude-code)