### PR TITLE
fix(server): support both /mcp and root path; dynamic resource URL from Host header

### DIFF
--- a/data/scopes.json
+++ b/data/scopes.json
@@ -3,6 +3,7 @@
     {
       "id": "0",
       "name": "General",
+      "key": "",
       "description": "General-purpose tools covering market data, quotes, fundamentals, alerts, DCA, sharelists, IPO, and content.",
       "tools": [
         "ah_premium",
@@ -117,6 +118,7 @@
     {
       "id": "4",
       "name": "Watchlist",
+      "key": "watchlist",
       "description": "Manage the user's watchlist groups (read/create/update/delete) and look up the securities each group contains.",
       "tools": [
         "create_watchlist_group",
@@ -129,6 +131,7 @@
     {
       "id": "6",
       "name": "Account & Positions",
+      "key": "account.read",
       "description": "Query account assets and cash flow — fund/stock holdings, account cash and equity, margin ratio, profit analysis and statements — for portfolio overviews, position display and account reconciliation.",
       "tools": [
         "account_balance",
@@ -152,6 +155,7 @@
     {
       "id": "10",
       "name": "Trade Order Lookup",
+      "key": "trade.read",
       "description": "Cover the post-submit order lifecycle and execution data: order detail, today/history orders, today/history executions, DCA plan reads, plus pre-trade max purchase quantity estimation.",
       "tools": [
         "dca_history",
@@ -168,6 +172,7 @@
     {
       "id": "11",
       "name": "Trade Execution",
+      "key": "trade.write",
       "description": "Place, replace and cancel orders, plus DCA plan create/update/pause/resume/stop.",
       "tools": [
         "cancel_order",

--- a/src/auth/metadata.rs
+++ b/src/auth/metadata.rs
@@ -25,10 +25,17 @@ pub(crate) fn resource_url_from_headers(headers: &HeaderMap, fallback: &str) -> 
     else {
         return fallback.to_string();
     };
+    // Prefer the proxy-set header; fall back to the scheme in --base-url so
+    // that local HTTP deployments without a reverse proxy still return "http".
+    let fallback_scheme = if fallback.starts_with("https://") {
+        "https"
+    } else {
+        "http"
+    };
     let scheme = headers
         .get("x-forwarded-proto")
         .and_then(|v| v.to_str().ok())
-        .unwrap_or("https");
+        .unwrap_or(fallback_scheme);
     format!("{scheme}://{host}")
 }
 

--- a/src/auth/metadata.rs
+++ b/src/auth/metadata.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, LazyLock};
 
 use axum::extract::State;
+use axum::http::HeaderMap;
 use axum::response::Json;
 use serde::Serialize;
 
@@ -9,6 +10,26 @@ use crate::auth::AppState;
 fn longbridge_oauth_url() -> String {
     std::env::var("LONGBRIDGE_HTTP_URL")
         .unwrap_or_else(|_| "https://openapi.longbridge.com".to_string())
+}
+
+/// Derives `scheme://host` from the incoming request headers.
+///
+/// Uses `X-Forwarded-Proto` for the scheme (falling back to `https`) and the
+/// `Host` header for the host.  Falls back to `fallback` (the `--base-url`
+/// flag) when the `Host` header is absent, so local / bare-binary deployments
+/// continue to work without a reverse proxy.
+pub(crate) fn resource_url_from_headers(headers: &HeaderMap, fallback: &str) -> String {
+    let Some(host) = headers
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+    else {
+        return fallback.to_string();
+    };
+    let scheme = headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("https");
+    format!("{scheme}://{host}")
 }
 
 #[derive(Serialize)]
@@ -20,9 +41,10 @@ pub(crate) struct ProtectedResourceMetadata {
 
 pub async fn protected_resource_metadata(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
 ) -> Json<ProtectedResourceMetadata> {
     Json(ProtectedResourceMetadata {
-        resource: state.base_url.clone(),
+        resource: resource_url_from_headers(&headers, &state.base_url),
         authorization_servers: vec![longbridge_oauth_url()],
         scopes_supported: vec!["openapi".to_string()],
     })

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -16,8 +16,9 @@ pub struct BearerToken(pub String);
 /// On 401 responses, includes `resource_metadata` in the `WWW-Authenticate`
 /// header as required by the MCP OAuth 2.1 spec (RFC 9728).
 pub async fn mcp_auth_layer(mut req: Request, next: Next, base_url: &str) -> Response {
+    let resource = crate::auth::metadata::resource_url_from_headers(req.headers(), base_url);
     let www_authenticate =
-        format!("Bearer resource_metadata=\"{base_url}/.well-known/oauth-protected-resource\"");
+        format!("Bearer resource_metadata=\"{resource}/.well-known/oauth-protected-resource\"");
 
     let bearer_token = req
         .headers()

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -126,24 +126,29 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/mcp/tools.json", axum::routing::get(tools_json))
         .route("/mcp/scopes.json", axum::routing::get(scopes_json));
 
-    let mcp_service = StreamableHttpService::new(
-        move || Ok(Longbridge),
-        Arc::new(NeverSessionManager::default()),
-        StreamableHttpServerConfig::default()
-            .with_stateful_mode(false)
-            .disable_allowed_hosts(),
-    );
+    // Build an auth-wrapped MCP service. Called twice so both /mcp and /
+    // (root) are served — allowing deployments where the gateway strips the
+    // /mcp prefix or routes directly to the domain root.
+    let make_mcp_with_auth = |base_url: String| {
+        let svc = StreamableHttpService::new(
+            move || Ok(Longbridge),
+            Arc::new(NeverSessionManager::default()),
+            StreamableHttpServerConfig::default()
+                .with_stateful_mode(false)
+                .disable_allowed_hosts(),
+        );
+        tower::ServiceBuilder::new()
+            .layer(axum::middleware::from_fn(
+                move |req: axum::extract::Request, next: axum::middleware::Next| {
+                    let base_url = base_url.clone();
+                    async move { middleware::mcp_auth_layer(req, next, &base_url).await }
+                },
+            ))
+            .service(svc)
+    };
 
-    // Auth middleware layer: extracts Bearer token into extensions
-    let base_url = state.base_url.clone();
-    let mcp_with_auth = tower::ServiceBuilder::new()
-        .layer(axum::middleware::from_fn(
-            move |req: axum::extract::Request, next: axum::middleware::Next| {
-                let base_url = base_url.clone();
-                async move { middleware::mcp_auth_layer(req, next, &base_url).await }
-            },
-        ))
-        .service(mcp_service);
+    let mcp_with_auth = make_mcp_with_auth(state.base_url.clone());
+    let mcp_with_auth_root = make_mcp_with_auth(state.base_url.clone());
 
     Router::new()
         .merge(metadata_routes)
@@ -152,6 +157,8 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .merge(metrics_route)
         .merge(tools_route)
         .nest_service("/mcp", mcp_with_auth)
+        // Also serve at root so deployments that omit the /mcp path prefix work.
+        .fallback_service(mcp_with_auth_root)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Two related fixes for multi-domain / path-flexible deployments:

### 1. Serve MCP at root path (`/`) in addition to `/mcp`

Deployments where the gateway routes the domain root directly (e.g. `https://mcp.example.com/`) received HTTP 404 because the MCP handler was only mounted at `/mcp`. A second auth-wrapped `StreamableHttpService` is now registered via `fallback_service` so both `/mcp` and `/` work. Existing explicit routes (`/.well-known/*`, `/health`, `/metrics`, `/mcp/tools.json`) continue to take precedence.

### 2. Dynamic `resource` URL derived from request `Host` header

The `/.well-known/oauth-protected-resource` `resource` field and `WWW-Authenticate` header previously returned the fixed `--base-url` value, which broke when the same binary is reachable via multiple domains. Now `resource_url_from_headers()` reads:
- `Host` header → hostname
- `X-Forwarded-Proto` header → scheme (falls back to the scheme in `--base-url` so local HTTP deployments without a proxy still work)

### 3. `data/scopes.json`: add `key` field + trailing newline

## Test plan
- [ ] `POST /mcp` → 401 (endpoint exists, auth required)
- [ ] `POST /` → 401 (endpoint exists, auth required)
- [ ] `GET /.well-known/oauth-protected-resource` → 200, `resource` matches request Host
- [ ] `GET /health` → 200 (not captured by fallback)
- [ ] Claude Code connects to `https://mcp.longbridge.xyz/` without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)