### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.longbridge/mcp",
   "description": "US/HK markets — 127 tools: real-time quotes, options, orders, fundamentals, IPO, alerts, DCA & portfolio",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.2.2",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.2.3",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",


### PR DESCRIPTION
## Summary

- Bump `Cargo.toml` and `server.json` (version + OCI identifier) to `0.2.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)