### PR TITLE
cli: Add `side` to `today_executions` and `history_executions`

### DIFF
--- a/src/tools/trade.rs
+++ b/src/tools/trade.rs
@@ -202,18 +202,41 @@ pub async fn today_executions(
     mctx: &crate::tools::McpContext,
     p: TodayExecutionsParam,
 ) -> Result<CallToolResult, McpError> {
-    let mut opts = GetTodayExecutionsOptions::new();
-    if let Some(symbol) = p.symbol {
-        opts = opts.symbol(symbol);
+    use std::collections::HashMap;
+
+    let mut exec_opts = GetTodayExecutionsOptions::new();
+    let mut order_opts = GetTodayOrdersOptions::new();
+    if let Some(ref symbol) = p.symbol {
+        exec_opts = exec_opts.symbol(symbol.clone());
+        order_opts = order_opts.symbol(symbol.clone());
     }
     if let Some(order_id) = p.order_id {
-        opts = opts.order_id(order_id);
+        exec_opts = exec_opts.order_id(order_id);
     }
+
     let (ctx, _) = TradeContext::new(mctx.create_config());
-    let result = ctx
-        .today_executions(opts)
-        .await
-        .map_err(Error::longbridge)?;
+    let (executions, orders) = tokio::try_join!(
+        ctx.today_executions(exec_opts),
+        ctx.today_orders(order_opts),
+    )
+    .map_err(Error::longbridge)?;
+
+    let side_map: HashMap<String, String> = orders
+        .into_iter()
+        .map(|o| (o.order_id, format!("{:?}", o.side)))
+        .collect();
+
+    let result: Vec<serde_json::Value> = executions
+        .iter()
+        .map(|e| {
+            let mut v = serde_json::to_value(e).unwrap_or_default();
+            if let serde_json::Value::Object(ref mut map) = v {
+                let side = side_map.get(&e.order_id).cloned().unwrap_or_default();
+                map.insert("side".to_string(), serde_json::Value::String(side));
+            }
+            v
+        })
+        .collect();
     tool_json(&result)
 }
 
@@ -238,19 +261,45 @@ pub async fn history_executions(
     mctx: &crate::tools::McpContext,
     p: HistoryOrdersParam,
 ) -> Result<CallToolResult, McpError> {
+    use std::collections::HashMap;
+
     let start = parse::parse_rfc3339(&p.start_at)?;
     let end = parse::parse_rfc3339(&p.end_at)?;
-    let mut opts = longbridge::trade::GetHistoryExecutionsOptions::new()
+
+    let mut exec_opts = longbridge::trade::GetHistoryExecutionsOptions::new()
         .start_at(start)
         .end_at(end);
-    if let Some(symbol) = p.symbol {
-        opts = opts.symbol(symbol);
+    let mut order_opts = longbridge::trade::GetHistoryOrdersOptions::new()
+        .start_at(start)
+        .end_at(end);
+    if let Some(ref symbol) = p.symbol {
+        exec_opts = exec_opts.symbol(symbol.clone());
+        order_opts = order_opts.symbol(symbol.clone());
     }
+
     let (ctx, _) = TradeContext::new(mctx.create_config());
-    let result = ctx
-        .history_executions(opts)
-        .await
-        .map_err(Error::longbridge)?;
+    let (executions, orders) = tokio::try_join!(
+        ctx.history_executions(exec_opts),
+        ctx.history_orders(order_opts),
+    )
+    .map_err(Error::longbridge)?;
+
+    let side_map: HashMap<String, String> = orders
+        .into_iter()
+        .map(|o| (o.order_id, format!("{:?}", o.side)))
+        .collect();
+
+    let result: Vec<serde_json::Value> = executions
+        .iter()
+        .map(|e| {
+            let mut v = serde_json::to_value(e).unwrap_or_default();
+            if let serde_json::Value::Object(ref mut map) = v {
+                let side = side_map.get(&e.order_id).cloned().unwrap_or_default();
+                map.insert("side".to_string(), serde_json::Value::String(side));
+            }
+            v
+        })
+        .collect();
     tool_json(&result)
 }
 


### PR DESCRIPTION
## Summary

- `today_executions` and `history_executions` now include a `side` field (Buy/Sell) by concurrently fetching the corresponding orders and joining by `order_id`
- `order_detail` already serializes the full SDK struct, so `history` (execution records) is automatically included in the response

## Test plan

- [ ] `today_executions` — verify `side` field appears in the result
- [ ] `history_executions` — verify `side` field appears in the result
- [ ] `order_detail` — verify `history` array is present with status/time/price/quantity/msg

🤖 Generated with [Claude Code](https://claude.com/claude-code)