### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-mcp"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longbridge-mcp"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
   <a href="https://longbridge.com"><img alt="Longbridge" src="https://img.shields.io/badge/brokerage-Longbridge-ffe000?labelColor=000"></a>
 </p>
 
-Official MCP server for the [Longbridge](https://longbridge.com) brokerage. **133 tools** across real-time quotes, options, order routing, fundamentals, analyst ratings, calendars, IPO, price alerts, DCA plans, portfolio analytics and community sharelists — covering **US and HK markets**. Built with Rust using [rmcp](https://github.com/anthropics/rmcp) and [axum](https://github.com/tokio-rs/axum).
+Official MCP server for the [Longbridge](https://longbridge.com) brokerage. **145 tools** across real-time quotes, options, order routing, fundamentals, analyst ratings, calendars, IPO, price alerts, DCA plans, portfolio analytics and community sharelists — covering **US and HK markets**. Built with Rust using [rmcp](https://github.com/anthropics/rmcp) and [axum](https://github.com/tokio-rs/axum).
 
 ## Features
 
-- **133 MCP tools** across 12 categories: quotes, trading, fundamentals, market data, calendars, IPO, portfolio, alerts, content, account statements, DCA, and community sharelists
+- **145 MCP tools** across 13 categories: quotes, trading, fundamentals, screener, market data, calendars, IPO, portfolio, alerts, content, account statements, DCA, and community sharelists
 - **Stateless architecture** -- each request carries a Bearer token forwarded directly to the Longbridge SDK; no server-side sessions or database
 - **OAuth 2.1 resource metadata** compliant with RFC 9728, pointing clients to Longbridge OAuth for authorization
 - **JSON response transformation** -- field names normalized to snake_case, timestamps converted to RFC 3339, internal counter_id values mapped to human-readable symbols

--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.longbridge/mcp",
-  "description": "US/HK markets — 133 tools: quotes, options, orders, fundamentals, IPO, alerts, DCA & portfolio",
-  "version": "0.3.2",
+  "description": "US/HK markets — 145 tools: quotes, options, orders, fundamentals, screener, IPO, alerts, DCA & portfolio",
+  "version": "0.4.0",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.3.2",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.4.0",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",
@@ -92,9 +92,9 @@
         }
       },
       "localizedDescriptions": {
-        "en": "Longbridge — official MCP server for the Longbridge brokerage. 133 tools across real-time quotes, options, order routing, fundamentals, IPO, calendars, alerts, DCA and portfolio analytics for US / HK markets.",
-        "zh-CN": "长桥证券官方 MCP 服务：133 个工具覆盖美股 / 港股的实时行情、期权、下单路由、基本面、IPO 打新、财报日历、价格预警、定投计划与组合分析。",
-        "zh-HK": "長橋證券官方 MCP 伺服器：133 個工具覆蓋美股 / 港股的即時行情、期權、下單路由、基本面、IPO 打新、財報日曆、價格警示、定投計劃與組合分析。"
+        "en": "Longbridge — official MCP server for the Longbridge brokerage. 145 tools across real-time quotes, options, order routing, fundamentals, stock screener, shareholders, short selling, IPO, calendars, alerts, DCA and portfolio analytics for US / HK markets.",
+        "zh-CN": "长桥证券官方 MCP 服务：145 个工具覆盖美股 / 港股的实时行情、期权、下单路由、基本面、选股器、股东持仓、卖空数据、IPO 打新、财报日历、价格预警、定投计划与组合分析。",
+        "zh-HK": "長橋證券官方 MCP 伺服器：145 個工具覆蓋美股 / 港股的即時行情、期權、下單路由、基本面、選股器、股東持倉、賣空數據、IPO 打新、財報日曆、價格警示、定投計劃與組合分析。"
       },
       "icons": [
         {
@@ -138,12 +138,13 @@
           "name": "Hong Kong"
         }
       ],
-      "toolCount": 133,
+      "toolCount": 145,
       "toolCategories": {
         "quote": 32,
-        "fundamental": 19,
+        "fundamental": 22,
         "trade": 14,
-        "market": 10,
+        "market": 14,
+        "screener": 5,
         "dca": 9,
         "ipo": 8,
         "content": 8,


### PR DESCRIPTION
## Summary

Version bump `0.3.2` → `0.4.0` following the merge of #49.

Minor version increment (0.3 → 0.4) reflects the addition of 14 new tools and associated changes.

### Changes
- `Cargo.toml`: `0.3.2` → `0.4.0`
- `server.json`: version, OCI image tag (`ghcr.io/...:0.4.0`), tool count `133 → 145`, category counts updated, localized descriptions updated
- `README.md`: tool count `133 → 145`, category count `12 → 13`, add screener category

### New tool breakdown (133 → 145)

| Category | Before | After | New tools |
|----------|--------|-------|-----------|
| fundamental | 19 | 22 | `shareholder_top`, `shareholder_detail`, `valuation_comparison` |
| market | 10 | 14 | `short_trades`, `top_movers`, `rank_categories`, `rank_list` |
| screener | — | 5 | `screener_recommend_strategies`, `screener_user_strategies`, `screener_strategy`, `screener_search`, `screener_indicators` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)