### PR TITLE
chore: bump version to 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-mcp"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longbridge-mcp"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 
 [build-dependencies]

--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -716,7 +716,11 @@
     },
     "short_positions": {
       "title": "做空持仓",
-      "description": "获取港股或美股的卖空持仓历史（未平仓空头头寸）。市场由 symbol 后缀自动判断。count: 1–100（默认20）。统一返回 data[]{timestamp(RFC3339), short_shares(空头持仓股数), rate(小数比率 如0.009=0.9%), close}。仅美股：avg_daily_vol(日均成交量), days_to_cover(回补天数)。仅港股：balance(港元空头余额)。美股来源：FINRA 双周报。港股来源：HKEX 每日。"
+      "description": "获取港股或美股的卖空持仓历史（未平仓空头头寸）。市场由 symbol 后缀自动判断。count: 1–100（默认20）。统一返回 data[]{timestamp(RFC3339), short_shares(空头持仓股数), rate(小数比率 如0.009=0.9%), close}。仅美股：avg_daily_vol(日均成交量), days_to_cover(回补天数)。仅港股：balance(港元空头余额)。美股来源：FINRA 双周报。港股来源：HKEX 每日。",
+      "properties": {
+        "symbol": "证券代码，如 AAPL.US（美股）或 700.HK（港股），市场由后缀自动判断",
+        "count": "返回记录数，1–100，默认 20"
+      }
     },
     "static_info": {
       "title": "证券基础信息",
@@ -1028,19 +1032,34 @@
     },
     "shareholder_top": {
       "title": "Top20 大股东",
-      "description": "获取前20大股东（机构、个人、内部人士）的多期持仓信息。返回 info[]{period, share_holders[]{object_id, name, title, shares_held, percent_shares_held, shares_changed, filing_date}}。用 object_id 传入 shareholder_detail 查看该股东的完整交易记录。"
+      "description": "获取前20大股东（机构、个人、内部人士）的多期持仓信息。返回 info[]{period, share_holders[]{object_id, name, title, shares_held, percent_shares_held, shares_changed, filing_date}}。用 object_id 传入 shareholder_detail 查看该股东的完整交易记录。",
+      "properties": {
+        "symbol": "证券代码，如 AAPL.US"
+      }
     },
     "shareholder_detail": {
       "title": "股东持仓详情",
-      "description": "获取指定股东的持仓历史与交易明细。需要来自 shareholder_top 的 object_id。返回 name, owner_source（Company/Institution/Person/Insider）, tradings[]{period, accum_buy, accum_sell, net_buy, trading_details[]{trading_date, trading_type, trading_shares, trading_price, security_type, filing_date}}, holding_summary, holding_periods, trading_periods。注意：机构股东（13F申报）的 trading_details[] 为空，仅个人/内部人（Form 4）有交易明细。"
+      "description": "获取指定股东的持仓历史与交易明细。需要来自 shareholder_top 的 object_id。返回 name, owner_source（Company/Institution/Person/Insider）, tradings[]{period, accum_buy, accum_sell, net_buy, trading_details[]{trading_date, trading_type, trading_shares, trading_price, security_type, filing_date}}, holding_summary, holding_periods, trading_periods。注意：机构股东（13F申报）的 trading_details[] 为空，仅个人/内部人（Form 4）有交易明细。",
+      "properties": {
+        "symbol": "证券代码，如 AAPL.US",
+        "object_id": "股东 object_id，来自 shareholder_top 返回的数据"
+      }
     },
     "valuation_comparison": {
       "title": "多股股票对比",
-      "description": "股票估值对比。模式A（单股）：只传 symbol，服务端自动返回该股票及同行业推荐对标股。模式B（多股）：传 symbol 作为主股 + comparison_symbols（逗号分隔，如 'MSFT.US,GOOGL.US'）进行指定股票对比。currency: USD/HKD/CNY。返回 list[]{symbol, name, market_value, price_close, pe, pb, ps, history[]{date, pe, pb, ps}}。"
+      "description": "股票估值对比。模式A（单股）：只传 symbol，服务端自动返回该股票及同行业推荐对标股。模式B（多股）：传 symbol 作为主股 + comparison_symbols（逗号分隔，如 'MSFT.US,GOOGL.US'）进行指定股票对比。currency: USD/HKD/CNY。返回 list[]{symbol, name, market_value, price_close, pe, pb, ps, history[]{date, pe, pb, ps}}。",
+      "properties": {
+        "symbol": "要比较的证券代码，如 AAPL.US",
+        "currency": "货币单位：USD/HKD/CNY",
+        "comparison_symbols": "对比标的，逗号分隔，最多 4 个，如 MSFT.US,GOOGL.US"
+      }
     },
     "screener_strategy": {
       "title": "策略详情",
-      "description": "运行前查看策略的过滤条件详情。返回 market, filter{filters[]{key, min, max, tech_values}}。如需直接执行策略，使用 screener_search 的 strategy_id 参数。"
+      "description": "运行前查看策略的过滤条件详情。返回 market, filter{filters[]{key, min, max, tech_values}}。如需直接执行策略，使用 screener_search 的 strategy_id 参数。",
+      "properties": {
+        "id": "策略 ID，来自 screener_recommend_strategies 或 screener_user_strategies 的 screeners[].id"
+      }
     },
     "screener_search": {
       "title": "策略选股",
@@ -1051,7 +1070,10 @@
     },
     "screener_indicators": {
       "title": "选股指标配置",
-      "description": "获取全部可用选股指标的 key、单位和默认值域。技术指标（MACD/RSI/KDJ/BOLL）含 tech_values 字段，列出可选参数值（如 macd_day 的 category: goldenfork/deadcross/upzero）。可选 symbol（如 AAPL.US）过滤特定股票的指标。返回 groups[]{group_name, indicators[]{id, key, name, unit, default_range{min,max}, tech_values?{param:[{value,label},...]}}}。"
+      "description": "获取全部可用选股指标的 key、单位和默认值域。技术指标（MACD/RSI/KDJ/BOLL）含 tech_values 字段，列出可选参数值（如 macd_day 的 category: goldenfork/deadcross/upzero）。可选 symbol（如 AAPL.US）过滤特定股票的指标。返回 groups[]{group_name, indicators[]{id, key, name, unit, default_range{min,max}, tech_values?{param:[{value,label},...]}}}。",
+      "properties": {
+        "symbol": "可选证券代码，用于筛选该股票支持的指标，如 AAPL.US"
+      }
     },
     "screener_recommend_strategies": {
       "title": "平台预设选股策略",
@@ -1059,11 +1081,21 @@
     },
     "screener_user_strategies": {
       "title": "我的选股策略",
-      "description": "获取当前用户已保存的选股策略列表。market: US|HK|CN|SG（默认 US）。返回 strategys[]{id, name, description, market, three_months_chg, risk}。将 id 传入 screener_search 的 strategy_id 可直接运行该策略；传入 screener_strategy 可查看策略的过滤条件。"
+      "description": "获取当前用户已保存的选股策略列表。market: US|HK|CN|SG（默认 US）。返回 strategys[]{id, name, description, market, three_months_chg, risk}。将 id 传入 screener_search 的 strategy_id 可直接运行该策略；传入 screener_strategy 可查看策略的过滤条件。",
+      "properties": {
+        "market": "市场筛选：US/HK/CN/SG，默认 US"
+      }
     },
     "top_movers": {
       "title": "热股异动",
-      "description": "获取价格波动超过近20日标准差的异动股票及关联新闻原因。markets: 逗号分隔的 HK/US/CN/SG（不传 = 全市场）。sort: 0=时间 1=涨跌幅 2=热度（默认）。limit: 每页数量（默认20）。next_params: 分页游标，传上一次返回的 next_params 对象。返回 events[]{timestamp(RFC3339), alert_reason, alert_type, stock{symbol, name, change(小数如0.0445=+4.45%), last_done, labels[], intro}}, updated_at, next_params。"
+      "description": "获取价格波动超过近20日标准差的异动股票及关联新闻原因。markets: 逗号分隔的 HK/US/CN/SG（不传 = 全市场）。sort: 0=时间 1=涨跌幅 2=热度（默认）。limit: 每页数量（默认20）。next_params: 分页游标，传上一次返回的 next_params 对象。返回 events[]{timestamp(RFC3339), alert_reason, alert_type, stock{symbol, name, change(小数如0.0445=+4.45%), last_done, labels[], intro}}, updated_at, next_params。",
+      "properties": {
+        "markets": "市场筛选，逗号分隔，支持 HK/US/CN/SG，不传返回全市场",
+        "sort": "排序方式：0=按时间（最新优先）1=按涨跌幅（幅度最大优先）2=按热度（默认）",
+        "date": "查询日期，格式 YYYY-MM-DD，不传默认今日",
+        "limit": "每页返回数量，默认 20，最多 100",
+        "next_params": "翻页游标，将上一次响应的 next_params 原样传入即可获取下一页，首页不传"
+      }
     },
     "rank_categories": {
       "title": "热度榜分类配置",
@@ -1071,11 +1103,22 @@
     },
     "rank_list": {
       "title": "热度榜股票列表",
-      "description": "按热度榜 key 获取股票排名列表。key 来自 rank_categories 的 second_tags[].key（如 hot_all-us、hot_up-hk、trade_heat-us）。market: 从 key 后缀推断或显式传入。size: 返回数量（默认 20）。返回 lists[]{symbol, name, last_done, chg(小数), inflow, market_cap, pre_post_price, pre_post_chg, amplitude, turnover_rate, volume_rate, five_day_chg, ten_day_chg, twenty_day_chg, this_year_chg, industry, intro}, updated_at。"
+      "description": "按热度榜 key 获取股票排名列表。key 来自 rank_categories 的 second_tags[].key（如 hot_all-us、hot_up-hk、trade_heat-us）。market: 从 key 后缀推断或显式传入。size: 返回数量（默认 20）。返回 lists[]{symbol, name, last_done, chg(小数), inflow, market_cap, pre_post_price, pre_post_chg, amplitude, turnover_rate, volume_rate, five_day_chg, ten_day_chg, twenty_day_chg, this_year_chg, industry, intro}, updated_at。",
+      "properties": {
+        "key": "榜单 key，来自 rank_categories 的 second_tags[].key，如 hot_all-us、hot_up-hk",
+        "market": "市场覆盖：US/HK/CN/SG，默认从 key 后缀推断",
+        "size": "返回数量，默认 20",
+        "need_article": "是否返回关联新闻，默认 false"
+      }
     },
     "short_trades": {
       "title": "做空成交",
-      "description": "获取港股或美股的每日卖空成交量历史。市场由 symbol 后缀自动判断。last_timestamp: Unix 秒（不传则取最新）。page_size: 1–100（默认20）。统一返回 data[]{timestamp(RFC3339), short_vol(当日卖空股数), rate(小数比率 如0.36=36%), close}。仅美股：nasdaq_vol(纳斯达克卖空量), nyse_vol(纽交所卖空量)。仅港股：balance(港元), market_vol(当日市场总成交量)。美股来源：FINRA/NASDAQ。港股来源：HKEX。"
+      "description": "获取港股或美股的每日卖空成交量历史。市场由 symbol 后缀自动判断。last_timestamp: Unix 秒（不传则取最新）。page_size: 1–100（默认20）。统一返回 data[]{timestamp(RFC3339), short_vol(当日卖空股数), rate(小数比率 如0.36=36%), close}。仅美股：nasdaq_vol(纳斯达克卖空量), nyse_vol(纽交所卖空量)。仅港股：balance(港元), market_vol(当日市场总成交量)。美股来源：FINRA/NASDAQ。港股来源：HKEX。",
+      "properties": {
+        "symbol": "证券代码，如 AAPL.US（美股）或 700.HK（港股），市场由后缀自动判断",
+        "last_timestamp": "查询截止时间戳（秒），传当前时间戳获取最新数据",
+        "page_size": "每页数量，1–100，默认 20"
+      }
     }
   }
 }

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -716,7 +716,11 @@
     },
     "short_positions": {
       "title": "做空持倉",
-      "description": "獲取港股或美股的賣空持倉歷史（未平倉空頭頭寸）。市場由 symbol 後綴自動判斷。count: 1–100（預設20）。統一返回 data[]{timestamp(RFC3339), short_shares(空頭持倉股數), rate(小數比率 如0.009=0.9%), close}。僅美股：avg_daily_vol(日均成交量), days_to_cover(回補天數)。僅港股：balance(港元空頭餘額)。美股來源：FINRA 雙週報。港股來源：HKEX 每日。"
+      "description": "獲取港股或美股的賣空持倉歷史（未平倉空頭頭寸）。市場由 symbol 後綴自動判斷。count: 1–100（預設20）。統一返回 data[]{timestamp(RFC3339), short_shares(空頭持倉股數), rate(小數比率 如0.009=0.9%), close}。僅美股：avg_daily_vol(日均成交量), days_to_cover(回補天數)。僅港股：balance(港元空頭餘額)。美股來源：FINRA 雙週報。港股來源：HKEX 每日。",
+      "properties": {
+        "symbol": "證券代碼，如 AAPL.US（美股）或 700.HK（港股），市場由後綴自動判斷",
+        "count": "返回記錄數，1–100，預設 20"
+      }
     },
     "static_info": {
       "title": "證券基礎信息",
@@ -1028,19 +1032,34 @@
     },
     "shareholder_top": {
       "title": "Top20 大股東",
-      "description": "獲取前20大股東（機構、個人、內部人士）的多期持倉資訊。返回 info[]{period, share_holders[]{object_id, name, title, shares_held, percent_shares_held, shares_changed, filing_date}}。用 object_id 傳入 shareholder_detail 查看該股東的完整交易記錄。"
+      "description": "獲取前20大股東（機構、個人、內部人士）的多期持倉資訊。返回 info[]{period, share_holders[]{object_id, name, title, shares_held, percent_shares_held, shares_changed, filing_date}}。用 object_id 傳入 shareholder_detail 查看該股東的完整交易記錄。",
+      "properties": {
+        "symbol": "證券代碼，如 AAPL.US"
+      }
     },
     "shareholder_detail": {
       "title": "股東持倉詳情",
-      "description": "獲取指定股東的持倉歷史與交易明細。需要來自 shareholder_top 的 object_id。返回 name, owner_source（Company/Institution/Person/Insider）, tradings[]{period, accum_buy, accum_sell, net_buy, trading_details[]{trading_date, trading_type, trading_shares, trading_price, security_type, filing_date}}, holding_summary, holding_periods, trading_periods。注意：機構股東（13F申報）的 trading_details[] 為空，僅個人/內部人（Form 4）有交易明細。"
+      "description": "獲取指定股東的持倉歷史與交易明細。需要來自 shareholder_top 的 object_id。返回 name, owner_source（Company/Institution/Person/Insider）, tradings[]{period, accum_buy, accum_sell, net_buy, trading_details[]{trading_date, trading_type, trading_shares, trading_price, security_type, filing_date}}, holding_summary, holding_periods, trading_periods。注意：機構股東（13F申報）的 trading_details[] 為空，僅個人/內部人（Form 4）有交易明細。",
+      "properties": {
+        "symbol": "證券代碼，如 AAPL.US",
+        "object_id": "股東 object_id，來自 shareholder_top 返回的數據"
+      }
     },
     "valuation_comparison": {
       "title": "多股股票對比",
-      "description": "股票估值對比。模式A（單股）：只傳 symbol，服務端自動返回該股票及同行業推薦對標股。模式B（多股）：傳 symbol 作為主股 + comparison_symbols（逗號分隔，如 'MSFT.US,GOOGL.US'）進行指定股票對比。currency: USD/HKD/CNY。返回 list[]{symbol, name, market_value, price_close, pe, pb, ps, history[]{date, pe, pb, ps}}。"
+      "description": "股票估值對比。模式A（單股）：只傳 symbol，服務端自動返回該股票及同行業推薦對標股。模式B（多股）：傳 symbol 作為主股 + comparison_symbols（逗號分隔，如 'MSFT.US,GOOGL.US'）進行指定股票對比。currency: USD/HKD/CNY。返回 list[]{symbol, name, market_value, price_close, pe, pb, ps, history[]{date, pe, pb, ps}}。",
+      "properties": {
+        "symbol": "要比較的證券代碼，如 AAPL.US",
+        "currency": "貨幣單位：USD/HKD/CNY",
+        "comparison_symbols": "對比標的，逗號分隔，最多 4 個，如 MSFT.US,GOOGL.US"
+      }
     },
     "screener_strategy": {
       "title": "策略詳情",
-      "description": "執行前查看策略的篩選條件詳情。返回 market, filter{filters[]{key, min, max, tech_values}}。如需直接執行策略，使用 screener_search 的 strategy_id 參數。"
+      "description": "執行前查看策略的篩選條件詳情。返回 market, filter{filters[]{key, min, max, tech_values}}。如需直接執行策略，使用 screener_search 的 strategy_id 參數。",
+      "properties": {
+        "id": "策略 ID，來自 screener_recommend_strategies 或 screener_user_strategies 的 screeners[].id"
+      }
     },
     "screener_search": {
       "title": "策略選股",
@@ -1051,7 +1070,10 @@
     },
     "screener_indicators": {
       "title": "選股指標配置",
-      "description": "獲取全部可用選股指標的 key、單位和預設值域。技術指標（MACD/RSI/KDJ/BOLL）含 tech_values 欄位，列出可選參數值（如 macd_day 的 category: goldenfork/deadcross/upzero）。可選 symbol（如 AAPL.US）過濾特定股票的指標。返回 groups[]{group_name, indicators[]{id, key, name, unit, default_range{min,max}, tech_values?{param:[{value,label},...]}}}。"
+      "description": "獲取全部可用選股指標的 key、單位和預設值域。技術指標（MACD/RSI/KDJ/BOLL）含 tech_values 欄位，列出可選參數值（如 macd_day 的 category: goldenfork/deadcross/upzero）。可選 symbol（如 AAPL.US）過濾特定股票的指標。返回 groups[]{group_name, indicators[]{id, key, name, unit, default_range{min,max}, tech_values?{param:[{value,label},...]}}}。",
+      "properties": {
+        "symbol": "可選證券代碼，用於篩選該股票支援的指標，如 AAPL.US"
+      }
     },
     "screener_recommend_strategies": {
       "title": "平台預設選股策略",
@@ -1059,11 +1081,21 @@
     },
     "screener_user_strategies": {
       "title": "我的選股策略",
-      "description": "獲取當前用戶已儲存的選股策略列表。market: US|HK|CN|SG（預設 US）。返回 strategys[]{id, name, description, market, three_months_chg, risk}。將 id 傳入 screener_search 的 strategy_id 可直接執行該策略；傳入 screener_strategy 可查看策略的篩選條件。"
+      "description": "獲取當前用戶已儲存的選股策略列表。market: US|HK|CN|SG（預設 US）。返回 strategys[]{id, name, description, market, three_months_chg, risk}。將 id 傳入 screener_search 的 strategy_id 可直接執行該策略；傳入 screener_strategy 可查看策略的篩選條件。",
+      "properties": {
+        "market": "市場篩選：US/HK/CN/SG，預設 US"
+      }
     },
     "top_movers": {
       "title": "熱股異動",
-      "description": "獲取價格波動超過近20日標準差的異動股票及關聯新聞原因。markets: 逗號分隔的 HK/US/CN/SG（不傳 = 全市場）。sort: 0=時間 1=漲跌幅 2=熱度（預設）。limit: 每頁數量（預設20）。next_params: 分頁游標，傳上一次返回的 next_params 物件。返回 events[]{timestamp(RFC3339), alert_reason, alert_type, stock{symbol, name, change(小數如0.0445=+4.45%), last_done, labels[], intro}}, updated_at, next_params。"
+      "description": "獲取價格波動超過近20日標準差的異動股票及關聯新聞原因。markets: 逗號分隔的 HK/US/CN/SG（不傳 = 全市場）。sort: 0=時間 1=漲跌幅 2=熱度（預設）。limit: 每頁數量（預設20）。next_params: 分頁游標，傳上一次返回的 next_params 物件。返回 events[]{timestamp(RFC3339), alert_reason, alert_type, stock{symbol, name, change(小數如0.0445=+4.45%), last_done, labels[], intro}}, updated_at, next_params。",
+      "properties": {
+        "markets": "市場篩選，逗號分隔，支援 HK/US/CN/SG，不傳返回全市場",
+        "sort": "排序方式：0=按時間（最新優先）1=按漲跌幅（幅度最大優先）2=按熱度（預設）",
+        "date": "查詢日期，格式 YYYY-MM-DD，不傳預設今日",
+        "limit": "每頁返回數量，預設 20，最多 100",
+        "next_params": "翻頁游標，將上一次回應的 next_params 原樣傳入即可取得下一頁，首頁不傳"
+      }
     },
     "rank_categories": {
       "title": "熱度榜分類配置",
@@ -1071,11 +1103,22 @@
     },
     "rank_list": {
       "title": "熱度榜股票列表",
-      "description": "按熱度榜 key 獲取股票排名列表。key 來自 rank_categories 的 second_tags[].key（如 hot_all-us、hot_up-hk、trade_heat-us）。market: 從 key 後綴推斷或顯式傳入。size: 返回數量（預設 20）。返回 lists[]{symbol, name, last_done, chg(小數), inflow, market_cap, pre_post_price, pre_post_chg, amplitude, turnover_rate, volume_rate, five_day_chg, ten_day_chg, twenty_day_chg, this_year_chg, industry, intro}, updated_at。"
+      "description": "按熱度榜 key 獲取股票排名列表。key 來自 rank_categories 的 second_tags[].key（如 hot_all-us、hot_up-hk、trade_heat-us）。market: 從 key 後綴推斷或顯式傳入。size: 返回數量（預設 20）。返回 lists[]{symbol, name, last_done, chg(小數), inflow, market_cap, pre_post_price, pre_post_chg, amplitude, turnover_rate, volume_rate, five_day_chg, ten_day_chg, twenty_day_chg, this_year_chg, industry, intro}, updated_at。",
+      "properties": {
+        "key": "榜單 key，來自 rank_categories 的 second_tags[].key，如 hot_all-us、hot_up-hk",
+        "market": "市場覆蓋：US/HK/CN/SG，預設從 key 後綴推斷",
+        "size": "返回數量，預設 20",
+        "need_article": "是否返回關聯新聞，預設 false"
+      }
     },
     "short_trades": {
       "title": "做空成交",
-      "description": "獲取港股或美股的每日賣空成交量歷史。市場由 symbol 後綴自動判斷。last_timestamp: Unix 秒（不傳則取最新）。page_size: 1–100（預設20）。統一返回 data[]{timestamp(RFC3339), short_vol(當日賣空股數), rate(小數比率 如0.36=36%), close}。僅美股：nasdaq_vol(納斯達克賣空量), nyse_vol(紐交所賣空量)。僅港股：balance(港元), market_vol(當日市場總成交量)。美股來源：FINRA/NASDAQ。港股來源：HKEX。"
+      "description": "獲取港股或美股的每日賣空成交量歷史。市場由 symbol 後綴自動判斷。last_timestamp: Unix 秒（不傳則取最新）。page_size: 1–100（預設20）。統一返回 data[]{timestamp(RFC3339), short_vol(當日賣空股數), rate(小數比率 如0.36=36%), close}。僅美股：nasdaq_vol(納斯達克賣空量), nyse_vol(紐交所賣空量)。僅港股：balance(港元), market_vol(當日市場總成交量)。美股來源：FINRA/NASDAQ。港股來源：HKEX。",
+      "properties": {
+        "symbol": "證券代碼，如 AAPL.US（美股）或 700.HK（港股），市場由後綴自動判斷",
+        "last_timestamp": "查詢截止時間戳（秒），傳當前時間戳取得最新數據",
+        "page_size": "每頁數量，1–100，預設 20"
+      }
     }
   }
 }

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.longbridge/mcp",
   "description": "US/HK markets — 145 tools: quotes, options, orders, fundamentals, screener, IPO, alerts, DCA & portfolio",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.4.2",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.4.3",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -389,6 +389,15 @@ pub struct TopMoversNextParams {
     pub visited: Vec<String>,
 }
 
