### PR TITLE
fix(tools): anomaly missing size param returns empty results

### DIFF
--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -318,9 +318,11 @@
     },
     "anomaly": {
       "title": "市场异动",
-      "description": "获取市场异动提醒（价量异常变动），返回 items[]{symbol, name, anomaly_type, change_rate, volume, timestamp}",
+      "description": "获取市场异动提醒（价量异常变动）。market: HK/US/CN/SG。symbol: 可选，筛选特定股票。count: 返回数量（默认 50，最多 100）。返回 changes[]{symbol, name, change_rate, volume, ...}, all_off。",
       "properties": {
-        "market": "市场代码：HK、US、CN、SG"
+        "market": "市场代码：HK、US、CN、SG",
+        "symbol": "可选证券代码，如 AAPL.US 或 700.HK，筛选特定股票的异动",
+        "count": "返回数量，默认 50，最多 100"
       }
     },
     "broker_holding": {

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -318,9 +318,11 @@
     },
     "anomaly": {
       "title": "市場異動",
-      "description": "獲取市場異動提醒（價量異常變動），返回 items[]{symbol, name, anomaly_type, change_rate, volume, timestamp}",
+      "description": "獲取市場異動提醒（價量異常變動）。market: HK/US/CN/SG。symbol: 可選，篩選特定股票。count: 返回數量（預設 50，最多 100）。返回 changes[]{symbol, name, change_rate, volume, ...}, all_off。",
       "properties": {
-        "market": "市場代碼：HK、US、CN、SG"
+        "market": "市場代碼：HK、US、CN、SG",
+        "symbol": "可選證券代碼，如 AAPL.US 或 700.HK，篩選特定股票的異動",
+        "count": "返回數量，預設 50，最多 100"
       }
     },
     "broker_holding": {

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -23,6 +23,16 @@ pub struct MarketParam {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct AnomalyParam {
+    /// Market code: HK, US, CN, SG
+    pub market: String,
+    /// Filter to a specific symbol, e.g. "700.HK" or "AAPL.US"
+    pub symbol: Option<String>,
+    /// Number of results to return (default: 50, max: 100)
+    pub count: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct BrokerHoldingDailyParam {
     /// Security symbol, e.g. "700.HK"
     pub symbol: String,
@@ -205,16 +215,22 @@ pub async fn trade_stats(
 
 pub async fn anomaly(
     mctx: &crate::tools::McpContext,
-    p: MarketParam,
+    p: AnomalyParam,
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let market_upper = p.market.to_uppercase();
-    http_get_tool(
-        &client,
-        "/v1/quote/changes",
-        &[("market", market_upper.as_str()), ("category", "0")],
-    )
-    .await
+    let count = p.count.unwrap_or(50).min(100).to_string();
+    let mut params: Vec<(&str, &str)> = vec![
+        ("category", "0"),
+        ("size", count.as_str()),
+        ("market", market_upper.as_str()),
+    ];
+    let cid;
+    if let Some(ref sym) = p.symbol {
+        cid = symbol_to_counter_id(sym);
+        params.push(("counter_id", cid.as_str()));
+    }
+    http_get_tool(&client, "/v1/quote/changes", &params).await
 }
 
 pub async fn constituent(

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1379,12 +1379,12 @@ impl Longbridge {
     #[tool(
         title = "Market Anomaly",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
-        description = "Get market anomaly alerts (unusual price/volume changes). Returns items[]{symbol, name, anomaly_type, change_rate, volume, timestamp} for the given market."
+        description = "Get market anomaly alerts (unusual price/volume changes). market: HK/US/CN/SG. symbol: optional, filter to a specific stock. count: results per page (default 50, max 100). Returns changes[]{symbol, name, change_rate, volume, ...}, all_off."
     )]
     async fn anomaly(
         &self,
         ctx: RequestContext<RoleServer>,
-        Parameters(p): Parameters<market::MarketParam>,
+        Parameters(p): Parameters<market::AnomalyParam>,
     ) -> Result<CallToolResult, McpError> {
         let mctx = extract_context(&ctx)?;
         measured_tool_call("anomaly", || market::anomaly(&mctx, p)).await


### PR DESCRIPTION
## Root Cause

`/v1/quote/changes` requires a `size` parameter to return results. The MCP implementation only sent `market` and `category=0`, omitting `size` entirely — causing the backend to return `{"changes":[], "all_off":false}` for all markets.

The CLI (`longbridge anomaly --market US`) works because it explicitly sends `size=50`.

## Changes

- Add `size` param (default 50, max 100) to match CLI behaviour
- Add optional `symbol` → `counter_id` support for per-stock filtering
- Fix description: `changes[]` not `items[]`
- Update zh-CN / zh-HK locale parameter descriptions

## Test plan
- [ ] `anomaly(market="US")` returns non-empty `changes[]`
- [ ] `anomaly(market="HK")` returns non-empty `changes[]`
- [ ] `anomaly(market="US", symbol="AAPL.US")` filters by stock
- [ ] `anomaly(market="US", count=10)` limits results

🤖 Generated with [Claude Code](https://claude.com/claude-code)