### PR TITLE
fix(auth): prefer X-Forwarded-Host over Host for resource URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-mcp"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longbridge-mcp"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 
 [build-dependencies]

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.longbridge/mcp",
   "description": "US/HK markets — 145 tools: quotes, options, orders, fundamentals, screener, IPO, alerts & DCA",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.4.5",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.4.6",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",

--- a/src/auth/metadata.rs
+++ b/src/auth/metadata.rs
@@ -14,13 +14,18 @@ fn longbridge_oauth_url() -> String {
 
 /// Derives `scheme://host` from the incoming request headers.
 ///
-/// Uses `X-Forwarded-Proto` for the scheme (falling back to `https`) and the
-/// `Host` header for the host.  Falls back to `fallback` (the `--base-url`
-/// flag) when the `Host` header is absent, so local / bare-binary deployments
-/// continue to work without a reverse proxy.
+/// Header priority for the host:
+///   1. `X-Forwarded-Host` — set by the reverse proxy to the external hostname
+///      (e.g. `openapi.longbridge.xyz` when the proxy rewrites the Host).
+///   2. `Host` — the hostname the client actually connected to (correct for
+///      direct connections; may be the internal backend host behind a proxy).
+///   3. Falls back to `fallback` (`--base-url`) when both are absent.
+///
+/// Scheme priority: `X-Forwarded-Proto` → scheme of `--base-url`.
 pub(crate) fn resource_url_from_headers(headers: &HeaderMap, fallback: &str) -> String {
     let Some(host) = headers
-        .get(axum::http::header::HOST)
+        .get("x-forwarded-host")
+        .or_else(|| headers.get(axum::http::header::HOST))
         .and_then(|v| v.to_str().ok())
     else {
         return fallback.to_string();


### PR DESCRIPTION
## Problem

When a reverse proxy routes `openapi.longbridge.xyz/mcp` to the backend at `mcp.longbridge.xyz/`, the `Host` header seen by the backend is `mcp.longbridge.xyz` (internal), not `openapi.longbridge.xyz` (external). The `resource` field in `/.well-known/oauth-protected-resource` returned the internal hostname, causing MCP clients to reject the OAuth flow with:

```
Protected resource https://mcp.longbridge.xyz does not match expected https://openapi.longbridge.xyz/mcp
```

## Fix

Check `X-Forwarded-Host` before `Host` when building the resource URL. The reverse proxy sets `X-Forwarded-Host: openapi.longbridge.xyz` to communicate the original external hostname.

| Header present | Result |
|----------------|--------|
| `X-Forwarded-Host: openapi.longbridge.xyz` | `https://openapi.longbridge.xyz` |
| `Host: mcp.longbridge.xyz` only | `https://mcp.longbridge.xyz` |
| Neither | falls back to `--base-url` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)