+fn next_params_schema(_: &mut rmcp::schemars::SchemaGenerator) -> rmcp::schemars::Schema {
+    rmcp::schemars::json_schema!({
+        "description": "Pagination cursor from the previous response. Pass the entire next_params object back verbatim to fetch the next page.",
+        "type": "object",
+        "properties": {},
+        "additionalProperties": true
+    })
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct StockEventsParam {
     /// Market filter: comma-separated list of markets to include.
@@ -407,6 +416,8 @@ pub struct StockEventsParam {
     /// Pagination cursor from previous response next_params field.
     /// Pass the entire next_params object returned by the previous call to get the next page.
     /// Omit for the first page.
+    #[serde(default)]
+    #[schemars(schema_with = "next_params_schema")]
     pub next_params: Option<TopMoversNextParams>,
 }
 


### PR DESCRIPTION
## Summary
- Bump version from 0.4.2 to 0.4.3 in `Cargo.toml` and `server.json`
- Fix `top_movers` `next_params` schema: replace `$ref`/`anyOf` with an inline open-object (`type: object, additionalProperties: true`)
- Add Chinese parameter descriptions (`properties`) for 9 tools that were missing them in `zh-CN` and `zh-HK` locales: `rank_list`, `screener_indicators`, `screener_strategy`, `screener_user_strategies`, `shareholder_detail`, `shareholder_top`, `short_positions`, `short_trades`, `valuation_comparison`

🤖 Generated with [Claude Code](https://claude.com/claude-code)