### PR TITLE
fix(schema+tools): strip null types & fix anomaly size param

### DIFF
--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -318,9 +318,11 @@
     },
     "anomaly": {
       "title": "市场异动",
-      "description": "获取市场异动提醒（价量异常变动），返回 items[]{symbol, name, anomaly_type, change_rate, volume, timestamp}",
+      "description": "获取市场异动提醒（价量异常变动）。market: HK/US/CN/SG。symbol: 可选，筛选特定股票。count: 返回数量（默认 50，最多 100）。返回 changes[]{symbol, name, change_rate, volume, ...}, all_off。",
       "properties": {
-        "market": "市场代码：HK、US、CN、SG"
+        "market": "市场代码：HK、US、CN、SG",
+        "symbol": "可选证券代码，如 AAPL.US 或 700.HK，筛选特定股票的异动",
+        "count": "返回数量，默认 50，最多 100"
       }
     },
     "broker_holding": {

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -318,9 +318,11 @@
     },
     "anomaly": {
       "title": "市場異動",
-      "description": "獲取市場異動提醒（價量異常變動），返回 items[]{symbol, name, anomaly_type, change_rate, volume, timestamp}",
+      "description": "獲取市場異動提醒（價量異常變動）。market: HK/US/CN/SG。symbol: 可選，篩選特定股票。count: 返回數量（預設 50，最多 100）。返回 changes[]{symbol, name, change_rate, volume, ...}, all_off。",
       "properties": {
-        "market": "市場代碼：HK、US、CN、SG"
+        "market": "市場代碼：HK、US、CN、SG",
+        "symbol": "可選證券代碼，如 AAPL.US 或 700.HK，篩選特定股票的異動",
+        "count": "返回數量，預設 50，最多 100"
       }
     },
     "broker_holding": {

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -23,6 +23,16 @@ pub struct MarketParam {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct AnomalyParam {
+    /// Market code: HK, US, CN, SG
+    pub market: String,
+    /// Filter to a specific symbol, e.g. "700.HK" or "AAPL.US"
+    pub symbol: Option<String>,
+    /// Number of results to return (default: 50, max: 100)
+    pub count: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct BrokerHoldingDailyParam {
     /// Security symbol, e.g. "700.HK"
     pub symbol: String,
@@ -205,16 +215,22 @@ pub async fn trade_stats(
 
 pub async fn anomaly(
     mctx: &crate::tools::McpContext,
-    p: MarketParam,
+    p: AnomalyParam,
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let market_upper = p.market.to_uppercase();
-    http_get_tool(
-        &client,
-        "/v1/quote/changes",
-        &[("market", market_upper.as_str()), ("category", "0")],
-    )
-    .await
+    let count = p.count.unwrap_or(50).min(100).to_string();
+    let mut params: Vec<(&str, &str)> = vec![
+        ("category", "0"),
+        ("size", count.as_str()),
+        ("market", market_upper.as_str()),
+    ];
+    let cid;
+    if let Some(ref sym) = p.symbol {
+        cid = symbol_to_counter_id(sym);
+        params.push(("counter_id", cid.as_str()));
+    }
+    http_get_tool(&client, "/v1/quote/changes", &params).await
 }
 
 pub async fn constituent(

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -17,12 +17,6 @@ pub struct SymbolParam {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct MarketParam {
-    /// Market code: HK, US, CN, SG
-    pub market: String,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
 pub struct AnomalyParam {
     /// Market code: HK, US, CN, SG
     pub market: String,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -268,8 +268,7 @@ fn strip_null_from_type_arrays(value: &mut serde_json::Value) {
                     .cloned()
                     .collect();
                 if filtered.len() == 1 {
-                    *map.get_mut("type").unwrap() =
-                        filtered.into_iter().next().unwrap();
+                    *map.get_mut("type").unwrap() = filtered.into_iter().next().unwrap();
                 } else if filtered.len() < types.len() {
                     *types = filtered;
                 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -236,8 +236,56 @@ fn extract_context(ctx: &RequestContext<RoleServer>) -> Result<McpContext, McpEr
 }
 
 /// Returns all registered MCP tools sorted by name.
+///
+/// Input schemas are post-processed to remove `null` from `type` arrays so that
+/// optional parameters are represented as plain scalar types (e.g. `"type": "string"`
+/// instead of `"type": ["string", "null"]`).  Optionality is already expressed by
+/// the field being absent from the `required` array, which is the MCP convention.
 pub fn list_tools() -> Vec<rmcp::model::Tool> {
-    Longbridge::tool_router().list_all()
+    Longbridge::tool_router()
+        .list_all()
+        .into_iter()
+        .map(|mut tool| {
+            let mut schema = serde_json::Value::Object((*tool.input_schema).clone());
+            strip_null_from_type_arrays(&mut schema);
+            if let serde_json::Value::Object(obj) = schema {
+                tool.input_schema = std::sync::Arc::new(obj);
+            }
+            tool
+        })
+        .collect()
+}
+
+/// Recursively remove `"null"` from JSON Schema `type` arrays.
+/// When the array is left with a single element it is unwrapped to a plain string.
+fn strip_null_from_type_arrays(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(type_val) = map.get_mut("type") {
+                if let serde_json::Value::Array(types) = type_val {
+                    let filtered: Vec<serde_json::Value> = types
+                        .iter()
+                        .filter(|t| t.as_str() != Some("null"))
+                        .cloned()
+                        .collect();
+                    if filtered.len() == 1 {
+                        *type_val = filtered.into_iter().next().unwrap();
+                    } else if filtered.len() < types.len() {
+                        *types = filtered;
+                    }
+                }
+            }
+            for v in map.values_mut() {
+                strip_null_from_type_arrays(v);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                strip_null_from_type_arrays(v);
+            }
+        }
+        _ => {}
+    }
 }
 
 use crate::tools::quote::{
@@ -2648,7 +2696,18 @@ impl Longbridge {
     name = "longbridge-mcp",
     instructions = "Longbridge OpenAPI MCP Server - provides market data, trading, and financial analysis tools"
 )]
-impl ServerHandler for Longbridge {}
+impl ServerHandler for Longbridge {
+    async fn list_tools(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<rmcp::model::ListToolsResult, rmcp::ErrorData> {
+        Ok(rmcp::model::ListToolsResult {
+            tools: list_tools(),
+            ..Default::default()
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -261,18 +261,17 @@ pub fn list_tools() -> Vec<rmcp::model::Tool> {
 fn strip_null_from_type_arrays(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::Object(map) => {
-            if let Some(type_val) = map.get_mut("type") {
-                if let serde_json::Value::Array(types) = type_val {
-                    let filtered: Vec<serde_json::Value> = types
-                        .iter()
-                        .filter(|t| t.as_str() != Some("null"))
-                        .cloned()
-                        .collect();
-                    if filtered.len() == 1 {
-                        *type_val = filtered.into_iter().next().unwrap();
-                    } else if filtered.len() < types.len() {
-                        *types = filtered;
-                    }
+            if let Some(serde_json::Value::Array(types)) = map.get_mut("type") {
+                let filtered: Vec<serde_json::Value> = types
+                    .iter()
+                    .filter(|t| t.as_str() != Some("null"))
+                    .cloned()
+                    .collect();
+                if filtered.len() == 1 {
+                    *map.get_mut("type").unwrap() =
+                        filtered.into_iter().next().unwrap();
+                } else if filtered.len() < types.len() {
+                    *types = filtered;
                 }
             }
             for v in map.values_mut() {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1427,12 +1427,12 @@ impl Longbridge {
     #[tool(
         title = "Market Anomaly",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
-        description = "Get market anomaly alerts (unusual price/volume changes). Returns items[]{symbol, name, anomaly_type, change_rate, volume, timestamp} for the given market."
+        description = "Get market anomaly alerts (unusual price/volume changes). market: HK/US/CN/SG. symbol: optional, filter to a specific stock. count: results per page (default 50, max 100). Returns changes[]{symbol, name, change_rate, volume, ...}, all_off."
     )]
     async fn anomaly(
         &self,
         ctx: RequestContext<RoleServer>,
-        Parameters(p): Parameters<market::MarketParam>,
+        Parameters(p): Parameters<market::AnomalyParam>,
     ) -> Result<CallToolResult, McpError> {
         let mctx = extract_context(&ctx)?;
         measured_tool_call("anomaly", || market::anomaly(&mctx, p)).await


### PR DESCRIPTION
Combines #61 and #62 with CI fixes.

## Changes

### fix(schema): strip null from input schema type arrays
schemars generates `["string", "null"]` for `Option<T>` fields. MCP convention expresses optionality via absence from `required`, not nullable types. Post-process all tool `inputSchema`s to convert `["string","null"]` → `"string"` etc. Override `ServerHandler::list_tools()` so both the MCP protocol path and `/mcp/tools.json` go through the same transform.

### fix(tools): anomaly missing size param returns empty results
`/v1/quote/changes` requires a `size` parameter to return data. The MCP implementation only sent `market` and `category=0`, omitting `size` — causing the backend to always return `{"changes":[]}`. Default `size=50` (max 100), matching the CLI. Also adds optional `symbol` filtering and corrects the description (`changes[]` not `items[]`).

### fix: clippy
- Collapse nested `if let` in `strip_null_from_type_arrays` (collapsible_if)
- Remove unused `MarketParam` from `market.rs` (replaced by `AnomalyParam`)

## Closes
- #61
- #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)