### PR TITLE
feat(http): identify MCP client via User-Agent product-token chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,8 +1511,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "longbridge"
-version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git#485cf02ed83226bf819046cc6be479c3575f98ac"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c5859e4aa8170673004ba3cb05b9983f16425618c3414a6bab561514439959"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -1546,8 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "longbridge-candlesticks"
-version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git#485cf02ed83226bf819046cc6be479c3575f98ac"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1075e5f434cd1f874bf8b32607cc67bb1a24e7b1d4a23fcc7e3afa9057fc7522"
 dependencies = [
  "bitflags 2.11.1",
  "num-traits",
@@ -1558,16 +1560,18 @@ dependencies = [
 
 [[package]]
 name = "longbridge-geo"
-version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git#485cf02ed83226bf819046cc6be479c3575f98ac"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "477ecfca47309a99ec8a26664d9f49f8be83b33e87978a1ec9f31e76bf1e259f"
 dependencies = [
  "reqwest 0.12.28",
 ]
 
 [[package]]
 name = "longbridge-httpcli"
-version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git#485cf02ed83226bf819046cc6be479c3575f98ac"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "315c214a11bdac9894a8ce200feaf1ea72892db580b99b2d2d7d06faf7244d3b"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -1618,8 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "longbridge-oauth"
-version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git#485cf02ed83226bf819046cc6be479c3575f98ac"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed592e19234c7479ec89e19bd17ca77fdb5b96dd69a80cb6d84613642c0bff7"
 dependencies = [
  "dirs",
  "futures-util",
@@ -1635,8 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "longbridge-proto"
-version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git#485cf02ed83226bf819046cc6be479c3575f98ac"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30168c182c81e21f8d8f3bca44a79084b6149f2167751c8215b3d5dc6214d95a"
 dependencies = [
  "prost",
  "serde",
@@ -1644,8 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "longbridge-wscli"
-version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git#485cf02ed83226bf819046cc6be479c3575f98ac"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1743220d5cc62edbcd1696793a323aa3eaf154bad6afe513df84d33919e1f5a7"
 dependencies = [
  "byteorder",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ phf_codegen = "0.11"
 
 [dependencies]
 phf = "0.11"
-longbridge = { git = "https://github.com/longbridge/openapi.git" }
+longbridge = "4.2.2"
 rust_decimal = "1"
 rmcp = { version = "1.4", features = [
     "server",

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -83,16 +83,38 @@ where
 pub struct McpContext {
     pub token: String,
     pub language: Option<String>,
+    /// The originating MCP client's `User-Agent` (e.g. `claude-code/2.1.89 (cli)`),
+    /// when the client sent one. Some clients (e.g. Codex) send none.
+    pub client_user_agent: Option<String>,
     /// Extra headers to forward to upstream Longbridge services.
     pub extra_headers: Vec<(String, String)>,
 }
 
 impl McpContext {
+    /// This server's own identity as an RFC 9110 product token.
+    const SELF_USER_AGENT: &'static str = concat!("longbridge-mcp/", env!("CARGO_PKG_VERSION"));
+
+    /// Builds the upstream `User-Agent` as an RFC 9110 product-token chain: the
+    /// originating MCP client's UA (when present) followed by this server's own
+    /// token, e.g. `claude-code/2.1.89 (cli) longbridge-mcp/0.4.6`. Acting as a
+    /// proxy, we append our token rather than inventing a custom header, so the
+    /// backend sees both the client and this server in a single standard field.
+    /// Falls back to just our token when the client sent no UA.
+    fn user_agent(&self) -> String {
+        match self.client_user_agent.as_deref() {
+            Some(ua) if !ua.trim().is_empty() => format!("{ua} {}", Self::SELF_USER_AGENT),
+            _ => Self::SELF_USER_AGENT.to_string(),
+        }
+    }
+
     pub fn create_config(&self) -> Arc<longbridge::Config> {
         let mut config =
             longbridge::Config::from_oauth(longbridge::oauth::OAuth::from_token(&self.token))
                 .dont_print_quote_packages()
-                .enable_overnight();
+                .enable_overnight()
+                // Identify MCP-originated requests on the Context path (REST and
+                // WebSocket upgrades), mirroring how longbridge-cli tags itself.
+                .header("user-agent", self.user_agent());
         if let Some(ref lang) = self.language {
             let lb_lang = if lang.contains("zh-CN") || lang.contains("zh-Hans") {
                 longbridge::Language::ZH_CN
@@ -117,7 +139,10 @@ impl McpContext {
         for (key, value) in &self.extra_headers {
             client = client.header(key.as_str(), value.as_str());
         }
-        client
+        // Identify MCP-originated upstream requests. The client's UA is appended
+        // with our token by `user_agent`; set last so a forwarded header cannot
+        // shadow it.
+        client.header("user-agent", self.user_agent())
     }
 
     /// Extracts `account_channel` from the JWT bearer token's `sub` claim.
@@ -197,6 +222,9 @@ const SKIP_FORWARD_HEADERS: &[&str] = &[
     "accept-encoding",
     "mcp-session-id",
     "authorization",
+    // Captured separately in `extract_context` and folded into the synthesized
+    // upstream User-Agent; never forwarded raw.
+    "user-agent",
 ];
 
 fn collect_headers(headers: &axum::http::HeaderMap) -> Vec<(String, String)> {
@@ -226,9 +254,15 @@ fn extract_context(ctx: &RequestContext<RoleServer>) -> Result<McpContext, McpEr
         .get("accept-language")
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
+    let client_user_agent = parts
+        .headers
+        .get("user-agent")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
     Ok(McpContext {
         token: token.0.clone(),
         language,
+        client_user_agent,
         // NOTE: This is very important for passing headers to upstream Longbridge services.
         // Do not remove this unless you have a good reason and know exactly which headers to forward instead.
         extra_headers: collect_headers(&parts.headers),
@@ -2730,6 +2764,106 @@ mod tests {
             headers
                 .iter()
                 .any(|(k, v)| k == "accept-language" && v == "zh-CN")
+        );
+    }
+
+    #[test]
+    fn does_not_forward_raw_user_agent() {
+        let mut map = HeaderMap::new();
+        map.insert(
+            HeaderName::from_static("user-agent"),
+            HeaderValue::from_static("claude-code/2.1.89 (cli)"),
+        );
+        // The client UA is folded into the synthesized upstream UA, not forwarded raw.
+        assert!(!collect_headers(&map).iter().any(|(k, _)| k == "user-agent"));
+    }
+
+    fn ctx_with_ua(ua: Option<&str>) -> super::McpContext {
+        super::McpContext {
+            token: String::new(),
+            language: None,
+            client_user_agent: ua.map(str::to_owned),
+            extra_headers: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn user_agent_chains_client_then_self() {
+        let ua = ctx_with_ua(Some("claude-code/2.1.89 (cli)")).user_agent();
+        assert!(ua.starts_with("claude-code/2.1.89 (cli) longbridge-mcp/"));
+    }
+
+    #[test]
+    fn user_agent_falls_back_to_self_when_client_absent() {
+        assert!(
+            ctx_with_ua(None)
+                .user_agent()
+                .starts_with("longbridge-mcp/")
+        );
+        assert!(
+            ctx_with_ua(Some("   "))
+                .user_agent()
+                .starts_with("longbridge-mcp/")
+        );
+    }
+
+    /// End-to-end: the client produced by `create_http_client` must put the
+    /// synthesized `User-Agent` (client UA + our token) on the wire as the
+    /// primary value. A minimal TCP server captures the real request headers;
+    /// the SDK base URL is redirected to it via the `HTTP_URL` env var.
+    #[tokio::test]
+    async fn upstream_request_carries_synthesized_user_agent() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::sync::{Arc, Mutex};
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let cap = Arc::clone(&captured);
+        std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 4096];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+                for line in req.lines() {
+                    if line.to_ascii_lowercase().starts_with("user-agent:") {
+                        *cap.lock().unwrap() =
+                            Some(line["user-agent:".len()..].trim().to_string());
+                        break;
+                    }
+                }
+                let _ = stream.write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n{}",
+                );
+            }
+        });
+
+        // SDK reads the base URL from `LONGBRIDGE_HTTP_URL` (see httpclient config).
+        // SAFETY: single-threaded test setup; no other thread reads it here.
+        unsafe { std::env::set_var("LONGBRIDGE_HTTP_URL", format!("http://{addr}")) };
+
+        let mctx = super::McpContext {
+            token: "dummy-token".to_string(),
+            language: None,
+            client_user_agent: Some("claude-code/2.1.89 (cli)".to_string()),
+            extra_headers: Vec::new(),
+        };
+        let _ = mctx
+            .create_http_client()
+            .request(reqwest::Method::GET, "/v1/ping")
+            .response::<String>()
+            .send()
+            .await;
+
+        let ua = captured
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("echo server did not receive a request");
+        assert!(
+            ua.starts_with("claude-code/2.1.89 (cli) longbridge-mcp/"),
+            "unexpected upstream User-Agent: {ua}"
         );
     }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2828,8 +2828,7 @@ mod tests {
                 let req = String::from_utf8_lossy(&buf[..n]);
                 for line in req.lines() {
                     if line.to_ascii_lowercase().starts_with("user-agent:") {
-                        *cap.lock().unwrap() =
-                            Some(line["user-agent:".len()..].trim().to_string());
+                        *cap.lock().unwrap() = Some(line["user-agent:".len()..].trim().to_string());
                         break;
                     }
                 }


### PR DESCRIPTION
## What

Make MCP-originated upstream requests identifiable by the Longbridge backend via a standards-compliant `User-Agent`, and pin the SDK to a published crate version.

## Why

The backend previously could not tell that a request came from this MCP server, nor which client (Claude Code, Codex, …) drove it. CLI already tags itself with `longbridge-cli/<version>`; MCP had no equivalent.

## How

- **`McpContext::user_agent()`** builds an RFC 9110 product-token chain: `<client-ua> longbridge-mcp/<version>`, e.g. `claude-code/2.1.89 (cli) longbridge-mcp/0.4.6`. Acting as a proxy, we append our token to the client's UA rather than inventing a custom header, so a single standard field carries both identities. Falls back to just `longbridge-mcp/<version>` when the client sends no UA (e.g. Codex currently sends none).
- Applied on both paths: `create_http_client` (REST) and `create_config` (Context / WebSocket upgrades), mirroring `longbridge-cli`.
- The client's raw `User-Agent` is no longer forwarded as-is (`SKIP_FORWARD_HEADERS`); it is captured in `extract_context` and folded into the chain.
- **Dependency**: switch `longbridge` from a git dependency to the published crate **`4.2.2`**, which provides the `Config::header` builder used above.

## Verification

- `cargo clippy --all-features --all-targets`: no issues.
- `cargo test`: 58 passed, including a new end-to-end test (`upstream_request_carries_synthesized_user_agent`) that redirects the SDK base URL to a local echo server via `LONGBRIDGE_HTTP_URL` and asserts the real on-the-wire `User-Agent`.
- Impact of the SDK bump (4.0.5 → 4.2.2) is contained: most tools use the REST path (`create_http_client`) and are unaffected by the typed-struct changes; only quote/trade/content/statement use high-level Contexts and all compile + test green. `alert` uses REST, so the 4.1.0 `AlertContext` breaking change does not affect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)