### PR TITLE
fix: shorten server.json description to ≤100 chars

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.longbridge/mcp",
-  "description": "US/HK markets — 127 tools: real-time quotes, options, orders, fundamentals, IPO, alerts, DCA & portfolio",
+  "description": "US/HK markets — 127 tools: quotes, options, orders, fundamentals, IPO, alerts, DCA & portfolio",
   "version": "0.2.3",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",


### PR DESCRIPTION
## Summary

`mcp-publisher publish` rejects descriptions > 100 characters. Removes "real-time " (10 chars) to bring it within limit (104 → 94 chars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)