### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longbridge-mcp"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 
 [build-dependencies]

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.longbridge/mcp",
   "description": "US/HK markets — 145 tools: quotes, options, orders, fundamentals, screener, IPO, alerts, DCA & portfolio",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.4.0",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.4.1",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",


### PR DESCRIPTION
## Improvements

### Stock Screener
- **`screener_recommend_strategies`** / **`screener_user_strategies`**: added `market` param (US/HK/CN/SG, default US)
- **`screener_search`** Mode B: `conditions[]` accepts filter objects `{key, min, max, tech_values}` — tech_values supported for technical indicators (MACD/RSI/KDJ/BOLL)
- **`screener_search`**: every result now includes 7 default columns — `prevclose`, `prevchg`, `marketcap`, `salesgrowthyoy`, `pettm`, `pbmrq`, `industry`
- **`screener_indicators`**: exposes `tech_values` schema per technical indicator (e.g. `macd_day`: category = goldenfork/deadcross/upzero, period = day/week)

🤖 Generated with [Claude Code](https://claude.com/claude-code)