### PR TITLE
feat(locales): improve all 133 zh-CN/zh-HK tool descriptions

### DIFF
--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -4,7 +4,7 @@
   "tools": {
     "create_watchlist_group": {
       "title": "新建自选分组",
-      "description": "新建一个自选分组，可选地附带初始股票列表",
+      "description": "新建自选分组，返回 {id, name}。可选传入 securities（如 [\"AAPL.US\"]）预填入证券",
       "properties": {
         "name": "分组名称",
         "securities": "要加入的证券代码，例如 `[\"700.HK\", \"AAPL.US\"]`"
@@ -12,7 +12,7 @@
     },
     "delete_watchlist_group": {
       "title": "删除自选分组",
-      "description": "按分组 id 删除自选分组",
+      "description": "按分组 id 删除自选分组。purge=true 时同时从其他分组中移除该分组包含的证券",
       "properties": {
         "id": "自选分组 id",
         "purge": "是否同时从其他分组中清除这些证券"
@@ -28,7 +28,7 @@
     },
     "update_watchlist_group": {
       "title": "更新自选分组",
-      "description": "更新自选分组（重命名，或对其中的证券进行新增 / 移除 / 替换）",
+      "description": "更新自选分组：重命名（name）或修改成员证券（securities + mode: add/remove/replace）",
       "properties": {
         "id": "自选分组 id",
         "name": "新的分组名称（可选）",
@@ -38,18 +38,18 @@
     },
     "watchlist": {
       "title": "自选列表",
-      "description": "获取所有自选分组及其包含的证券"
+      "description": "获取所有自选分组及其包含的证券，返回 groups[]{id, name, securities[]{symbol, name, watched_price, watched_at}}"
     },
     "account_balance": {
       "title": "账户余额",
-      "description": "查询账户现金余额与资产概览。可传入 `currency`（如 `\"USD\"`、`\"HKD\"`）按币种筛选，省略则返回全部币种",
+      "description": "查询账户现金余额与资产概览，返回 balances[]{currency, total_cash, max_finance_amount, remaining_finance_amount, risk_level, margin_call}",
       "properties": {
         "currency": "按币种代码筛选（如 `\"USD\"`、`\"HKD\"`），省略则返回所有币种"
       }
     },
     "cash_flow": {
       "title": "资金流水",
-      "description": "查询资金流水记录（出入金、派息等）",
+      "description": "查询资金流水记录（出入金、派息等），返回 items[]{transaction_type, amount, currency, balance, created_at, remark}",
       "properties": {
         "start_at": "起始时间（RFC3339 格式）",
         "end_at": "结束时间（RFC3339 格式）"
@@ -57,18 +57,18 @@
     },
     "fund_positions": {
       "title": "基金持仓",
-      "description": "查询当前的基金持仓"
+      "description": "查询当前基金持仓，返回 list[].fund_info[]{symbol, symbol_name, currency, holding_units, current_net_asset_value, cost_net_asset_value, net_asset_value_day}"
     },
     "margin_ratio": {
       "title": "保证金比率",
-      "description": "查询保证金比率（初始 / 维持 / 强平）",
+      "description": "查询标的保证金比率，返回 {im_factor（初始保证金）, mm_factor（维持保证金）, fm_factor（强平保证金）}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "profit_analysis": {
       "title": "盈亏分析",
-      "description": "获取组合盈亏分析汇总。`start` / `end` 为可选日期区间（`yyyy-mm-dd`），必须成对传入；只传其中之一会返回空结果",
+      "description": "获取组合盈亏分析汇总。start/end（yyyy-mm-dd）须成对传入，只传其中之一会返回空结果",
       "properties": {
         "start": "起始日期（`yyyy-mm-dd`）。必须与 `end` 成对传入，只传其一会返回空结果",
         "end": "结束日期（`yyyy-mm-dd`）。必须与 `start` 成对传入，只传其一会返回空结果"
@@ -76,7 +76,7 @@
     },
     "profit_analysis_detail": {
       "title": "盈亏分析明细",
-      "description": "获取指定标的的详细盈亏分析。`start` / `end` 为可选日期区间（`yyyy-mm-dd`），必须成对传入；只传其中之一会返回空结果",
+      "description": "获取指定标的详细盈亏分析。start/end（yyyy-mm-dd）须成对传入，只传其中之一会返回空结果",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`",
         "start": "起始日期（`yyyy-mm-dd`）。必须与 `end` 成对传入，只传其一会返回空结果",
@@ -85,14 +85,14 @@
     },
     "statement_export": {
       "title": "对账单导出",
-      "description": "获取对账单数据文件的预签名下载 URL（`file_key` 来自 `statement_list`）。返回 `{url}`，访问该 URL 即可获取对账单 JSON",
+      "description": "获取对账单文件的预签名下载 URL（file_key 来自 statement_list），返回 {url}，访问该 URL 即可获取对账单 JSON",
       "properties": {
         "file_key": "来自 `statement_list` 的文件 key，例如 `\"/statement_data/data/.../20975338.json\"`"
       }
     },
     "statement_list": {
       "title": "对账单列表",
-      "description": "列出可获取的账户对账单（日 / 月对账单）",
+      "description": "列出可获取的账户对账单（日报/月报），返回 list[]{id, type, date, status}，用 id 调用 statement_export 下载",
       "properties": {
         "statement_type": "对账单类型：`\"daily\"`（默认，日报）或 `\"monthly\"`（月报）",
         "start_date": "起始日期（`yyyy-mm-dd`）。`daily` 默认 30 天前，`monthly` 默认 12 个月前",
@@ -101,11 +101,11 @@
     },
     "stock_positions": {
       "title": "股票持仓",
-      "description": "查询所有渠道下的当前股票持仓"
+      "description": "查询所有渠道下的当前股票持仓，返回 list[].stock_info[]{symbol, symbol_name, quantity, available_quantity, currency, cost_price, market}"
     },
     "dca_history": {
       "title": "定投执行历史",
-      "description": "按 `plan_id` 查询定投计划的扣款执行历史",
+      "description": "按 plan_id 查询定投计划的扣款执行历史，返回 executions[]{date, quantity, amount, price, status, order_id}",
       "properties": {
         "plan_id": "定投计划 ID",
         "page": "页码（默认 1）",
@@ -114,7 +114,7 @@
     },
     "dca_list": {
       "title": "定投计划列表",
-      "description": "列出定投计划，可按状态（`Active` 进行中 / `Suspended` 暂停 / `Finished` 已结束）或证券筛选",
+      "description": "列出定投计划，返回 plans[]{plan_id, symbol, amount, currency, frequency, status, next_execution_date}",
       "properties": {
         "status": "按状态筛选：`Active`、`Suspended`、`Finished`，省略则返回全部",
         "symbol": "按证券筛选，例如 `\"AAPL.US\"`，省略则返回全部计划",
@@ -124,14 +124,14 @@
     },
     "dca_stats": {
       "title": "定投统计",
-      "description": "获取定投投资统计汇总，可选地按证券筛选",
+      "description": "获取定投投资统计汇总，返回 {total_invested, total_value, total_return, return_rate, plan_count, items[]{symbol, invested, value, return_rate}}",
       "properties": {
         "symbol": "按证券筛选，例如 `\"AAPL.US\"`，省略则返回所有计划的合计统计"
       }
     },
     "estimate_max_purchase_quantity": {
       "title": "最大可买估算",
-      "description": "估算指定证券的最大可买 / 可卖数量",
+      "description": "估算指定证券的最大可买/可卖数量，返回 {cash_max_qty, margin_max_qty}",
       "properties": {
         "symbol": "证券代码",
         "side": "买卖方向：`Buy`（买入）或 `Sell`（卖出）",
@@ -141,7 +141,7 @@
     },
     "history_executions": {
       "title": "历史成交",
-      "description": "查询指定日期区间内的历史成交记录",
+      "description": "查询指定日期区间内的历史成交记录，返回 executions[]{order_id, symbol, side, quantity, price, trade_done_at}",
       "properties": {
         "symbol": "按证券筛选（可选）",
         "start_at": "起始时间（RFC3339 格式）",
@@ -150,7 +150,7 @@
     },
     "history_orders": {
       "title": "历史委托",
-      "description": "查询指定日期区间内的历史委托（不含当日）",
+      "description": "查询指定日期区间内的历史委托（不含当日），返回 orders[]{order_id, symbol, side, status, quantity, price, submitted_at}",
       "properties": {
         "symbol": "按证券筛选（可选）",
         "start_at": "起始时间（RFC3339 格式）",
@@ -159,14 +159,14 @@
     },
     "order_detail": {
       "title": "委托详情",
-      "description": "查询单个委托的详细信息",
+      "description": "查询单个委托详情，返回 {order_id, symbol, status, side, order_type, quantity, price, executed_quantity, executed_price, submitted_at, time_in_force, msg}",
       "properties": {
         "order_id": "委托单号"
       }
     },
     "today_executions": {
       "title": "当日成交",
-      "description": "查询当日成交（filled）。可传入 `symbol` 或 `order_id` 筛选，两者都省略则返回全部",
+      "description": "查询当日成交（filled），返回 executions[]{order_id, symbol, side, quantity, price, trade_done_at}。可按 symbol 或 order_id 筛选",
       "properties": {
         "symbol": "按证券筛选，例如 `\"700.HK\"`",
         "order_id": "按指定委托单号筛选"
@@ -174,21 +174,21 @@
     },
     "today_orders": {
       "title": "当日委托",
-      "description": "查询当日委托。可传入 `symbol` 筛选，省略则返回全部",
+      "description": "查询当日委托，返回 orders[]{order_id, symbol, side, order_type, status, quantity, price, submitted_at, executed_quantity, executed_price}",
       "properties": {
         "symbol": "按证券筛选，例如 `\"700.HK\"`，省略则返回当日全部委托"
       }
     },
     "cancel_order": {
       "title": "撤销委托",
-      "description": "按 `order_id` 撤销未成交的委托",
+      "description": "按 order_id 撤销未成交的委托，成功返回 \"order cancelled\"；已成交或已撤销则报错",
       "properties": {
         "order_id": "委托单号"
       }
     },
     "dca_create": {
       "title": "创建定投计划",
-      "description": "创建定投（DCA）计划。`frequency` 可选 `Daily` / `Weekly` / `Monthly`；周频对应 `day_of_week`（`Mon`–`Fri`），月频对应 `day_of_month`（1-28）",
+      "description": "创建定投（DCA）计划。frequency: Daily/Weekly/Monthly；周频对应 day_of_week（Mon–Fri），月频对应 day_of_month（1-28）",
       "properties": {
         "symbol": "证券代码，例如 `\"AAPL.US\"`",
         "amount": "每期投入金额，例如 `\"100\"`",
@@ -200,28 +200,28 @@
     },
     "dca_pause": {
       "title": "暂停定投计划",
-      "description": "按 `plan_id` 暂停定投计划",
+      "description": "按 plan_id 暂停定投计划，计划停止执行直至恢复。如需临时暂停请使用此接口（永久终止用 dca_stop）",
       "properties": {
         "plan_id": "定投计划 ID"
       }
     },
     "dca_resume": {
       "title": "恢复定投计划",
-      "description": "按 `plan_id` 恢复已暂停的定投计划",
+      "description": "按 plan_id 恢复已暂停的定投计划，按原有周期继续自动执行",
       "properties": {
         "plan_id": "定投计划 ID"
       }
     },
     "dca_stop": {
       "title": "终止定投计划",
-      "description": "按 `plan_id` 永久终止定投计划",
+      "description": "按 plan_id 永久终止定投计划，操作不可撤销。如需临时暂停请使用 dca_pause",
       "properties": {
         "plan_id": "定投计划 ID"
       }
     },
     "dca_update": {
       "title": "更新定投计划",
-      "description": "按 `plan_id` 更新已存在的定投计划",
+      "description": "按 plan_id 更新定投计划，可修改 amount、frequency（Daily/Weekly/Monthly）、day_of_week（Mon-Fri）或 day_of_month（1-28）",
       "properties": {
         "plan_id": "待更新的定投计划 ID",
         "amount": "新的每期投入金额",
@@ -233,7 +233,7 @@
     },
     "replace_order": {
       "title": "修改委托",
-      "description": "改单（替换 / 修改已存在的委托）",
+      "description": "修改未成交委托的数量、价格、触发价或追踪止损参数，成功返回 \"order replaced\"",
       "properties": {
         "order_id": "委托单号",
         "quantity": "新的委托数量",
@@ -246,7 +246,7 @@
     },
     "submit_order": {
       "title": "提交委托",
-      "description": "提交买入 / 卖出委托。`order_type` 可选：`LO`（限价）/ `ELO`（港股增强限价）/ `MO`（市价）/ `AO`（港股竞价）/ `ALO`（港股竞价限价）/ `ODD`（港股碎股）/ `LIT`（触价限价）/ `MIT`（触价市价）/ `TSLPAMT`（按金额跟踪止损限价）/ `TSLPPCT`（按百分比跟踪止损限价）/ `SLO`（港股特别限价）；`side` 为 `Buy` / `Sell`；`time_in_force` 为 `Day` / `GTC` / `GTD`",
+      "description": "提交买卖委托。order_type：LO（限价）/ ELO（港股增强限价）/ MO（市价）/ AO（港股竞价）/ ALO（港股竞价限价）/ ODD（港股碎股）/ LIT（触价限价）/ MIT（触价市价）/ TSLPAMT（按金额追踪止损）/ TSLPPCT（按百分比追踪止损）/ SLO（港股特别限价）；side：Buy/Sell；time_in_force：Day/GTC/GTD",
       "properties": {
         "symbol": "证券代码",
         "order_type": "委托类型（港股全部支持；美股仅支持 `LO` / `MO` / `LIT` / `MIT` / `TSLPAMT` / `TSLPPCT`）：<br>- `LO`（限价单）：需 `submitted_price`<br>- `ELO`（增强限价单，港股）：需 `submitted_price`<br>- `MO`（市价单）：无需价格<br>- `AO`（竞价单，港股）：以竞价价成交，无需价格<br>- `ALO`（竞价限价单，港股）：需 `submitted_price`<br>- `ODD`（碎股单，港股）：需 `submitted_price`，用于非标准手数<br>- `LIT`（触价限价）：需 `submitted_price` 与 `trigger_price`，行情触及触发价时激活<br>- `MIT`（触价市价）：仅需 `trigger_price`，触及后按市价成交<br>- `TSLPAMT`（按金额跟踪止损限价）：需 `trailing_amount` 与 `limit_offset`<br>- `TSLPPCT`（按百分比跟踪止损限价）：需 `trailing_percent`（0-1）与 `limit_offset`<br>- `SLO`（特别限价单，港股）：需 `submitted_price`，提交后不可改单",
@@ -265,7 +265,7 @@
     },
     "ah_premium": {
       "title": "A/H 溢价",
-      "description": "获取 A/H 股溢价的历史 K 线数据",
+      "description": "获取 A/H 股溢价历史 K 线数据，返回 items[]{timestamp, open, high, low, close}，表示溢价百分比",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`",
         "period": "K 线周期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`（默认）、`week`、`month`、`year`",
@@ -274,14 +274,14 @@
     },
     "ah_premium_intraday": {
       "title": "A/H 溢价（分时）",
-      "description": "获取 A/H 股溢价的当日分时数据",
+      "description": "获取 A/H 股溢价当日分时数据，返回 items[]{timestamp, premium_rate}，逐分钟展示溢价百分比",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "alert_add": {
       "title": "新增价格预警",
-      "description": "新增价格预警。`condition` 可选 `price_rise`（涨破）/ `price_fall`（跌破）/ `percent_rise`（涨幅）/ `percent_fall`（跌幅）",
+      "description": "新增价格预警，返回已创建的预警对象。condition：price_rise/price_fall（绝对价格）或 percent_rise/percent_fall（涨跌幅）；frequency：once/daily/every",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`",
         "condition": "预警条件：`price_rise`、`price_fall`、`percent_rise`、`percent_fall`",
@@ -291,39 +291,39 @@
     },
     "alert_delete": {
       "title": "删除价格预警",
-      "description": "按 `alert_id` 删除价格预警",
+      "description": "按 alert_id（来自 alert_list 的数字字符串）删除价格预警",
       "properties": {
         "alert_id": "预警指标 id"
       }
     },
     "alert_disable": {
       "title": "停用价格预警",
-      "description": "按 `alert_id` 停用价格预警",
+      "description": "按 alert_id 停用价格预警，返回 {alert_id, enabled: false}",
       "properties": {
         "alert_id": "预警指标 id"
       }
     },
     "alert_enable": {
       "title": "启用价格预警",
-      "description": "按 `alert_id` 启用价格预警",
+      "description": "按 alert_id 启用价格预警，返回 {alert_id, enabled: true}",
       "properties": {
         "alert_id": "预警指标 id"
       }
     },
     "alert_list": {
       "title": "价格预警列表",
-      "description": "获取所有已配置的价格预警"
+      "description": "获取所有已配置的价格预警，返回 lists[]{counter_id, indicators[]{id, condition, price, frequency, enabled, triggered_at}}"
     },
     "anomaly": {
       "title": "市场异动",
-      "description": "获取市场异动提醒（价量异常变动）",
+      "description": "获取市场异动提醒（价量异常变动），返回 items[]{symbol, name, anomaly_type, change_rate, volume, timestamp}",
       "properties": {
         "market": "市场代码：HK、US、CN、SG"
       }
     },
     "broker_holding": {
       "title": "券商持仓",
-      "description": "获取指定证券的主要券商持仓数据",
+      "description": "获取指定证券的主要券商持仓数据，返回 items[]{broker_name, holding_quantity, holding_change, holding_ratio}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`",
         "period": "时间窗口：`rct_1`（近 1 日，默认）、`rct_5`（近 5 日）、`rct_20`（近 20 日）、`rct_60`（近 60 日）"
@@ -331,7 +331,7 @@
     },
     "broker_holding_daily": {
       "title": "券商持仓（日度）",
-      "description": "获取指定券商对某证券的逐日持仓历史",
+      "description": "获取指定券商（broker_id）对某证券的逐日持仓历史，返回 items[]{date, holding_quantity, holding_change, holding_ratio}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`",
         "broker_id": "券商参与者编号"
@@ -339,21 +339,21 @@
     },
     "broker_holding_detail": {
       "title": "券商持仓明细",
-      "description": "获取完整的券商持仓明细列表",
+      "description": "获取完整的券商持仓明细列表，返回 items[]{broker_id, broker_name, holding_quantity, holding_ratio, holding_change, date}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "brokers": {
       "title": "经纪商队列",
-      "description": "获取经纪商买卖盘队列数据",
+      "description": "获取港股经纪商买卖盘队列（仅港股），返回 bid_brokers/ask_brokers[]{position, broker_ids}，通过 participants 工具将 broker_id 映射为名称",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "calc_indexes": {
       "title": "指标计算",
-      "description": "为证券计算财务 / 行情指标（PE、PB、股息率等）",
+      "description": "批量计算证券的行情/财务指标（PE、PB、股息率、最新价、换手率等），传入 symbols 和 indexes 列表，返回各标的的指标值",
       "properties": {
         "symbols": "证券代码，例如 `[\"700.HK\", \"AAPL.US\"]`",
         "indexes": "待计算指标：`LastDone`、`ChangeValue`、`ChangeRate`、`Volume`、`Turnover`、`YtdChangeRate`、`TurnoverRate`、`TotalMarketValue`、`CapitalFlow`、`Amplitude`、`VolumeRatio`、`PeTtmRatio`、`PbRatio`、`DividendRatioTtm`、`FiveDayChangeRate`、`TenDayChangeRate`、`HalfYearChangeRate`、`FiveMinutesChangeRate`、`ExpiryDate`、`StrikePrice`、`UpperStrikePrice`、`LowerStrikePrice`、`OutstandingQty`、`OutstandingRatio`、`Premium`、`ItmOtm`、`ImpliedVolatility`、`WarrantDelta`、`CallPrice`、`ToCallPrice`、`EffectiveLeverage`、`LeverageRatio`、`ConversionRatio`、`BalancePoint`、`OpenInterest`、`Delta`、`Gamma`、`Theta`、`Vega`、`Rho`"
@@ -361,7 +361,7 @@
     },
     "candlesticks": {
       "title": "K 线数据",
-      "description": "获取 K 线数据（OHLCV）。`period` 可选 `1m` / `5m` / `15m` / `30m` / `60m` / `day` / `week` / `month` / `year`；`trade_sessions` 可选 `intraday` / `all`",
+      "description": "获取 K 线数据（OHLCV）。period：1m/5m/15m/30m/60m/day/week/month/year；trade_sessions：intraday（默认，仅正常时段）或 all（含盘前盘后）",
       "properties": {
         "symbol": "证券代码",
         "period": "K 线周期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`",
@@ -372,95 +372,95 @@
     },
     "capital_distribution": {
       "title": "资金分布",
-      "description": "获取资金分布（大 / 中 / 小单的资金流向）",
+      "description": "获取资金分布（大/中/小单流入流出），返回 {timestamp, capital_in{large, medium, small}, capital_out{large, medium, small}}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "capital_flow": {
       "title": "资金流向",
-      "description": "获取资金流入 / 流出的时间序列",
+      "description": "获取资金净流入/流出当日时间序列，返回 items[]{timestamp, inflow, outflow, net_flow}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "company": {
       "title": "公司概况",
-      "description": "获取公司概况（名称、CEO、员工数、简介等）",
+      "description": "获取公司概况，返回 name、description、employees、CEO、founded_year、website、exchange、industry、market_cap 等信息",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "consensus": {
       "title": "一致预期",
-      "description": "获取分析师一致预期（营收、EPS、净利润等）",
+      "description": "获取分析师一致预期，返回 items[]{period, revenue_estimate, eps_estimate, net_income_estimate, analyst_count, last_updated}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "constituent": {
       "title": "指数成份股",
-      "description": "获取指数成分股（例如 `HSI.HK`）",
+      "description": "获取指数成份股（如 HSI.HK），返回 constituents[]{symbol, name, last_done（最新价）, change_rate, market_cap, weight}",
       "properties": {
         "symbol": "指数代码，例如 `\"HSI.HK\"`"
       }
     },
     "corp_action": {
       "title": "公司行动",
-      "description": "获取公司行动信息（拆股、回购、更名等）",
+      "description": "获取公司行动信息（拆股、回购、更名等），返回 items[]{action_type, effective_date, ratio, description}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "dca_check": {
       "title": "检查定投支持",
-      "description": "检查指定证券是否支持定投（DCA）",
+      "description": "检查证券是否支持定投（DCA），返回 items[]{symbol, support_dca, reason}",
       "properties": {
         "symbols": "待检查的证券代码，例如 `[\"AAPL.US\", \"TSLA.US\"]`"
       }
     },
     "depth": {
       "title": "盘口深度",
-      "description": "获取盘口深度数据（买卖各档位）",
+      "description": "获取买卖盘深度（最多 10 档），返回 {bids[]{position, price, volume, order_num}, asks[]{position, price, volume, order_num}}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "dividend": {
       "title": "派息历史",
-      "description": "获取证券的派息历史",
+      "description": "获取证券的派息历史，返回 items[]{ex_date（除权日）, pay_date（派发日）, record_date, dividend_type, amount, currency, status}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "dividend_detail": {
       "title": "派息明细",
-      "description": "获取详细的派息分红方案",
+      "description": "获取详细派息分红方案，返回 details[]{period, cash_dividend, stock_dividend, record_date, ex_date, pay_date, currency}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "exchange_rate": {
       "title": "汇率",
-      "description": "获取全部支持币种的汇率"
+      "description": "获取全部支持币种的汇率，返回 list[]{from_currency, to_currency, rate, timestamp}，覆盖 USD/HKD/CNY/SGD 等"
     },
     "executive": {
       "title": "高管与董事",
-      "description": "获取公司高管及董事会成员信息",
+      "description": "获取公司高管及董事会成员信息，返回 members[]{name, title, appointed_date, age, biography, compensation}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "filings": {
       "title": "监管公告",
-      "description": "获取监管文件公告（8-K、10-Q、10-K 等）",
+      "description": "获取监管文件公告（8-K、10-Q、10-K 等），返回 items[]{id, title, type, language, filing_date, url}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "finance_calendar": {
       "title": "财经日历",
-      "description": "获取财经日历事件。`category` 可选 `financial` / `report` / `dividend` / `ipo` / `macrodata` / `closed`",
+      "description": "获取财经日历事件。category：report（财报+业绩）/ dividend（除息日与派发日）/ split（拆股/反拆）/ ipo / macrodata（CPI、非农、议息等）/ closed（休市日）；market：HK/US/CN/SG/JP/UK/DE/AU",
       "properties": {
         "market": "市场代码：HK、US、CN、SG，省略则查询所有市场",
         "start": "起始日期（`yyyy-mm-dd`）",
@@ -470,7 +470,7 @@
     },
     "financial_report": {
       "title": "财务报表",
-      "description": "获取证券的财务报告。`report_type` 用于区分年报或季报等",
+      "description": "获取财务报告（利润表/资产负债表/现金流量表）。kind：IS/BS/CF/ALL；report_type：af（年报）/saf（半年报）/q1/q2/q3/qf（季报全量）",
       "properties": {
         "symbol": "证券代码，例如 `\"AAPL.US\"`",
         "kind": "报表种类：`IS`（利润表）、`BS`（资产负债表）、`CF`（现金流量表）、`ALL`（默认全部）",
@@ -479,21 +479,21 @@
     },
     "forecast_eps": {
       "title": "EPS 预测",
-      "description": "获取 EPS 预测及分析师预期历史",
+      "description": "获取 EPS 预测及分析师预期历史，返回 items[]{forecast_start_date, forecast_end_date, eps_estimate, eps_actual, surprise_pct, analyst_count}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "fund_holder": {
       "title": "持仓基金",
-      "description": "获取持有指定证券的基金及 ETF",
+      "description": "获取持有指定证券的基金及 ETF，返回 fund_holders[]{fund_name, fund_symbol, shares, ratio, change, reported_at}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "history_candlesticks_by_date": {
       "title": "历史 K 线（按日期）",
-      "description": "按日期区间获取历史 K 线数据。`period` 可选 `1m` / `5m` / `15m` / `30m` / `60m` / `day` / `week` / `month` / `year`",
+      "description": "按日期区间获取历史 K 线（OHLCV）数据。period：1m/5m/15m/30m/60m/day/week/month/year",
       "properties": {
         "symbol": "证券代码",
         "period": "K 线周期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`",
@@ -505,7 +505,7 @@
     },
     "history_candlesticks_by_offset": {
       "title": "历史 K 线（按偏移）",
-      "description": "以参考时间为锚点，按偏移量获取历史 K 线数据。`period` 可选 `1m` / `5m` / `15m` / `30m` / `60m` / `day` / `week` / `month` / `year`",
+      "description": "以参考时间为锚点按偏移量获取历史 K 线（OHLCV）数据。period：1m/5m/15m/30m/60m/day/week/month/year",
       "properties": {
         "symbol": "证券代码",
         "period": "K 线周期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`",
@@ -518,7 +518,7 @@
     },
     "history_market_temperature": {
       "title": "历史市场温度",
-      "description": "获取市场情绪温度的历史时间序列",
+      "description": "获取市场情绪温度历史时间序列，返回 {type, list[]{temperature, description, valuation, sentiment, timestamp}}",
       "properties": {
         "market": "市场代码：HK、US、CN、SG",
         "start": "起始日期（`yyyy-mm-dd`）",
@@ -527,35 +527,35 @@
     },
     "industry_valuation": {
       "title": "行业估值",
-      "description": "获取同行业可比公司的估值对比",
+      "description": "获取同行业可比公司估值对比，返回 list[]{symbol, name, pe, pb, ps, dividend_yield, history[]{date, pe, pb}}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "industry_valuation_dist": {
       "title": "行业估值分布",
-      "description": "获取行业 PE / PB / PS 估值分布",
+      "description": "获取行业 PE/PB/PS 估值分布，返回 distributions{pe/pb/ps}{min, p25, median, p75, max, current_percentile}，显示个股在行业中的分位",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "institution_rating": {
       "title": "机构评级",
-      "description": "获取机构评级汇总，含一致评级与目标价",
+      "description": "获取机构评级汇总，返回 analyst{buy, outperform, hold, underperform, sell 家数, target_price, consensus_rating} 及评级列表",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "institution_rating_detail": {
       "title": "机构评级明细",
-      "description": "获取详细的机构评级与目标价历史",
+      "description": "获取机构评级与目标价历史明细，返回 target.list[]{analyst, firm, rating, target_price, timestamp}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "intraday": {
       "title": "分时数据",
-      "description": "获取分时（逐分钟）价格 / 成交数据。`trade_sessions` 可选 `intraday`（默认，仅常规时段）或 `all`（含盘前盘后）",
+      "description": "获取分时（逐分钟）价格/成交量数据。trade_sessions：intraday（默认，仅正常时段）或 all（含盘前盘后）",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`",
         "trade_sessions": "包含的交易时段：`intraday`（默认，仅常规时段）或 `all`（含盘前盘后）"
@@ -563,50 +563,50 @@
     },
     "invest_relation": {
       "title": "投资者关系",
-      "description": "获取投资者关系事件与公告",
+      "description": "获取投资者关系事件与公告，返回 items[]{title, event_type, event_date, url, description}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "market_status": {
       "title": "市场状态",
-      "description": "获取所有市场当前的交易状态"
+      "description": "获取所有市场当前交易状态，返回 market_time[]{market, trade_status（Pre-Open/Trading/Lunch Break/Post-Trading/Closed 等）, timestamp}"
     },
     "market_temperature": {
       "title": "市场温度",
-      "description": "获取当前市场情绪温度（0-100）",
+      "description": "获取当前市场情绪温度，返回 {temperature（0-100）, description, valuation（0-100）, sentiment（0-100）, timestamp}",
       "properties": {
         "market": "市场代码：HK、US、CN、SG"
       }
     },
     "news": {
       "title": "资讯",
-      "description": "获取证券相关的最新新闻",
+      "description": "获取证券相关最新新闻，返回 items[]{id, title, source, publish_time, summary, url, related_symbols[]}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "now": {
       "title": "当前时间",
-      "description": "获取当前 UTC 时间"
+      "description": "获取当前 UTC 时间（RFC3339 格式），用于在发起日期相关查询前确认当前日期"
     },
     "operating": {
       "title": "经营业绩",
-      "description": "获取公司经营指标",
+      "description": "获取公司经营指标（仅港股），返回 items[]{period, metric_name, value, unit}，如客运量、货运量、门店数等",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "option_chain_expiry_date_list": {
       "title": "期权到期日列表",
-      "description": "获取期权链可选的到期日列表",
+      "description": "获取期权链可选到期日列表，返回 expiry_dates[]（yyyy-mm-dd）。配合 option_chain_info_by_date 查询行权价和 Greeks",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "option_chain_info_by_date": {
       "title": "期权链",
-      "description": "获取指定到期日的期权链行权价及希腊字母",
+      "description": "获取指定到期日的期权链，返回 strikePrices[]{strike_price, call{symbol, last_done, iv, delta, gamma}, put{symbol, last_done, iv, delta, gamma}}",
       "properties": {
         "symbol": "证券代码",
         "date": "到期日（`yyyy-mm-dd`）"
@@ -614,21 +614,21 @@
     },
     "option_quote": {
       "title": "期权报价",
-      "description": "获取期权行情（最多 500 个标的）",
+      "description": "获取期权行情（最多 500 个），返回各标的：last_done（最新价）, prev_close, open, high, low, volume（成交量）, turnover（成交额）, implied_volatility（隐含波动率）, delta/gamma/theta/vega/rho（Greeks）, open_interest（未平仓量）",
       "properties": {
         "symbols": "证券代码，例如 `[\"700.HK\", \"AAPL.US\"]`"
       }
     },
     "option_volume": {
       "title": "期权成交量",
-      "description": "获取美股的实时期权认购 / 认沽成交量及 PCR",
+      "description": "获取美股实时期权认购/认沽成交量统计，返回 {call_volume, put_volume, put_call_ratio, call_oi, put_oi} 及活跃合约列表",
       "properties": {
         "symbol": "标的代码（仅美股），例如 `\"AAPL.US\"`"
       }
     },
     "option_volume_daily": {
       "title": "期权成交量（日度）",
-      "description": "获取美股的逐日期权认购 / 认沽成交量、未平仓量及 PCR 历史",
+      "description": "获取美股逐日期权成交量历史，返回 items[]{date, call_volume, put_volume, put_call_vol_ratio, call_oi, put_oi, put_call_oi_ratio}",
       "properties": {
         "symbol": "标的代码（仅美股），例如 `\"AAPL.US\"`",
         "count": "返回的交易日数量（默认 20）"
@@ -636,25 +636,25 @@
     },
     "participants": {
       "title": "市场参与者",
-      "description": "获取市场参与者（券商）信息"
+      "description": "获取港股市场参与者（券商）信息，返回 participants[]{broker_ids[], name_en, name_cn, name_hk}，用于解析经纪商队列数据"
     },
     "quote": {
       "title": "行情快照",
-      "description": "获取最新行情快照（最新价、开盘、最高、最低、成交量、成交额）",
+      "description": "获取最新行情快照，返回各标的：last_done（最新价）, prev_close（昨收）, open（开盘价）, high/low（最高/最低价）, volume（成交量）, turnover（成交额）, change_rate, change_value, trade_status, timestamp",
       "properties": {
         "symbols": "证券代码，例如 `[\"700.HK\", \"AAPL.US\"]`"
       }
     },
     "shareholder": {
       "title": "机构股东",
-      "description": "获取证券的机构股东信息",
+      "description": "获取证券的机构股东信息，返回 shareholders[]{institution, shares, ratio, change, change_type, reported_at}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "sharelist_add": {
       "title": "加入分享股单",
-      "description": "向社区分享股单中添加证券",
+      "description": "向社区分享股单中添加证券。symbols 为股票代码列表（如 [\"AAPL.US\"]），id 为股单 ID。成功返回更新后的股单。",
       "properties": {
         "id": "分享股单 ID",
         "symbols": "证券代码，例如 `[\"AAPL.US\", \"700.HK\"]`"
@@ -662,7 +662,7 @@
     },
     "sharelist_create": {
       "title": "创建分享股单",
-      "description": "新建一个社区分享股单",
+      "description": "新建社区分享股单，返回创建的股单对象（含 id、name、description）",
       "properties": {
         "name": "股单名称（若未传 `description`，名称同时作为描述）",
         "description": "股单描述，省略时默认与 `name` 相同"
@@ -670,35 +670,35 @@
     },
     "sharelist_delete": {
       "title": "删除分享股单",
-      "description": "按 id 删除社区分享股单",
+      "description": "按 id 删除自建社区分享股单（已订阅他人的股单不可删除）",
       "properties": {
         "id": "分享股单 ID"
       }
     },
     "sharelist_detail": {
       "title": "分享股单详情",
-      "description": "按 id 获取社区分享股单详情，含成分股及行情",
+      "description": "按 id 获取社区分享股单详情，返回 {id, name, description, constituents[]{symbol, name, last_done, change_rate}, 订阅状态}",
       "properties": {
         "id": "分享股单 ID"
       }
     },
     "sharelist_list": {
       "title": "分享股单列表",
-      "description": "列出用户自建以及已订阅的社区分享股单",
+      "description": "列出用户自建及已订阅的社区分享股单，返回 lists[]{id, name, description, symbol_count, is_owner, follower_count}",
       "properties": {
         "count": "返回数量（默认 20）"
       }
     },
     "sharelist_popular": {
       "title": "热门分享股单",
-      "description": "获取热门 / 正在流行的社区分享股单",
+      "description": "获取热门/流行社区分享股单，返回 lists[]{id, name, description, symbol_count, follower_count, creator}，按热度排序",
       "properties": {
         "count": "返回数量（默认 20）"
       }
     },
     "sharelist_remove": {
       "title": "移出分享股单",
-      "description": "从社区分享股单中移除证券",
+      "description": "从社区分享股单中移除指定证券。symbols 为要移除的股票代码列表，id 为股单 ID。成功返回更新后的股单。",
       "properties": {
         "id": "分享股单 ID",
         "symbols": "证券代码，例如 `[\"AAPL.US\", \"700.HK\"]`"
@@ -706,7 +706,7 @@
     },
     "sharelist_sort": {
       "title": "分享股单排序",
-      "description": "调整社区分享股单中证券的顺序（按目标顺序传入 `symbols`）",
+      "description": "调整社区分享股单中证券的排列顺序（按目标顺序传入 symbols）",
       "properties": {
         "id": "分享股单 ID",
         "symbols": "证券代码，例如 `[\"AAPL.US\", \"700.HK\"]`"
@@ -714,7 +714,7 @@
     },
     "short_positions": {
       "title": "空头持仓",
-      "description": "获取美股的做空数据（空头比率、空头股数、回补天数等），仅支持美股市场",
+      "description": "获取美股做空数据（空头比率、空头股数、回补天数等），仅支持美股市场",
       "properties": {
         "symbol": "证券代码（仅美股），例如 `\"AAPL.US\"`",
         "count": "返回条数（1-100，默认 20）"
@@ -722,21 +722,21 @@
     },
     "static_info": {
       "title": "证券基础信息",
-      "description": "获取证券的基础信息（名称、交易所、类型、每手股数等）",
+      "description": "获取证券基础信息，返回各标的：symbol, name_cn, name_en, exchange（如 NASDAQ）, type（如 US_Stock）, lot_size（每手股数）, listed_date, delisted",
       "properties": {
         "symbols": "证券代码，例如 `[\"700.HK\", \"AAPL.US\"]`"
       }
     },
     "topic": {
       "title": "讨论列表",
-      "description": "获取与某证券相关的讨论",
+      "description": "获取证券相关的社区讨论，返回 items[]{id, title, author, created_at, like_count, comment_count, content_summary}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "topic_create": {
       "title": "发布讨论",
-      "description": "发布讨论。`topic_type=\"post\"`（默认）为纯文本；`\"article\"` 需要非空 `title`，正文可使用 Markdown",
+      "description": "发布社区讨论。topic_type=\"post\"（默认）为纯文本；\"article\" 需非空 title，正文支持 Markdown",
       "properties": {
         "title": "讨论标题。`topic_type=\"article\"` 时必填，`\"post\"` 时可选",
         "body": "讨论正文。`post` 仅支持纯文本，`article` 支持 Markdown",
@@ -746,7 +746,7 @@
     },
     "topic_create_reply": {
       "title": "发布讨论回复",
-      "description": "对讨论发表回复。传入 `reply_to_id` 表示对某条回复的子级回复，省略则为顶层回复",
+      "description": "对讨论发表回复。传入 reply_to_id 表示楼中楼回复，省略则为顶层回复",
       "properties": {
         "topic_id": "待回复的讨论 ID",
         "body": "回复正文（仅支持纯文本）",
@@ -755,14 +755,14 @@
     },
     "topic_detail": {
       "title": "讨论详情",
-      "description": "按 `topic_id` 获取讨论详情",
+      "description": "按 topic_id 获取讨论详情，返回 {id, title, content, author, created_at, like_count, comment_count, symbols[]}",
       "properties": {
         "topic_id": "讨论 ID"
       }
     },
     "topic_replies": {
       "title": "讨论回复",
-      "description": "分页获取讨论的回复（`page` 默认 1，`size` 默认 20，范围 1-50）",
+      "description": "分页获取讨论的回复（page 默认 1，size 默认 20，范围 1-50）",
       "properties": {
         "topic_id": "讨论 ID",
         "page": "页码（从 1 开始，默认 1）",
@@ -771,14 +771,14 @@
     },
     "trade_stats": {
       "title": "成交统计",
-      "description": "获取成交统计（主动买 / 主动卖 / 中性盘的成交量分布）",
+      "description": "获取成交统计（主动买/主动卖/中性盘成交量分布），返回 items[]{price_range, buy_volume, sell_volume, neutral_volume}",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "trades": {
       "title": "最近成交",
-      "description": "获取最近的逐笔成交（最多 1000 条）",
+      "description": "获取最近逐笔成交（最多 1000 条），返回 trades[]{price, volume, timestamp, trade_type, direction}",
       "properties": {
         "symbol": "证券代码",
         "count": "返回的最大条数（最多 1000）"
@@ -786,7 +786,7 @@
     },
     "trading_days": {
       "title": "交易日列表",
-      "description": "获取指定市场在某日期区间内的交易日",
+      "description": "获取指定市场在日期区间内的交易日，返回 trading_days[] 和 half_trading_days[]（格式 yyyy-mm-dd）",
       "properties": {
         "market": "市场代码：HK、US、CN、SG",
         "start": "起始日期（`yyyy-mm-dd`）",
@@ -795,29 +795,29 @@
     },
     "trading_session": {
       "title": "交易时段",
-      "description": "获取所有市场的交易时段安排"
+      "description": "获取所有市场的交易时段安排，返回 market_sessions[]{market, trade_sessions[]{beg_time, end_time, trade_session_type}}"
     },
     "valuation": {
       "title": "估值",
-      "description": "获取估值概览及同业对比",
+      "description": "获取估值概览及同业对比，返回 metrics.pe/pb/ps/dividend_yield{current, industry_avg, 5yr_avg, percentile} 及同业对比列表",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "valuation_history": {
       "title": "估值历史",
-      "description": "获取详细的估值历史时间序列",
+      "description": "获取详细估值历史时间序列，返回 history.metrics{pe/pb/ps/dividend_yield}[]{timestamp, value}，用于长期分位分析",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "warrant_issuers": {
       "title": "权证发行商",
-      "description": "获取窝轮 / 牛熊证发行商信息"
+      "description": "获取港股窝轮/牛熊证发行商信息，返回 issuers[]{id, name_en, name_cn}，id 可用于 warrant_list 的发行商筛选"
     },
     "warrant_list": {
       "title": "权证列表",
-      "description": "按筛选条件获取指定标的的窝轮 / 牛熊证列表",
+      "description": "按条件筛选标的的窝轮/牛熊证列表，返回 warrants[]{symbol, name, last_done, change_rate, implied_volatility, expiry_date, strike_price, leverage_ratio, outstanding_ratio}",
       "properties": {
         "symbol": "标的代码，例如 `\"700.HK\"`",
         "sort_by": "排序字段：`LastDone`、`ChangeRate`、`ChangeValue`、`Volume`、`Turnover`、`ExpiryDate`、`StrikePrice`、`UpperStrikePrice`、`LowerStrikePrice`、`OutstandingQuantity`、`OutstandingRatio`、`Premium`、`ItmOtm`、`ImpliedVolatility`、`Delta`",
@@ -831,14 +831,14 @@
     },
     "warrant_quote": {
       "title": "权证报价",
-      "description": "获取窝轮 / 牛熊证行情",
+      "description": "获取窝轮/牛熊证行情，返回各标的：last_done（最新价）, prev_close, open, high, low, volume（成交量）, turnover（成交额）, implied_volatility（隐含波动率）, delta, leverage_ratio, effective_leverage",
       "properties": {
         "symbols": "证券代码，例如 `[\"700.HK\", \"AAPL.US\"]`"
       }
     },
     "quant_run": {
       "title": "量化指标脚本运行",
-      "description": "在服务端针对历史 K 线数据运行量化指标脚本，执行后将计算得到的指标/绘图值以 JSON 形式返回。周期：1m、5m、15m、30m、1h、day、week、month、year（默认 day）。可选 input 参数接收一个 JSON 数组，顺序需与脚本中 input.*() 调用一致，例如 \"[14,2.0]\"。",
+      "description": "在服务端对历史 K 线数据运行量化指标脚本，以 JSON 形式返回计算的指标/绘图值。周期：1m/5m/15m/30m/1h/day/week/month/year（默认 day）；input 为 JSON 数组，顺序需与脚本中 input.*() 调用一致",
       "properties": {
         "symbol": "证券代码，`<CODE>.<MARKET>` 格式，例如 `TSLA.US`、`700.HK`",
         "period": "K 线周期：`1m`、`5m`、`15m`、`30m`、`1h`、`day`、`week`、`month`、`year`（默认 `day`）",
@@ -850,7 +850,7 @@
     },
     "news_search": {
       "title": "新闻搜索",
-      "description": "按关键词搜索新闻文章，返回 id、标题、时间、来源及链接。",
+      "description": "按关键词搜索新闻文章，返回 news_list[]{id, title, description, source_name, publish_at（RFC3339 时间格式）, score}",
       "properties": {
         "keyword": "搜索关键词",
         "limit": "最多返回条数（默认 20）"
@@ -858,7 +858,7 @@
     },
     "topic_search": {
       "title": "社区话题搜索",
-      "description": "按关键词搜索社区帖子/话题，返回 id、作者、时间及摘要。",
+      "description": "按关键词搜索社区帖子/话题，返回 id、作者、时间及摘要",
       "properties": {
         "keyword": "搜索关键词",
         "limit": "最多返回条数（默认 20）"
@@ -866,7 +866,7 @@
     },
     "financial_statement": {
       "title": "财务报表",
-      "description": "获取证券的财务报表（利润表、资产负债表或现金流量表）。kind：IS（利润表）、BS（资产负债表）、CF（现金流量表）、ALL（全部，默认）。report：af（年报）、saf（半年报）、qf（季报）、q1/q2/q3。",
+      "description": "获取证券财务报表（利润表/资产负债表/现金流量表）。kind：IS/BS/CF/ALL（默认）；report：af（年报）/saf（半年报）/qf（季报）/q1/q2/q3",
       "properties": {
         "symbol": "证券代码，例如 `\"AAPL.US\"`",
         "kind": "报表类型：`IS`（利润表）、`BS`（资产负债表）、`CF`（现金流量表）、`ALL`（全部，默认）",
@@ -875,14 +875,14 @@
     },
     "financial_report_latest": {
       "title": "最新财务报告",
-      "description": "获取证券最新财务报告的摘要信息，包含主要财务指标。",
+      "description": "获取证券最新财务报告摘要，返回 {period, revenue, net_income, eps, roe, gross_margin, report_date} 等主要财务指标",
       "properties": {
         "symbol": "证券代码，例如 `\"AAPL.US\"`"
       }
     },
     "valuation_rank": {
       "title": "估值分位",
-      "description": "获取证券在指定日期区间内的每日估值分位（PE/PB/PS/股息率行业百分位）。start/end 格式：yyyymmdd。",
+      "description": "获取证券在指定日期区间内每日估值分位（PE/PB/PS/股息率行业百分位）。start/end 格式：yyyymmdd",
       "properties": {
         "symbol": "证券代码，例如 `\"AAPL.US\"`",
         "start": "起始日期，yyyymmdd 格式（默认近 30 天）",
@@ -891,14 +891,14 @@
     },
     "institution_rating_history": {
       "title": "机构评级历史",
-      "description": "获取证券的机构评级历史，包含目标价变动和评级变动记录。",
+      "description": "获取机构评级历史，返回 target_history[]{firm, analyst, old_target, new_target, date} 及 evaluate_history[]{firm, old_rating, new_rating, date}",
       "properties": {
         "symbol": "证券代码，例如 `\"AAPL.US\"`"
       }
     },
     "institution_rating_industry_rank": {
       "title": "机构评级行业排名",
-      "description": "获取同行业内各证券按机构分析师评级的排名对比。",
+      "description": "获取同行业各证券的机构评级排名对比，返回 list[]{symbol, name, buy_count, sell_count, consensus_rating, target_price}，支持分页",
       "properties": {
         "symbol": "证券代码，例如 `\"AAPL.US\"`",
         "page": "页码（默认 1）",
@@ -907,15 +907,15 @@
     },
     "short_margin": {
       "title": "卖空保证金",
-      "description": "获取当前账户的卖空保证金存款明细。"
+      "description": "获取当前账户卖空保证金存款明细，返回各空头持仓的 margin_amount、margin_rate、interest_rate、symbol、quantity"
     },
     "bank_cards": {
       "title": "绑定银行卡",
-      "description": "列出当前账户绑定的提款银行卡。"
+      "description": "列出当前账户绑定的提款银行卡，返回 cards[]{id, bank_name, account_number（脱敏）, currency, status}"
     },
     "withdrawals": {
       "title": "提款记录",
-      "description": "获取当前账户的提款历史记录。",
+      "description": "获取当前账户提款历史，返回 items[]{id, amount, currency, status, created_at, bank_name, account_number（脱敏）}",
       "properties": {
         "page": "页码（默认 1）",
         "size": "每页条数（默认 20）"
@@ -923,7 +923,7 @@
     },
     "deposits": {
       "title": "入款记录",
-      "description": "获取当前账户的入款历史记录。states：逗号分隔的入款状态过滤。currencies：逗号分隔的货币代码，例如 `\"USD,HKD\"`。",
+      "description": "获取当前账户入款历史，返回 items[]{id, amount, currency, status, created_at, updated_at}。states：逗号分隔的状态（Pending/Finished/Failed）；currencies：逗号分隔的货币代码",
       "properties": {
         "page": "页码（默认 1）",
         "size": "每页条数（默认 20）",
@@ -933,15 +933,15 @@
     },
     "ipo_subscriptions": {
       "title": "IPO 认购列表",
-      "description": "列出当前港股和美股市场处于认购或预申请阶段的 IPO 股票（合并返回 HK 和 US 两市结果）。"
+      "description": "列出港股和美股当前处于认购/预申请阶段的 IPO，返回 items[]{symbol, name, market, sub_start_date, sub_end_date, listing_date, issue_price, min_lot_size}"
     },
     "ipo_calendar": {
       "title": "IPO 日历",
-      "description": "显示 IPO 日历，包含所有即将上市及近期已上市的 IPO，含认购日期和上市日期。"
+      "description": "显示 IPO 日历，返回 items[]{symbol, name, market, sub_start_date, sub_end_date, listing_date, status}，含即将上市及近期已上市的 IPO"
     },
     "ipo_listed": {
       "title": "IPO 已上市列表",
-      "description": "列出港股和美股近期已上市的 IPO，包含发行价、首日涨跌幅及成交量信息。",
+      "description": "列出港股和美股近期已上市的 IPO，返回 items[]{symbol, name, listing_date, issue_price, first_day_close, first_day_return, volume, market}",
       "properties": {
         "page": "页码（默认 1）",
         "size": "每页条数（默认 20）"
@@ -949,7 +949,7 @@
     },
     "ipo_detail": {
       "title": "IPO 详情",
-      "description": "查看某只股票的 IPO 详情，包含招股简介（profile）、时间线（timeline）及认购资格（eligibility）。",
+      "description": "查看 IPO 详情，返回 profile（业务简介）、timeline[]{event, date}、认购资格（eligibility）、pricing_range、lot_size、配股规则",
       "properties": {
         "symbol": "证券代码，例如 `\"6871.HK\"` 或 `\"ARM.US\"`",
         "market": "市场：`HK` 或 `US`（默认根据代码后缀推断）"
@@ -957,7 +957,7 @@
     },
     "ipo_orders": {
       "title": "IPO 订单列表",
-      "description": "列出当前账户的 IPO 订单（有效订单和历史订单），可按证券代码、市场或状态过滤。",
+      "description": "列出当前账户的 IPO 订单（有效和历史），返回 orders[]{order_id, symbol, market, quantity, total_amount, status, submitted_at}，可按 symbol/market/status 过滤",
       "properties": {
         "symbol": "按证券代码过滤，例如 `\"6871.HK\"`",
         "market": "按市场过滤：`HK` 或 `US`",
@@ -968,14 +968,14 @@
     },
     "ipo_order_detail": {
       "title": "IPO 订单详情",
-      "description": "按订单 ID 查看 IPO 订单的详细信息。",
+      "description": "按 order_id 查看 IPO 订单详细信息，返回 {order_id, symbol, market, quantity, allotted_quantity, total_amount, status, submitted_at}",
       "properties": {
         "order_id": "IPO 订单 ID"
       }
     },
     "ipo_profit_loss": {
       "title": "IPO 盈亏",
-      "description": "查看当前账户的 IPO 打新盈亏汇总及逐笔明细。period：all（全部，默认）、ytd（今年）、1y（近一年）、3y（近三年）。",
+      "description": "查看账户 IPO 打新盈亏汇总及逐笔明细，返回 {total_cost, total_value, total_return, items[]{symbol, cost, current_value, return_rate}}。period：all/ytd/1y/3y",
       "properties": {
         "period": "时间范围：`all`（全部，默认）、`ytd`（今年）、`1y`（近一年）、`3y`（近三年）",
         "page": "页码（默认 1）",
@@ -984,27 +984,49 @@
     },
     "business_segments": {
       "title": "主营业务分部",
-      "description": "获取当期主营业务分部营收占比快照（各分部名称、占比、总营收、货币单位）。"
+      "description": "获取当期主营业务分部营收占比快照，返回各分部名称、占比、总营收及货币单位",
+      "properties": {
+        "symbol": "证券代码，例如 `\"AAPL.US\"`"
+      }
     },
     "business_segments_history": {
       "title": "主营业务分部历史",
-      "description": "获取主营业务分部营收历史趋势，含地区维度。report：qf（季报）、saf（中报）、af（年报）。"
+      "description": "获取主营业务分部营收历史趋势，返回 historical[]{date, total, currency, business[{name, percent, value}], regionals[{name, percent, value}]}",
+      "properties": {
+        "symbol": "证券代码，例如 `\"AAPL.US\"`",
+        "report": "报告期：`qf`（季报）、`saf`（中报）、`af`（年报）"
+      }
     },
     "institutional_views": {
       "title": "机构观点月度时序",
-      "description": "获取机构评级月度分布时序（每月买入/跑赢/持有/跑输/卖出家数）。"
+      "description": "获取机构评级月度分布时序，返回 months[]{date, buy, outperform, hold, underperform, sell, total}，用于评级趋势分析",
+      "properties": {
+        "symbol": "证券代码，例如 `\"AAPL.US\"`"
+      }
     },
     "industry_rank": {
       "title": "行业排行榜",
-      "description": "按市场（US/HK/CN/SG）和指标排列行业。indicator：0=领涨 1=今日走势 2=人气 3=市值 4=营收 5=营收增长率 6=净利润 7=净利润增长率。sort_type：0=单级 1=多层。返回 items[]{counter_id(BK/US/IN00258), name, chg, lists[]}，counter_id 可直接传入 industry_peers。"
+      "description": "按市场（US/HK/CN/SG）和指标排列行业。indicator：0=领涨 1=今日走势 2=人气 3=市值 4=营收 5=营收增长率 6=净利润 7=净利润增长率。sort_type：0=单级 1=多层。返回 items[]{counter_id（如 BK/US/IN00258）, name, chg, lists[]}，counter_id 可直接传入 industry_peers",
+      "properties": {
+        "market": "市场代码：US、HK、CN、SG",
+        "indicator": "排列指标：0=领涨、1=今日走势、2=人气、3=市值、4=营收、5=营收增长率、6=净利润、7=净利润增长率",
+        "sort_type": "排序类型：0=单级、1=多层"
+      }
     },
     "industry_peers": {
       "title": "行业同业分组树",
-      "description": "行业分组的层级同业树。接受来自 industry_rank 的 BK counter_id（如 BK/US/IN00258）。返回 chain{name,counter_id,stock_num,chg,ytd_chg,next[{...}]} 和 top{name,market}，每个节点包含成分股数量、日涨跌幅和年初至今涨跌幅。"
+      "description": "获取行业分组的层级同业树，接受来自 industry_rank 的 BK counter_id（如 BK/US/IN00258），返回 chain{name, counter_id, stock_num, chg, ytd_chg, next[...]} 和 top{name, market}",
+      "properties": {
+        "symbol": "来自 industry_rank 的 BK counter_id，例如 `\"BK/US/IN00258\"`"
+      }
     },
     "financial_report_snapshot": {
       "title": "财报快照",
-      "description": "获取财报快照：report_desc（文字摘要）、fo_revenue/fo_ebit/fo_eps（实际 vs 预期，含同比/超预期描述）、fr_* 财务比率（ROE、利润率、资产负债、现金流）。report：qf/saf/af。"
+      "description": "获取财报快照：report_desc（文字摘要）、fo_revenue/fo_ebit/fo_eps（实际 vs 预期，含同比/超预期描述）、fr_* 财务比率（ROE、利润率、资产负债、现金流）。report：qf/saf/af",
+      "properties": {
+        "symbol": "证券代码，例如 `\"AAPL.US\"`",
+        "report": "报告期：`qf`（季报）、`saf`（半年报）、`af`（年报）"
+      }
     }
   }
 }

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -4,7 +4,7 @@
   "tools": {
     "create_watchlist_group": {
       "title": "新建自選分組",
-      "description": "新建一個自選分組，可選地附帶初始股票列表",
+      "description": "新建自選分組，返回 {id, name}。可選傳入 securities（如 [\"AAPL.US\"]）預填入證券",
       "properties": {
         "name": "分組名稱",
         "securities": "要加入的證券代碼，例如 `[\"700.HK\", \"AAPL.US\"]`"
@@ -12,7 +12,7 @@
     },
     "delete_watchlist_group": {
       "title": "刪除自選分組",
-      "description": "按分組 id 刪除自選分組",
+      "description": "按分組 id 刪除自選分組。purge=true 時同時從其他分組中移除該分組包含的證券",
       "properties": {
         "id": "自選分組 id",
         "purge": "是否同時從其他分組中清除這些證券"
@@ -20,55 +20,55 @@
     },
     "security_list": {
       "title": "證券列表",
-      "description": "獲取指定市場的證券列表。`category` 當前必須為 `\"Overnight\"`，其他取值或留空都會報錯；並且目前僅支持 `market=\"US\"`，其他市場同樣會返回錯誤",
+      "description": "獲取指定市場的證券列表。`category` 當前必須為 `\"Overnight\"`，其他取值或留空都會報錯；並且目前僅支援 `market=\"US\"`，其他市場同樣會返回錯誤",
       "properties": {
         "market": "市場代碼：HK、US、CN、SG",
-        "category": "類別篩選。當前僅支持 `\"Overnight\"`，傳入其他值或不傳都會觸發 `param_error`；並且 `\"Overnight\"` 類別目前僅支持 `US` 市場，其他市場同樣會返回 `param_error`"
+        "category": "類別篩選。當前僅支援 `\"Overnight\"`，傳入其他值或不傳都會觸發 `param_error`；並且 `\"Overnight\"` 類別目前僅支援 `US` 市場，其他市場同樣會返回 `param_error`"
       }
     },
     "update_watchlist_group": {
       "title": "更新自選分組",
-      "description": "更新自選分組（重命名，或對其中的證券進行新增 / 移除 / 替換）",
+      "description": "更新自選分組：重命名（name）或修改成員證券（securities + mode: add/remove/replace）",
       "properties": {
         "id": "自選分組 id",
         "name": "新的分組名稱（可選）",
         "securities": "證券代碼列表（可選）",
-        "mode": "證券更新模式：`add`（新增）、`remove`（移除）或 `replace`（替換，默認）"
+        "mode": "證券更新模式：`add`（新增）、`remove`（移除）或 `replace`（替換，預設）"
       }
     },
     "watchlist": {
       "title": "自選列表",
-      "description": "獲取所有自選分組及其包含的證券"
+      "description": "獲取所有自選分組及其包含的證券，返回 groups[]{id, name, securities[]{symbol, name, watched_price, watched_at}}"
     },
     "account_balance": {
-      "title": "賬戶餘額",
-      "description": "查詢賬戶現金餘額與資產概覽。可傳入 `currency`（如 `\"USD\"`、`\"HKD\"`）按幣種篩選，省略則返回全部幣種",
+      "title": "帳戶餘額",
+      "description": "查詢帳戶現金餘額與資產概覽，返回 balances[]{currency, total_cash, max_finance_amount, remaining_finance_amount, risk_level, margin_call}",
       "properties": {
         "currency": "按幣種代碼篩選（如 `\"USD\"`、`\"HKD\"`），省略則返回所有幣種"
       }
     },
     "cash_flow": {
       "title": "資金流水",
-      "description": "查詢資金流水記錄（出入金、派息等）",
+      "description": "查詢資金流水記錄（出入金、派息等），返回 items[]{transaction_type, amount, currency, balance, created_at, remark}",
       "properties": {
-        "start_at": "起始時間（RFC3339 格式）",
-        "end_at": "結束時間（RFC3339 格式）"
+        "start_at": "起始時間（RFC3339 時間格式）",
+        "end_at": "結束時間（RFC3339 時間格式）"
       }
     },
     "fund_positions": {
       "title": "基金持倉",
-      "description": "查詢當前的基金持倉"
+      "description": "查詢當前基金持倉，返回 list[].fund_info[]{symbol, symbol_name, currency, holding_units, current_net_asset_value, cost_net_asset_value, net_asset_value_day}"
     },
     "margin_ratio": {
       "title": "保證金比率",
-      "description": "查詢保證金比率（初始 / 維持 / 強平）",
+      "description": "查詢標的保證金比率，返回 {im_factor（初始保證金）, mm_factor（維持保證金）, fm_factor（強平保證金）}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "profit_analysis": {
       "title": "盈虧分析",
-      "description": "獲取組合盈虧分析彙總。`start` / `end` 為可選日期區間（`yyyy-mm-dd`），必須成對傳入；只傳其中之一會返回空結果",
+      "description": "獲取組合盈虧分析彙總。start/end（yyyy-mm-dd）須成對傳入，只傳其中之一會返回空結果",
       "properties": {
         "start": "起始日期（`yyyy-mm-dd`）。必須與 `end` 成對傳入，只傳其一會返回空結果",
         "end": "結束日期（`yyyy-mm-dd`）。必須與 `start` 成對傳入，只傳其一會返回空結果"
@@ -76,7 +76,7 @@
     },
     "profit_analysis_detail": {
       "title": "盈虧分析明細",
-      "description": "獲取指定標的的詳細盈虧分析。`start` / `end` 為可選日期區間（`yyyy-mm-dd`），必須成對傳入；只傳其中之一會返回空結果",
+      "description": "獲取指定標的詳細盈虧分析。start/end（yyyy-mm-dd）須成對傳入，只傳其中之一會返回空結果",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`",
         "start": "起始日期（`yyyy-mm-dd`）。必須與 `end` 成對傳入，只傳其一會返回空結果",
@@ -84,54 +84,54 @@
       }
     },
     "statement_export": {
-      "title": "對賬單導出",
-      "description": "獲取對賬單數據文件的預簽名下載 URL（`file_key` 來自 `statement_list`）。返回 `{url}`，訪問該 URL 即可獲取對賬單 JSON",
+      "title": "對帳單導出",
+      "description": "獲取對帳單文件的預簽名下載 URL（file_key 來自 statement_list），返回 {url}，訪問該 URL 即可獲取對帳單 JSON",
       "properties": {
         "file_key": "來自 `statement_list` 的文件 key，例如 `\"/statement_data/data/.../20975338.json\"`"
       }
     },
     "statement_list": {
-      "title": "對賬單列表",
-      "description": "列出可獲取的賬戶對賬單（日 / 月對賬單）",
+      "title": "對帳單列表",
+      "description": "列出可獲取的帳戶對帳單（日報/月報），返回 list[]{id, type, date, status}，用 id 調用 statement_export 下載",
       "properties": {
-        "statement_type": "對賬單類型：`\"daily\"`（默認，日報）或 `\"monthly\"`（月報）",
-        "start_date": "起始日期（`yyyy-mm-dd`）。`daily` 默認 30 天前，`monthly` 默認 12 個月前",
-        "limit": "返回條數。`daily` 默認 30，`monthly` 默認 12"
+        "statement_type": "對帳單類型：`\"daily\"`（預設，日報）或 `\"monthly\"`（月報）",
+        "start_date": "起始日期（`yyyy-mm-dd`）。`daily` 預設 30 天前，`monthly` 預設 12 個月前",
+        "limit": "返回條數。`daily` 預設 30，`monthly` 預設 12"
       }
     },
     "stock_positions": {
       "title": "股票持倉",
-      "description": "查詢所有渠道下的當前股票持倉"
+      "description": "查詢所有渠道下的當前股票持倉，返回 list[].stock_info[]{symbol, symbol_name, quantity, available_quantity, currency, cost_price, market}"
     },
     "dca_history": {
       "title": "定投執行歷史",
-      "description": "按 `plan_id` 查詢定投計劃的扣款執行歷史",
+      "description": "按 plan_id 查詢定投計劃的扣款執行歷史，返回 executions[]{date, quantity, amount, price, status, order_id}",
       "properties": {
         "plan_id": "定投計劃 ID",
-        "page": "頁碼（默認 1）",
-        "limit": "每頁條數（默認 20）"
+        "page": "頁碼（預設 1）",
+        "limit": "每頁條數（預設 20）"
       }
     },
     "dca_list": {
       "title": "定投計劃列表",
-      "description": "列出定投計劃，可按狀態（`Active` 進行中 / `Suspended` 暫停 / `Finished` 已結束）或證券篩選",
+      "description": "列出定投計劃，返回 plans[]{plan_id, symbol, amount, currency, frequency, status, next_execution_date}",
       "properties": {
         "status": "按狀態篩選：`Active`、`Suspended`、`Finished`，省略則返回全部",
         "symbol": "按證券篩選，例如 `\"AAPL.US\"`，省略則返回全部計劃",
-        "page": "頁碼（默認 1）",
-        "limit": "每頁條數（默認 20）"
+        "page": "頁碼（預設 1）",
+        "limit": "每頁條數（預設 20）"
       }
     },
     "dca_stats": {
       "title": "定投統計",
-      "description": "獲取定投投資統計彙總，可選地按證券篩選",
+      "description": "獲取定投投資統計彙總，返回 {total_invested, total_value, total_return, return_rate, plan_count, items[]{symbol, invested, value, return_rate}}",
       "properties": {
         "symbol": "按證券篩選，例如 `\"AAPL.US\"`，省略則返回所有計劃的合計統計"
       }
     },
     "estimate_max_purchase_quantity": {
       "title": "最大可買估算",
-      "description": "估算指定證券的最大可買 / 可賣數量",
+      "description": "估算指定證券的最大可買/可賣數量，返回 {cash_max_qty, margin_max_qty}",
       "properties": {
         "symbol": "證券代碼",
         "side": "買賣方向：`Buy`（買入）或 `Sell`（賣出）",
@@ -141,32 +141,32 @@
     },
     "history_executions": {
       "title": "歷史成交",
-      "description": "查詢指定日期區間內的歷史成交記錄",
+      "description": "查詢指定日期區間內的歷史成交記錄，返回 executions[]{order_id, symbol, side, quantity, price, trade_done_at}",
       "properties": {
         "symbol": "按證券篩選（可選）",
-        "start_at": "起始時間（RFC3339 格式）",
-        "end_at": "結束時間（RFC3339 格式）"
+        "start_at": "起始時間（RFC3339 時間格式）",
+        "end_at": "結束時間（RFC3339 時間格式）"
       }
     },
     "history_orders": {
       "title": "歷史委託",
-      "description": "查詢指定日期區間內的歷史委託（不含當日）",
+      "description": "查詢指定日期區間內的歷史委託（不含當日），返回 orders[]{order_id, symbol, side, status, quantity, price, submitted_at}",
       "properties": {
         "symbol": "按證券篩選（可選）",
-        "start_at": "起始時間（RFC3339 格式）",
-        "end_at": "結束時間（RFC3339 格式）"
+        "start_at": "起始時間（RFC3339 時間格式）",
+        "end_at": "結束時間（RFC3339 時間格式）"
       }
     },
     "order_detail": {
       "title": "委託詳情",
-      "description": "查詢單個委託的詳細信息",
+      "description": "查詢單個委託詳情，返回 {order_id, symbol, status, side, order_type, quantity, price, executed_quantity, executed_price, submitted_at, time_in_force, msg}",
       "properties": {
         "order_id": "委託單號"
       }
     },
     "today_executions": {
       "title": "當日成交",
-      "description": "查詢當日成交（filled）。可傳入 `symbol` 或 `order_id` 篩選，兩者都省略則返回全部",
+      "description": "查詢當日成交（filled），返回 executions[]{order_id, symbol, side, quantity, price, trade_done_at}。可按 symbol 或 order_id 篩選",
       "properties": {
         "symbol": "按證券篩選，例如 `\"700.HK\"`",
         "order_id": "按指定委託單號篩選"
@@ -174,90 +174,90 @@
     },
     "today_orders": {
       "title": "當日委託",
-      "description": "查詢當日委託。可傳入 `symbol` 篩選，省略則返回全部",
+      "description": "查詢當日委託，返回 orders[]{order_id, symbol, side, order_type, status, quantity, price, submitted_at, executed_quantity, executed_price}",
       "properties": {
         "symbol": "按證券篩選，例如 `\"700.HK\"`，省略則返回當日全部委託"
       }
     },
     "cancel_order": {
       "title": "撤銷委託",
-      "description": "按 `order_id` 撤銷未成交的委託",
+      "description": "按 order_id 撤銷未成交的委託，成功返回 \"order cancelled\"；已成交或已撤銷則報錯",
       "properties": {
         "order_id": "委託單號"
       }
     },
     "dca_create": {
       "title": "創建定投計劃",
-      "description": "創建定投（DCA）計劃。`frequency` 可選 `Daily` / `Weekly` / `Monthly`；周頻對應 `day_of_week`（`Mon`–`Fri`），月頻對應 `day_of_month`（1-28）",
+      "description": "創建定投（DCA）計劃。frequency：Daily/Weekly/Monthly；週頻對應 day_of_week（Mon–Fri），月頻對應 day_of_month（1-28）",
       "properties": {
         "symbol": "證券代碼，例如 `\"AAPL.US\"`",
         "amount": "每期投入金額，例如 `\"100\"`",
         "frequency": "定投頻率：`Daily`（每日）、`Weekly`（每週）、`Monthly`（每月）",
-        "day_of_week": "周頻時指定的周幾：`Mon`、`Tue`、`Wed`、`Thu`、`Fri`",
+        "day_of_week": "週頻時指定的週幾：`Mon`、`Tue`、`Wed`、`Thu`、`Fri`",
         "day_of_month": "月頻時指定的日期（1-28）",
-        "allow_margin": "是否允許使用融資（默認 `false`）"
+        "allow_margin": "是否允許使用融資（預設 `false`）"
       }
     },
     "dca_pause": {
       "title": "暫停定投計劃",
-      "description": "按 `plan_id` 暫停定投計劃",
+      "description": "按 plan_id 暫停定投計劃，計劃停止執行直至恢復。如需臨時暫停請使用此接口（永久終止用 dca_stop）",
       "properties": {
         "plan_id": "定投計劃 ID"
       }
     },
     "dca_resume": {
       "title": "恢復定投計劃",
-      "description": "按 `plan_id` 恢復已暫停的定投計劃",
+      "description": "按 plan_id 恢復已暫停的定投計劃，按原有週期繼續自動執行",
       "properties": {
         "plan_id": "定投計劃 ID"
       }
     },
     "dca_stop": {
       "title": "終止定投計劃",
-      "description": "按 `plan_id` 永久終止定投計劃",
+      "description": "按 plan_id 永久終止定投計劃，操作不可撤銷。如需臨時暫停請使用 dca_pause",
       "properties": {
         "plan_id": "定投計劃 ID"
       }
     },
     "dca_update": {
       "title": "更新定投計劃",
-      "description": "按 `plan_id` 更新已存在的定投計劃",
+      "description": "按 plan_id 更新定投計劃，可修改 amount、frequency（Daily/Weekly/Monthly）、day_of_week（Mon-Fri）或 day_of_month（1-28）",
       "properties": {
         "plan_id": "待更新的定投計劃 ID",
         "amount": "新的每期投入金額",
         "frequency": "新的定投頻率：`Daily`、`Weekly`、`Monthly`",
-        "day_of_week": "周頻時指定的周幾：`Mon`、`Tue`、`Wed`、`Thu`、`Fri`",
+        "day_of_week": "週頻時指定的週幾：`Mon`、`Tue`、`Wed`、`Thu`、`Fri`",
         "day_of_month": "月頻時指定的日期（1-28）",
         "allow_margin": "是否允許使用融資"
       }
     },
     "replace_order": {
       "title": "修改委託",
-      "description": "改單（替換 / 修改已存在的委託）",
+      "description": "修改未成交委託的數量、價格、觸發價或追蹤止損參數，成功返回 \"order replaced\"",
       "properties": {
         "order_id": "委託單號",
         "quantity": "新的委託數量",
         "price": "新的委託價格",
         "trigger_price": "新的觸發價",
         "limit_offset": "新的限價偏移量",
-        "trailing_amount": "新的跟蹤止損金額",
-        "trailing_percent": "新的跟蹤止損百分比"
+        "trailing_amount": "新的追蹤止損金額",
+        "trailing_percent": "新的追蹤止損百分比"
       }
     },
     "submit_order": {
       "title": "提交委託",
-      "description": "提交買入 / 賣出委託。`order_type` 可選：`LO`（限價）/ `ELO`（港股增強限價）/ `MO`（市價）/ `AO`（港股競價）/ `ALO`（港股競價限價）/ `ODD`（港股碎股）/ `LIT`（觸價限價）/ `MIT`（觸價市價）/ `TSLPAMT`（按金額跟蹤止損限價）/ `TSLPPCT`（按百分比跟蹤止損限價）/ `SLO`（港股特別限價）；`side` 為 `Buy` / `Sell`；`time_in_force` 為 `Day` / `GTC` / `GTD`",
+      "description": "提交買賣委託。order_type：LO（限價）/ ELO（港股增強限價）/ MO（市價）/ AO（港股競價）/ ALO（港股競價限價）/ ODD（港股碎股）/ LIT（觸價限價）/ MIT（觸價市價）/ TSLPAMT（按金額追蹤止損）/ TSLPPCT（按百分比追蹤止損）/ SLO（港股特別限價）；side：Buy/Sell；time_in_force：Day/GTC/GTD",
       "properties": {
         "symbol": "證券代碼",
-        "order_type": "委託類型（港股全部支持；美股僅支持 `LO` / `MO` / `LIT` / `MIT` / `TSLPAMT` / `TSLPPCT`）：<br>- `LO`（限價單）：需 `submitted_price`<br>- `ELO`（增強限價單，港股）：需 `submitted_price`<br>- `MO`（市價單）：無需價格<br>- `AO`（競價單，港股）：以競價價成交，無需價格<br>- `ALO`（競價限價單，港股）：需 `submitted_price`<br>- `ODD`（碎股單，港股）：需 `submitted_price`，用於非標準手數<br>- `LIT`（觸價限價）：需 `submitted_price` 與 `trigger_price`，行情觸及觸發價時激活<br>- `MIT`（觸價市價）：僅需 `trigger_price`，觸及後按市價成交<br>- `TSLPAMT`（按金額跟蹤止損限價）：需 `trailing_amount` 與 `limit_offset`<br>- `TSLPPCT`（按百分比跟蹤止損限價）：需 `trailing_percent`（0-1）與 `limit_offset`<br>- `SLO`（特別限價單，港股）：需 `submitted_price`，提交後不可改單",
+        "order_type": "委託類型（港股全部支援；美股僅支援 `LO` / `MO` / `LIT` / `MIT` / `TSLPAMT` / `TSLPPCT`）：<br>- `LO`（限價單）：需 `submitted_price`<br>- `ELO`（增強限價單，港股）：需 `submitted_price`<br>- `MO`（市價單）：無需價格<br>- `AO`（競價單，港股）：以競價價成交，無需價格<br>- `ALO`（競價限價單，港股）：需 `submitted_price`<br>- `ODD`（碎股單，港股）：需 `submitted_price`，用於非標準手數<br>- `LIT`（觸價限價）：需 `submitted_price` 與 `trigger_price`，行情觸及觸發價時激活<br>- `MIT`（觸價市價）：僅需 `trigger_price`，觸及後按市價成交<br>- `TSLPAMT`（按金額追蹤止損限價）：需 `trailing_amount` 與 `limit_offset`<br>- `TSLPPCT`（按百分比追蹤止損限價）：需 `trailing_percent`（0-1）與 `limit_offset`<br>- `SLO`（特別限價單，港股）：需 `submitted_price`，提交後不可改單",
         "side": "買賣方向：`Buy`（買入）或 `Sell`（賣出）",
         "submitted_quantity": "委託數量",
         "time_in_force": "委託有效期：`Day`（當日有效）、`GTC`（撤單前有效）、`GTD`（指定日期前有效，需 `expire_date`）",
         "submitted_price": "委託限價。`LO` / `ELO` / `ALO` / `ODD` / `LIT` / `SLO` 必填",
         "trigger_price": "觸發價。`LIT` / `MIT` / `TSLPAMT` / `TSLPPCT` 必填",
-        "limit_offset": "相對跟蹤止損價的限價偏移量。`TSLPAMT` / `TSLPPCT` 必填",
-        "trailing_amount": "跟蹤金額（絕對價格距離），`TSLPAMT` 必填",
-        "trailing_percent": "跟蹤百分比（小數形式，例如 `0.05` 表示 5%），`TSLPPCT` 必填",
+        "limit_offset": "相對追蹤止損價的限價偏移量。`TSLPAMT` / `TSLPPCT` 必填",
+        "trailing_amount": "追蹤金額（絕對價格距離），`TSLPAMT` 必填",
+        "trailing_percent": "追蹤百分比（小數形式，例如 `0.05` 表示 5%），`TSLPPCT` 必填",
         "expire_date": "到期日期（`yyyy-mm-dd`），`time_in_force=GTD` 時必填",
         "outside_rth": "盤前盤後設置：`RTH_ONLY`（僅常規交易時段）、`ANY_TIME`（含盤前盤後任意時段）、`OVERNIGHT`（夜盤，僅美股）",
         "remark": "委託備註（最多 255 字符）"
@@ -265,23 +265,23 @@
     },
     "ah_premium": {
       "title": "A/H 溢價",
-      "description": "獲取 A/H 股溢價的歷史 K 線數據",
+      "description": "獲取 A/H 股溢價歷史 K 線數據，返回 items[]{timestamp, open, high, low, close}，表示溢價百分比",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`",
-        "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`（默認）、`week`、`month`、`year`",
-        "count": "返回的 K 線數量（默認 100）"
+        "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`（預設）、`week`、`month`、`year`",
+        "count": "返回的 K 線數量（預設 100）"
       }
     },
     "ah_premium_intraday": {
       "title": "A/H 溢價（分時）",
-      "description": "獲取 A/H 股溢價的當日分時數據",
+      "description": "獲取 A/H 股溢價當日分時數據，返回 items[]{timestamp, premium_rate}，逐分鐘展示溢價百分比",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "alert_add": {
       "title": "新增價格預警",
-      "description": "新增價格預警。`condition` 可選 `price_rise`（漲破）/ `price_fall`（跌破）/ `percent_rise`（漲幅）/ `percent_fall`（跌幅）",
+      "description": "新增價格預警，返回已創建的預警對象。condition：price_rise/price_fall（絕對價格）或 percent_rise/percent_fall（升跌幅）；frequency：once/daily/every",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`",
         "condition": "預警條件：`price_rise`、`price_fall`、`percent_rise`、`percent_fall`",
@@ -291,47 +291,47 @@
     },
     "alert_delete": {
       "title": "刪除價格預警",
-      "description": "按 `alert_id` 刪除價格預警",
+      "description": "按 alert_id（來自 alert_list 的數字字符串）刪除價格預警",
       "properties": {
         "alert_id": "預警指標 id"
       }
     },
     "alert_disable": {
       "title": "停用價格預警",
-      "description": "按 `alert_id` 停用價格預警",
+      "description": "按 alert_id 停用價格預警，返回 {alert_id, enabled: false}",
       "properties": {
         "alert_id": "預警指標 id"
       }
     },
     "alert_enable": {
-      "title": "啓用價格預警",
-      "description": "按 `alert_id` 啓用價格預警",
+      "title": "啟用價格預警",
+      "description": "按 alert_id 啟用價格預警，返回 {alert_id, enabled: true}",
       "properties": {
         "alert_id": "預警指標 id"
       }
     },
     "alert_list": {
       "title": "價格預警列表",
-      "description": "獲取所有已配置的價格預警"
+      "description": "獲取所有已配置的價格預警，返回 lists[]{counter_id, indicators[]{id, condition, price, frequency, enabled, triggered_at}}"
     },
     "anomaly": {
       "title": "市場異動",
-      "description": "獲取市場異動提醒（價量異常變動）",
+      "description": "獲取市場異動提醒（價量異常變動），返回 items[]{symbol, name, anomaly_type, change_rate, volume, timestamp}",
       "properties": {
         "market": "市場代碼：HK、US、CN、SG"
       }
     },
     "broker_holding": {
       "title": "券商持倉",
-      "description": "獲取指定證券的主要券商持倉數據",
+      "description": "獲取指定證券的主要券商持倉數據，返回 items[]{broker_name, holding_quantity, holding_change, holding_ratio}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`",
-        "period": "時間窗口：`rct_1`（近 1 日，默認）、`rct_5`（近 5 日）、`rct_20`（近 20 日）、`rct_60`（近 60 日）"
+        "period": "時間窗口：`rct_1`（近 1 日，預設）、`rct_5`（近 5 日）、`rct_20`（近 20 日）、`rct_60`（近 60 日）"
       }
     },
     "broker_holding_daily": {
       "title": "券商持倉（日度）",
-      "description": "獲取指定券商對某證券的逐日持倉歷史",
+      "description": "獲取指定券商（broker_id）對某證券的逐日持倉歷史，返回 items[]{date, holding_quantity, holding_change, holding_ratio}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`",
         "broker_id": "券商參與者編號"
@@ -339,21 +339,21 @@
     },
     "broker_holding_detail": {
       "title": "券商持倉明細",
-      "description": "獲取完整的券商持倉明細列表",
+      "description": "獲取完整的券商持倉明細列表，返回 items[]{broker_id, broker_name, holding_quantity, holding_ratio, holding_change, date}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "brokers": {
       "title": "經紀商隊列",
-      "description": "獲取經紀商買賣盤隊列數據",
+      "description": "獲取港股經紀商買賣盤隊列（僅港股），返回 bid_brokers/ask_brokers[]{position, broker_ids}，通過 participants 工具將 broker_id 映射為名稱",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "calc_indexes": {
       "title": "指標計算",
-      "description": "為證券計算財務 / 行情指標（PE、PB、股息率等）",
+      "description": "批量計算證券的行情/財務指標（PE、PB、股息率、最新價、換手率等），傳入 symbols 和 indexes 列表，返回各標的的指標值",
       "properties": {
         "symbols": "證券代碼，例如 `[\"700.HK\", \"AAPL.US\"]`",
         "indexes": "待計算指標：`LastDone`、`ChangeValue`、`ChangeRate`、`Volume`、`Turnover`、`YtdChangeRate`、`TurnoverRate`、`TotalMarketValue`、`CapitalFlow`、`Amplitude`、`VolumeRatio`、`PeTtmRatio`、`PbRatio`、`DividendRatioTtm`、`FiveDayChangeRate`、`TenDayChangeRate`、`HalfYearChangeRate`、`FiveMinutesChangeRate`、`ExpiryDate`、`StrikePrice`、`UpperStrikePrice`、`LowerStrikePrice`、`OutstandingQty`、`OutstandingRatio`、`Premium`、`ItmOtm`、`ImpliedVolatility`、`WarrantDelta`、`CallPrice`、`ToCallPrice`、`EffectiveLeverage`、`LeverageRatio`、`ConversionRatio`、`BalancePoint`、`OpenInterest`、`Delta`、`Gamma`、`Theta`、`Vega`、`Rho`"
@@ -361,7 +361,7 @@
     },
     "candlesticks": {
       "title": "K 線數據",
-      "description": "獲取 K 線數據（OHLCV）。`period` 可選 `1m` / `5m` / `15m` / `30m` / `60m` / `day` / `week` / `month` / `year`；`trade_sessions` 可選 `intraday` / `all`",
+      "description": "獲取 K 線數據（OHLCV）。period：1m/5m/15m/30m/60m/day/week/month/year；trade_sessions：intraday（預設，僅正常時段）或 all（含盤前盤後）",
       "properties": {
         "symbol": "證券代碼",
         "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`",
@@ -372,95 +372,95 @@
     },
     "capital_distribution": {
       "title": "資金分佈",
-      "description": "獲取資金分佈（大 / 中 / 小單的資金流向）",
+      "description": "獲取資金分佈（大/中/小單流入流出），返回 {timestamp, capital_in{large, medium, small}, capital_out{large, medium, small}}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "capital_flow": {
       "title": "資金流向",
-      "description": "獲取資金流入 / 流出的時間序列",
+      "description": "獲取資金淨流入/流出當日時間序列，返回 items[]{timestamp, inflow, outflow, net_flow}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "company": {
       "title": "公司概況",
-      "description": "獲取公司概況（名稱、CEO、員工數、簡介等）",
+      "description": "獲取公司概況，返回 name、description、employees、CEO、founded_year、website、exchange、industry、market_cap 等信息",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "consensus": {
       "title": "一致預期",
-      "description": "獲取分析師一致預期（營收、EPS、淨利潤等）",
+      "description": "獲取分析師一致預期，返回 items[]{period, revenue_estimate, eps_estimate, net_income_estimate, analyst_count, last_updated}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "constituent": {
       "title": "指數成份股",
-      "description": "獲取指數成分股（例如 `HSI.HK`）",
+      "description": "獲取指數成份股（如 HSI.HK），返回 constituents[]{symbol, name, last_done（最新價）, change_rate, market_cap, weight}",
       "properties": {
         "symbol": "指數代碼，例如 `\"HSI.HK\"`"
       }
     },
     "corp_action": {
       "title": "公司行動",
-      "description": "獲取公司行動信息（拆股、回購、更名等）",
+      "description": "獲取公司行動信息（拆股、回購、更名等），返回 items[]{action_type, effective_date, ratio, description}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "dca_check": {
-      "title": "檢查定投支持",
-      "description": "檢查指定證券是否支持定投（DCA）",
+      "title": "檢查定投支援",
+      "description": "檢查證券是否支援定投（DCA），返回 items[]{symbol, support_dca, reason}",
       "properties": {
         "symbols": "待檢查的證券代碼，例如 `[\"AAPL.US\", \"TSLA.US\"]`"
       }
     },
     "depth": {
       "title": "盤口深度",
-      "description": "獲取盤口深度數據（買賣各檔位）",
+      "description": "獲取買賣盤深度（最多 10 檔），返回 {bids[]{position, price, volume, order_num}, asks[]{position, price, volume, order_num}}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "dividend": {
       "title": "派息歷史",
-      "description": "獲取證券的派息歷史",
+      "description": "獲取證券的派息歷史，返回 items[]{ex_date（除權日）, pay_date（派發日）, record_date, dividend_type, amount, currency, status}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "dividend_detail": {
       "title": "派息明細",
-      "description": "獲取詳細的派息分紅方案",
+      "description": "獲取詳細派息分紅方案，返回 details[]{period, cash_dividend, stock_dividend, record_date, ex_date, pay_date, currency}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "exchange_rate": {
       "title": "匯率",
-      "description": "獲取全部支持幣種的匯率"
+      "description": "獲取全部支援幣種的匯率，返回 list[]{from_currency, to_currency, rate, timestamp}，覆蓋 USD/HKD/CNY/SGD 等"
     },
     "executive": {
       "title": "高管與董事",
-      "description": "獲取公司高管及董事會成員信息",
+      "description": "獲取公司高管及董事會成員信息，返回 members[]{name, title, appointed_date, age, biography, compensation}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "filings": {
       "title": "監管公告",
-      "description": "獲取監管文件公告（8-K、10-Q、10-K 等）",
+      "description": "獲取監管文件公告（8-K、10-Q、10-K 等），返回 items[]{id, title, type, language, filing_date, url}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "finance_calendar": {
       "title": "財經日曆",
-      "description": "獲取財經日曆事件。`category` 可選 `financial` / `report` / `dividend` / `ipo` / `macrodata` / `closed`",
+      "description": "獲取財經日曆事件。category：report（財報+業績）/ dividend（除息日與派發日）/ split（拆股/反拆）/ ipo / macrodata（CPI、非農、議息等）/ closed（休市日）；market：HK/US/CN/SG/JP/UK/DE/AU",
       "properties": {
         "market": "市場代碼：HK、US、CN、SG，省略則查詢所有市場",
         "start": "起始日期（`yyyy-mm-dd`）",
@@ -470,30 +470,30 @@
     },
     "financial_report": {
       "title": "財務報表",
-      "description": "獲取證券的財務報告。`report_type` 用於區分年報或季報等",
+      "description": "獲取財務報告（損益表/資產負債表/現金流量表）。kind：IS/BS/CF/ALL；report_type：af（年報）/saf（半年報）/q1/q2/q3/qf（季報全量）",
       "properties": {
         "symbol": "證券代碼，例如 `\"AAPL.US\"`",
-        "kind": "報表種類：`IS`（利潤表）、`BS`（資產負債表）、`CF`（現金流量表）、`ALL`（默認全部）",
+        "kind": "報表種類：`IS`（損益表）、`BS`（資產負債表）、`CF`（現金流量表）、`ALL`（預設全部）",
         "report_type": "報告期：`af`（年度）、`saf`（半年度）、`q1` / `q2` / `q3`（季度）、`qf`（季度全量）"
       }
     },
     "forecast_eps": {
       "title": "EPS 預測",
-      "description": "獲取 EPS 預測及分析師預期歷史",
+      "description": "獲取 EPS 預測及分析師預期歷史，返回 items[]{forecast_start_date, forecast_end_date, eps_estimate, eps_actual, surprise_pct, analyst_count}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "fund_holder": {
       "title": "持倉基金",
-      "description": "獲取持有指定證券的基金及 ETF",
+      "description": "獲取持有指定證券的基金及 ETF，返回 fund_holders[]{fund_name, fund_symbol, shares, ratio, change, reported_at}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "history_candlesticks_by_date": {
       "title": "歷史 K 線（按日期）",
-      "description": "按日期區間獲取歷史 K 線數據。`period` 可選 `1m` / `5m` / `15m` / `30m` / `60m` / `day` / `week` / `month` / `year`",
+      "description": "按日期區間獲取歷史 K 線（OHLCV）數據。period：1m/5m/15m/30m/60m/day/week/month/year",
       "properties": {
         "symbol": "證券代碼",
         "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`",
@@ -505,7 +505,7 @@
     },
     "history_candlesticks_by_offset": {
       "title": "歷史 K 線（按偏移）",
-      "description": "以參考時間為錨點，按偏移量獲取歷史 K 線數據。`period` 可選 `1m` / `5m` / `15m` / `30m` / `60m` / `day` / `week` / `month` / `year`",
+      "description": "以參考時間為錨點按偏移量獲取歷史 K 線（OHLCV）數據。period：1m/5m/15m/30m/60m/day/week/month/year",
       "properties": {
         "symbol": "證券代碼",
         "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`",
@@ -517,8 +517,8 @@
       }
     },
     "history_market_temperature": {
-      "title": "歷史市場温度",
-      "description": "獲取市場情緒温度的歷史時間序列",
+      "title": "歷史市場溫度",
+      "description": "獲取市場情緒溫度歷史時間序列，返回 {type, list[]{temperature, description, valuation, sentiment, timestamp}}",
       "properties": {
         "market": "市場代碼：HK、US、CN、SG",
         "start": "起始日期（`yyyy-mm-dd`）",
@@ -527,86 +527,86 @@
     },
     "industry_valuation": {
       "title": "行業估值",
-      "description": "獲取同行業可比公司的估值對比",
+      "description": "獲取同行業可比公司估值對比，返回 list[]{symbol, name, pe, pb, ps, dividend_yield, history[]{date, pe, pb}}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "industry_valuation_dist": {
       "title": "行業估值分佈",
-      "description": "獲取行業 PE / PB / PS 估值分佈",
+      "description": "獲取行業 PE/PB/PS 估值分佈，返回 distributions{pe/pb/ps}{min, p25, median, p75, max, current_percentile}，顯示個股在行業中的分位",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "institution_rating": {
       "title": "機構評級",
-      "description": "獲取機構評級彙總，含一致評級與目標價",
+      "description": "獲取機構評級彙總，返回 analyst{buy, outperform, hold, underperform, sell 家數, target_price, consensus_rating} 及評級列表",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "institution_rating_detail": {
       "title": "機構評級明細",
-      "description": "獲取詳細的機構評級與目標價歷史",
+      "description": "獲取機構評級與目標價歷史明細，返回 target.list[]{analyst, firm, rating, target_price, timestamp}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "intraday": {
       "title": "分時數據",
-      "description": "獲取分時（逐分鐘）價格 / 成交數據。`trade_sessions` 可選 `intraday`（默認，僅常規時段）或 `all`（含盤前盤後）",
+      "description": "獲取分時（逐分鐘）價格/成交量數據。trade_sessions：intraday（預設，僅正常時段）或 all（含盤前盤後）",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`",
-        "trade_sessions": "包含的交易時段：`intraday`（默認，僅常規時段）或 `all`（含盤前盤後）"
+        "trade_sessions": "包含的交易時段：`intraday`（預設，僅常規時段）或 `all`（含盤前盤後）"
       }
     },
     "invest_relation": {
       "title": "投資者關係",
-      "description": "獲取投資者關係事件與公告",
+      "description": "獲取投資者關係事件與公告，返回 items[]{title, event_type, event_date, url, description}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "market_status": {
       "title": "市場狀態",
-      "description": "獲取所有市場當前的交易狀態"
+      "description": "獲取所有市場當前交易狀態，返回 market_time[]{market, trade_status（Pre-Open/Trading/Lunch Break/Post-Trading/Closed 等）, timestamp}"
     },
     "market_temperature": {
-      "title": "市場温度",
-      "description": "獲取當前市場情緒温度（0-100）",
+      "title": "市場溫度",
+      "description": "獲取當前市場情緒溫度，返回 {temperature（0-100）, description, valuation（0-100）, sentiment（0-100）, timestamp}",
       "properties": {
         "market": "市場代碼：HK、US、CN、SG"
       }
     },
     "news": {
       "title": "資訊",
-      "description": "獲取證券相關的最新新聞",
+      "description": "獲取證券相關最新新聞，返回 items[]{id, title, source, publish_time, summary, url, related_symbols[]}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "now": {
       "title": "當前時間",
-      "description": "獲取當前 UTC 時間"
+      "description": "獲取當前 UTC 時間（RFC3339 時間格式），用於在發起日期相關查詢前確認當前日期"
     },
     "operating": {
       "title": "經營業績",
-      "description": "獲取公司經營指標",
+      "description": "獲取公司經營指標（僅港股），返回 items[]{period, metric_name, value, unit}，如客運量、貨運量、門店數等",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "option_chain_expiry_date_list": {
       "title": "期權到期日列表",
-      "description": "獲取期權鏈可選的到期日列表",
+      "description": "獲取期權鏈可選到期日列表，返回 expiry_dates[]（yyyy-mm-dd）。配合 option_chain_info_by_date 查詢行權價和 Greeks",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "option_chain_info_by_date": {
       "title": "期權鏈",
-      "description": "獲取指定到期日的期權鏈行權價及希臘字母",
+      "description": "獲取指定到期日的期權鏈，返回 strikePrices[]{strike_price, call{symbol, last_done, iv, delta, gamma}, put{symbol, last_done, iv, delta, gamma}}",
       "properties": {
         "symbol": "證券代碼",
         "date": "到期日（`yyyy-mm-dd`）"
@@ -614,47 +614,47 @@
     },
     "option_quote": {
       "title": "期權報價",
-      "description": "獲取期權行情（最多 500 個標的）",
+      "description": "獲取期權行情（最多 500 個），返回各標的：last_done（最新價）, prev_close, open, high, low, volume（成交量）, turnover（成交額）, implied_volatility（隱含波動率）, delta/gamma/theta/vega/rho（Greeks）, open_interest（未平倉量）",
       "properties": {
         "symbols": "證券代碼，例如 `[\"700.HK\", \"AAPL.US\"]`"
       }
     },
     "option_volume": {
       "title": "期權成交量",
-      "description": "獲取美股的實時期權認購 / 認沽成交量及 PCR",
+      "description": "獲取美股實時期權認購/認沽成交量統計，返回 {call_volume, put_volume, put_call_ratio, call_oi, put_oi} 及活躍合約列表",
       "properties": {
         "symbol": "標的代碼（僅美股），例如 `\"AAPL.US\"`"
       }
     },
     "option_volume_daily": {
       "title": "期權成交量（日度）",
-      "description": "獲取美股的逐日期權認購 / 認沽成交量、未平倉量及 PCR 歷史",
+      "description": "獲取美股逐日期權成交量歷史，返回 items[]{date, call_volume, put_volume, put_call_vol_ratio, call_oi, put_oi, put_call_oi_ratio}",
       "properties": {
         "symbol": "標的代碼（僅美股），例如 `\"AAPL.US\"`",
-        "count": "返回的交易日數量（默認 20）"
+        "count": "返回的交易日數量（預設 20）"
       }
     },
     "participants": {
       "title": "市場參與者",
-      "description": "獲取市場參與者（券商）信息"
+      "description": "獲取港股市場參與者（券商）信息，返回 participants[]{broker_ids[], name_en, name_cn, name_hk}，用於解析經紀商隊列數據"
     },
     "quote": {
       "title": "行情快照",
-      "description": "獲取最新行情快照（最新價、開盤、最高、最低、成交量、成交額）",
+      "description": "獲取最新行情快照，返回各標的：last_done（最新價）, prev_close（昨收）, open（開盤價）, high/low（最高/最低價）, volume（成交量）, turnover（成交額）, change_rate, change_value, trade_status, timestamp",
       "properties": {
         "symbols": "證券代碼，例如 `[\"700.HK\", \"AAPL.US\"]`"
       }
     },
     "shareholder": {
       "title": "機構股東",
-      "description": "獲取證券的機構股東信息",
+      "description": "獲取證券的機構股東信息，返回 shareholders[]{institution, shares, ratio, change, change_type, reported_at}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "sharelist_add": {
       "title": "加入分享股單",
-      "description": "向社區分享股單中添加證券",
+      "description": "向社區分享股單中添加證券。symbols 為股票代碼列表（如 [\"AAPL.US\"]），id 為股單 ID。成功返回更新後的股單。",
       "properties": {
         "id": "分享股單 ID",
         "symbols": "證券代碼，例如 `[\"AAPL.US\", \"700.HK\"]`"
@@ -662,43 +662,43 @@
     },
     "sharelist_create": {
       "title": "創建分享股單",
-      "description": "新建一個社區分享股單",
+      "description": "新建社區分享股單，返回創建的股單對象（含 id、name、description）",
       "properties": {
         "name": "股單名稱（若未傳 `description`，名稱同時作為描述）",
-        "description": "股單描述，省略時默認與 `name` 相同"
+        "description": "股單描述，省略時預設與 `name` 相同"
       }
     },
     "sharelist_delete": {
       "title": "刪除分享股單",
-      "description": "按 id 刪除社區分享股單",
+      "description": "按 id 刪除自建社區分享股單（已訂閱他人的股單不可刪除）",
       "properties": {
         "id": "分享股單 ID"
       }
     },
     "sharelist_detail": {
       "title": "分享股單詳情",
-      "description": "按 id 獲取社區分享股單詳情，含成分股及行情",
+      "description": "按 id 獲取社區分享股單詳情，返回 {id, name, description, constituents[]{symbol, name, last_done, change_rate}, 訂閱狀態}",
       "properties": {
         "id": "分享股單 ID"
       }
     },
     "sharelist_list": {
       "title": "分享股單列表",
-      "description": "列出用戶自建以及已訂閲的社區分享股單",
+      "description": "列出用戶自建及已訂閱的社區分享股單，返回 lists[]{id, name, description, symbol_count, is_owner, follower_count}",
       "properties": {
-        "count": "返回數量（默認 20）"
+        "count": "返回數量（預設 20）"
       }
     },
     "sharelist_popular": {
       "title": "熱門分享股單",
-      "description": "獲取熱門 / 正在流行的社區分享股單",
+      "description": "獲取熱門/流行社區分享股單，返回 lists[]{id, name, description, symbol_count, follower_count, creator}，按熱度排序",
       "properties": {
-        "count": "返回數量（默認 20）"
+        "count": "返回數量（預設 20）"
       }
     },
     "sharelist_remove": {
       "title": "移出分享股單",
-      "description": "從社區分享股單中移除證券",
+      "description": "從社區分享股單中移除指定證券。symbols 為要移除的股票代碼列表，id 為股單 ID。成功返回更新後的股單。",
       "properties": {
         "id": "分享股單 ID",
         "symbols": "證券代碼，例如 `[\"AAPL.US\", \"700.HK\"]`"
@@ -706,7 +706,7 @@
     },
     "sharelist_sort": {
       "title": "分享股單排序",
-      "description": "調整社區分享股單中證券的順序（按目標順序傳入 `symbols`）",
+      "description": "調整社區分享股單中證券的排列順序（按目標順序傳入 symbols）",
       "properties": {
         "id": "分享股單 ID",
         "symbols": "證券代碼，例如 `[\"AAPL.US\", \"700.HK\"]`"
@@ -714,71 +714,71 @@
     },
     "short_positions": {
       "title": "空頭持倉",
-      "description": "獲取美股的做空數據（空頭比率、空頭股數、回補天數等），僅支持美股市場",
+      "description": "獲取美股沽空數據（空頭比率、空頭股數、回補天數等），僅支援美股市場",
       "properties": {
         "symbol": "證券代碼（僅美股），例如 `\"AAPL.US\"`",
-        "count": "返回條數（1-100，默認 20）"
+        "count": "返回條數（1-100，預設 20）"
       }
     },
     "static_info": {
       "title": "證券基礎信息",
-      "description": "獲取證券的基礎信息（名稱、交易所、類型、每手股數等）",
+      "description": "獲取證券基礎信息，返回各標的：symbol, name_cn, name_en, exchange（如 NASDAQ）, type（如 US_Stock）, lot_size（每手股數）, listed_date, delisted",
       "properties": {
         "symbols": "證券代碼，例如 `[\"700.HK\", \"AAPL.US\"]`"
       }
     },
     "topic": {
       "title": "討論列表",
-      "description": "獲取與某證券相關的討論",
+      "description": "獲取證券相關的社區討論，返回 items[]{id, title, author, created_at, like_count, comment_count, content_summary}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "topic_create": {
       "title": "發佈討論",
-      "description": "發佈討論。`topic_type=\"post\"`（默認）為純文本；`\"article\"` 需要非空 `title`，正文可使用 Markdown",
+      "description": "發佈社區討論。topic_type=\"post\"（預設）為純文本；\"article\" 需非空 title，正文支援 Markdown",
       "properties": {
         "title": "討論標題。`topic_type=\"article\"` 時必填，`\"post\"` 時可選",
-        "body": "討論正文。`post` 僅支持純文本，`article` 支持 Markdown",
+        "body": "討論正文。`post` 僅支援純文本，`article` 支援 Markdown",
         "symbols": "相關證券代碼，例如 `[\"700.HK\", \"TSLA.US\"]`（最多 10 個）",
-        "topic_type": "討論類型：`post`（默認，純文本）或 `article`（Markdown，需 `title`）"
+        "topic_type": "討論類型：`post`（預設，純文本）或 `article`（Markdown，需 `title`）"
       }
     },
     "topic_create_reply": {
       "title": "發佈討論回覆",
-      "description": "對討論發表回覆。傳入 `reply_to_id` 表示對某條回覆的子級回覆，省略則為頂層回覆",
+      "description": "對討論發表回覆。傳入 reply_to_id 表示樓中樓回覆，省略則為頂層回覆",
       "properties": {
         "topic_id": "待回覆的討論 ID",
-        "body": "回覆正文（僅支持純文本）",
+        "body": "回覆正文（僅支援純文本）",
         "reply_to_id": "可選的父回覆 ID，用於樓中樓回覆，從 `topic_replies` 獲取；省略則為頂層回覆"
       }
     },
     "topic_detail": {
       "title": "討論詳情",
-      "description": "按 `topic_id` 獲取討論詳情",
+      "description": "按 topic_id 獲取討論詳情，返回 {id, title, content, author, created_at, like_count, comment_count, symbols[]}",
       "properties": {
         "topic_id": "討論 ID"
       }
     },
     "topic_replies": {
       "title": "討論回覆",
-      "description": "分頁獲取討論的回覆（`page` 默認 1，`size` 默認 20，範圍 1-50）",
+      "description": "分頁獲取討論的回覆（page 預設 1，size 預設 20，範圍 1-50）",
       "properties": {
         "topic_id": "討論 ID",
-        "page": "頁碼（從 1 開始，默認 1）",
-        "size": "每頁條數（1-50，默認 20）"
+        "page": "頁碼（從 1 開始，預設 1）",
+        "size": "每頁條數（1-50，預設 20）"
       }
     },
     "trade_stats": {
       "title": "成交統計",
-      "description": "獲取成交統計（主動買 / 主動賣 / 中性盤的成交量分佈）",
+      "description": "獲取成交統計（主動買/主動賣/中性盤成交量分佈），返回 items[]{price_range, buy_volume, sell_volume, neutral_volume}",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "trades": {
       "title": "最近成交",
-      "description": "獲取最近的逐筆成交（最多 1000 條）",
+      "description": "獲取最近逐筆成交（最多 1000 條），返回 trades[]{price, volume, timestamp, trade_type, direction}",
       "properties": {
         "symbol": "證券代碼",
         "count": "返回的最大條數（最多 1000）"
@@ -786,7 +786,7 @@
     },
     "trading_days": {
       "title": "交易日列表",
-      "description": "獲取指定市場在某日期區間內的交易日",
+      "description": "獲取指定市場在日期區間內的交易日，返回 trading_days[] 和 half_trading_days[]（格式 yyyy-mm-dd）",
       "properties": {
         "market": "市場代碼：HK、US、CN、SG",
         "start": "起始日期（`yyyy-mm-dd`）",
@@ -795,29 +795,29 @@
     },
     "trading_session": {
       "title": "交易時段",
-      "description": "獲取所有市場的交易時段安排"
+      "description": "獲取所有市場的交易時段安排，返回 market_sessions[]{market, trade_sessions[]{beg_time, end_time, trade_session_type}}"
     },
     "valuation": {
       "title": "估值",
-      "description": "獲取估值概覽及同業對比",
+      "description": "獲取估值概覽及同業對比，返回 metrics.pe/pb/ps/dividend_yield{current, industry_avg, 5yr_avg, percentile} 及同業對比列表",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "valuation_history": {
       "title": "估值歷史",
-      "description": "獲取詳細的估值歷史時間序列",
+      "description": "獲取詳細估值歷史時間序列，返回 history.metrics{pe/pb/ps/dividend_yield}[]{timestamp, value}，用於長期分位分析",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "warrant_issuers": {
       "title": "權證發行商",
-      "description": "獲取窩輪 / 牛熊證發行商信息"
+      "description": "獲取港股窩輪/牛熊證發行商信息，返回 issuers[]{id, name_en, name_cn}，id 可用於 warrant_list 的發行商篩選"
     },
     "warrant_list": {
       "title": "權證列表",
-      "description": "按篩選條件獲取指定標的的窩輪 / 牛熊證列表",
+      "description": "按條件篩選標的的窩輪/牛熊證列表，返回 warrants[]{symbol, name, last_done, change_rate, implied_volatility, expiry_date, strike_price, leverage_ratio, outstanding_ratio}",
       "properties": {
         "symbol": "標的代碼，例如 `\"700.HK\"`",
         "sort_by": "排序字段：`LastDone`、`ChangeRate`、`ChangeValue`、`Volume`、`Turnover`、`ExpiryDate`、`StrikePrice`、`UpperStrikePrice`、`LowerStrikePrice`、`OutstandingQuantity`、`OutstandingRatio`、`Premium`、`ItmOtm`、`ImpliedVolatility`、`Delta`",
@@ -831,17 +831,17 @@
     },
     "warrant_quote": {
       "title": "權證報價",
-      "description": "獲取窩輪 / 牛熊證行情",
+      "description": "獲取窩輪/牛熊證行情，返回各標的：last_done（最新價）, prev_close, open, high, low, volume（成交量）, turnover（成交額）, implied_volatility（隱含波動率）, delta, leverage_ratio, effective_leverage",
       "properties": {
         "symbols": "證券代碼，例如 `[\"700.HK\", \"AAPL.US\"]`"
       }
     },
     "quant_run": {
       "title": "量化指標腳本運行",
-      "description": "在服務端針對歷史 K 線數據運行量化指標腳本，執行後將計算得到的指標/繪圖值以 JSON 形式返回。週期：1m、5m、15m、30m、1h、day、week、month、year（默認 day）。可選 input 參數接收一個 JSON 數組，順序需與腳本中 input.*() 調用一致，例如 \"[14,2.0]\"。",
+      "description": "在服務端對歷史 K 線數據運行量化指標腳本，以 JSON 形式返回計算的指標/繪圖值。週期：1m/5m/15m/30m/1h/day/week/month/year（預設 day）；input 為 JSON 數組，順序需與腳本中 input.*() 調用一致",
       "properties": {
         "symbol": "證券代碼，`<CODE>.<MARKET>` 格式，例如 `TSLA.US`、`700.HK`",
-        "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`1h`、`day`、`week`、`month`、`year`（默認 `day`）",
+        "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`1h`、`day`、`week`、`month`、`year`（預設 `day`）",
         "start": "K 線區間起始日期（YYYY-MM-DD）",
         "end": "K 線區間結束日期（YYYY-MM-DD）",
         "script": "指標腳本源代碼",
@@ -850,7 +850,7 @@
     },
     "news_search": {
       "title": "新聞搜尋",
-      "description": "按關鍵詞搜尋新聞文章，返回 id、標題、時間、來源及連結。",
+      "description": "按關鍵詞搜尋新聞文章，返回 news_list[]{id, title, description, source_name, publish_at（RFC3339 時間格式）, score}",
       "properties": {
         "keyword": "搜尋關鍵詞",
         "limit": "最多返回條數（預設 20）"
@@ -858,7 +858,7 @@
     },
     "topic_search": {
       "title": "社區話題搜尋",
-      "description": "按關鍵詞搜尋社區帖子/話題，返回 id、作者、時間及摘要。",
+      "description": "按關鍵詞搜尋社區帖子/話題，返回 id、作者、時間及摘要",
       "properties": {
         "keyword": "搜尋關鍵詞",
         "limit": "最多返回條數（預設 20）"
@@ -866,7 +866,7 @@
     },
     "financial_statement": {
       "title": "財務報表",
-      "description": "獲取證券的財務報表（損益表、資產負債表或現金流量表）。kind：IS（損益表）、BS（資產負債表）、CF（現金流量表）、ALL（全部，預設）。report：af（年報）、saf（半年報）、qf（季報）、q1/q2/q3。",
+      "description": "獲取證券財務報表（損益表/資產負債表/現金流量表）。kind：IS/BS/CF/ALL（預設）；report：af（年報）/saf（半年報）/qf（季報）/q1/q2/q3",
       "properties": {
         "symbol": "證券代碼，例如 `\"AAPL.US\"`",
         "kind": "報表類型：`IS`（損益表）、`BS`（資產負債表）、`CF`（現金流量表）、`ALL`（全部，預設）",
@@ -875,14 +875,14 @@
     },
     "financial_report_latest": {
       "title": "最新財務報告",
-      "description": "獲取證券最新財務報告的摘要資訊，包含主要財務指標。",
+      "description": "獲取證券最新財務報告摘要，返回 {period, revenue, net_income, eps, roe, gross_margin, report_date} 等主要財務指標",
       "properties": {
         "symbol": "證券代碼，例如 `\"AAPL.US\"`"
       }
     },
     "valuation_rank": {
       "title": "估值分位",
-      "description": "獲取證券在指定日期區間內的每日估值分位（PE/PB/PS/股息率行業百分位）。start/end 格式：yyyymmdd。",
+      "description": "獲取證券在指定日期區間內每日估值分位（PE/PB/PS/股息率行業百分位）。start/end 格式：yyyymmdd",
       "properties": {
         "symbol": "證券代碼，例如 `\"AAPL.US\"`",
         "start": "起始日期，yyyymmdd 格式（預設近 30 天）",
@@ -891,14 +891,14 @@
     },
     "institution_rating_history": {
       "title": "機構評級歷史",
-      "description": "獲取證券的機構評級歷史，包含目標價變動和評級變動記錄。",
+      "description": "獲取機構評級歷史，返回 target_history[]{firm, analyst, old_target, new_target, date} 及 evaluate_history[]{firm, old_rating, new_rating, date}",
       "properties": {
         "symbol": "證券代碼，例如 `\"AAPL.US\"`"
       }
     },
     "institution_rating_industry_rank": {
       "title": "機構評級行業排名",
-      "description": "獲取同行業內各證券按機構分析師評級的排名對比。",
+      "description": "獲取同行業各證券的機構評級排名對比，返回 list[]{symbol, name, buy_count, sell_count, consensus_rating, target_price}，支援分頁",
       "properties": {
         "symbol": "證券代碼，例如 `\"AAPL.US\"`",
         "page": "頁碼（預設 1）",
@@ -907,15 +907,15 @@
     },
     "short_margin": {
       "title": "沽空保證金",
-      "description": "獲取當前帳戶的沽空保證金存款明細。"
+      "description": "獲取當前帳戶沽空保證金存款明細，返回各空頭持倉的 margin_amount、margin_rate、interest_rate、symbol、quantity"
     },
     "bank_cards": {
       "title": "綁定銀行卡",
-      "description": "列出當前帳戶綁定的提款銀行卡。"
+      "description": "列出當前帳戶綁定的提款銀行卡，返回 cards[]{id, bank_name, account_number（脫敏）, currency, status}"
     },
     "withdrawals": {
       "title": "提款記錄",
-      "description": "獲取當前帳戶的提款歷史記錄。",
+      "description": "獲取當前帳戶提款歷史，返回 items[]{id, amount, currency, status, created_at, bank_name, account_number（脫敏）}",
       "properties": {
         "page": "頁碼（預設 1）",
         "size": "每頁條數（預設 20）"
@@ -923,7 +923,7 @@
     },
     "deposits": {
       "title": "入款記錄",
-      "description": "獲取當前帳戶的入款歷史記錄。states：逗號分隔的入款狀態過濾。currencies：逗號分隔的貨幣代碼，例如 `\"USD,HKD\"`。",
+      "description": "獲取當前帳戶入款歷史，返回 items[]{id, amount, currency, status, created_at, updated_at}。states：逗號分隔的狀態（Pending/Finished/Failed）；currencies：逗號分隔的貨幣代碼",
       "properties": {
         "page": "頁碼（預設 1）",
         "size": "每頁條數（預設 20）",
@@ -933,15 +933,15 @@
     },
     "ipo_subscriptions": {
       "title": "IPO 認購列表",
-      "description": "列出當前港股和美股市場處於認購或預申請階段的 IPO 股票（合併返回 HK 和 US 兩市結果）。"
+      "description": "列出港股和美股當前處於認購/預申請階段的 IPO，返回 items[]{symbol, name, market, sub_start_date, sub_end_date, listing_date, issue_price, min_lot_size}"
     },
     "ipo_calendar": {
       "title": "IPO 日曆",
-      "description": "顯示 IPO 日曆，包含所有即將上市及近期已上市的 IPO，含認購日期和上市日期。"
+      "description": "顯示 IPO 日曆，返回 items[]{symbol, name, market, sub_start_date, sub_end_date, listing_date, status}，含即將上市及近期已上市的 IPO"
     },
     "ipo_listed": {
       "title": "IPO 已上市列表",
-      "description": "列出港股和美股近期已上市的 IPO，包含發行價、首日升跌幅及成交量資訊。",
+      "description": "列出港股和美股近期已上市的 IPO，返回 items[]{symbol, name, listing_date, issue_price, first_day_close, first_day_return, volume, market}",
       "properties": {
         "page": "頁碼（預設 1）",
         "size": "每頁條數（預設 20）"
@@ -949,7 +949,7 @@
     },
     "ipo_detail": {
       "title": "IPO 詳情",
-      "description": "查看某隻股票的 IPO 詳情，包含招股簡介（profile）、時間線（timeline）及認購資格（eligibility）。",
+      "description": "查看 IPO 詳情，返回 profile（業務簡介）、timeline[]{event, date}、認購資格（eligibility）、pricing_range、lot_size、配股規則",
       "properties": {
         "symbol": "證券代碼，例如 `\"6871.HK\"` 或 `\"ARM.US\"`",
         "market": "市場：`HK` 或 `US`（預設根據代碼後綴推斷）"
@@ -957,7 +957,7 @@
     },
     "ipo_orders": {
       "title": "IPO 訂單列表",
-      "description": "列出當前帳戶的 IPO 訂單（有效訂單和歷史訂單），可按證券代碼、市場或狀態過濾。",
+      "description": "列出當前帳戶的 IPO 訂單（有效和歷史），返回 orders[]{order_id, symbol, market, quantity, total_amount, status, submitted_at}，可按 symbol/market/status 過濾",
       "properties": {
         "symbol": "按證券代碼過濾，例如 `\"6871.HK\"`",
         "market": "按市場過濾：`HK` 或 `US`",
@@ -968,14 +968,14 @@
     },
     "ipo_order_detail": {
       "title": "IPO 訂單詳情",
-      "description": "按訂單 ID 查看 IPO 訂單的詳細資訊。",
+      "description": "按 order_id 查看 IPO 訂單詳細信息，返回 {order_id, symbol, market, quantity, allotted_quantity, total_amount, status, submitted_at}",
       "properties": {
         "order_id": "IPO 訂單 ID"
       }
     },
     "ipo_profit_loss": {
       "title": "IPO 盈虧",
-      "description": "查看當前帳戶的 IPO 打新盈虧匯總及逐筆明細。period：all（全部，預設）、ytd（今年）、1y（近一年）、3y（近三年）。",
+      "description": "查看帳戶 IPO 打新盈虧彙總及逐筆明細，返回 {total_cost, total_value, total_return, items[]{symbol, cost, current_value, return_rate}}。period：all/ytd/1y/3y",
       "properties": {
         "period": "時間範圍：`all`（全部，預設）、`ytd`（今年）、`1y`（近一年）、`3y`（近三年）",
         "page": "頁碼（預設 1）",
@@ -984,27 +984,49 @@
     },
     "business_segments": {
       "title": "主營業務分部",
-      "description": "取得當期主營業務分部營收佔比快照（各分部名稱、佔比、總營收、貨幣單位）。"
+      "description": "獲取當期主營業務分部營收佔比快照，返回各分部名稱、佔比、總營收及貨幣單位",
+      "properties": {
+        "symbol": "證券代碼，例如 `\"AAPL.US\"`"
+      }
     },
     "business_segments_history": {
       "title": "主營業務分部歷史",
-      "description": "取得主營業務分部營收歷史趨勢，含地區維度。report：qf（季報）、saf（中報）、af（年報）。"
+      "description": "獲取主營業務分部營收歷史趨勢，返回 historical[]{date, total, currency, business[{name, percent, value}], regionals[{name, percent, value}]}",
+      "properties": {
+        "symbol": "證券代碼，例如 `\"AAPL.US\"`",
+        "report": "報告期：`qf`（季報）、`saf`（中報）、`af`（年報）"
+      }
     },
     "institutional_views": {
       "title": "機構觀點月度時序",
-      "description": "取得機構評級月度分佈時序（每月買入/跑贏/持有/跑輸/賣出家數）。"
+      "description": "獲取機構評級月度分佈時序，返回 months[]{date, buy, outperform, hold, underperform, sell, total}，用於評級趨勢分析",
+      "properties": {
+        "symbol": "證券代碼，例如 `\"AAPL.US\"`"
+      }
     },
     "industry_rank": {
       "title": "行業排行榜",
-      "description": "按市場（US/HK/CN/SG）和指標排列行業。indicator：0=領漲 1=今日走勢 2=人氣 3=市值 4=營收 5=營收增長率 6=淨利潤 7=淨利潤增長率。sort_type：0=單級 1=多層。返回 items[]{counter_id(BK/US/IN00258), name, chg, lists[]}，counter_id 可直接傳入 industry_peers。"
+      "description": "按市場（US/HK/CN/SG）和指標排列行業。indicator：0=領漲 1=今日走勢 2=人氣 3=市值 4=營收 5=營收增長率 6=淨利潤 7=淨利潤增長率。sort_type：0=單級 1=多層。返回 items[]{counter_id（如 BK/US/IN00258）, name, chg, lists[]}，counter_id 可直接傳入 industry_peers",
+      "properties": {
+        "market": "市場代碼：US、HK、CN、SG",
+        "indicator": "排列指標：0=領漲、1=今日走勢、2=人氣、3=市值、4=營收、5=營收增長率、6=淨利潤、7=淨利潤增長率",
+        "sort_type": "排序類型：0=單級、1=多層"
+      }
     },
     "industry_peers": {
       "title": "行業同業分組樹",
-      "description": "行業分組的層級同業樹。接受來自 industry_rank 的 BK counter_id（如 BK/US/IN00258）。返回 chain{name,counter_id,stock_num,chg,ytd_chg,next[{...}]} 和 top{name,market}，每個節點包含成分股數量、日漲跌幅和年初至今漲跌幅。"
+      "description": "獲取行業分組的層級同業樹，接受來自 industry_rank 的 BK counter_id（如 BK/US/IN00258），返回 chain{name, counter_id, stock_num, chg, ytd_chg, next[...]} 和 top{name, market}",
+      "properties": {
+        "symbol": "來自 industry_rank 的 BK counter_id，例如 `\"BK/US/IN00258\"`"
+      }
     },
     "financial_report_snapshot": {
       "title": "財報快照",
-      "description": "取得財報快照：report_desc（文字摘要）、fo_revenue/fo_ebit/fo_eps（實際 vs 預期，含同比/超預期描述）、fr_* 財務比率（ROE、利潤率、資產負債、現金流）。report：qf/saf/af。"
+      "description": "獲取財報快照：report_desc（文字摘要）、fo_revenue/fo_ebit/fo_eps（實際 vs 預期，含同比/超預期描述）、fr_* 財務比率（ROE、利潤率、資產負債、現金流）。report：qf/saf/af",
+      "properties": {
+        "symbol": "證券代碼，例如 `\"AAPL.US\"`",
+        "report": "報告期：`qf`（季報）、`saf`（半年報）、`af`（年報）"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Improves all 133 Chinese tool descriptions in zh-CN and zh-HK locale files.

- Average description length: **36 → 90 chars**
- Added return field names in Chinese (最新价, 成交量, 除权日, etc.)
- Added parameter examples and constraints
- zh-HK uses consistent Traditional Chinese (繁體)

## Verification
- `cargo test locales_match_live_tool_schema` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)