### PR TITLE
chore: bump version to 0.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-mcp"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longbridge-mcp"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2024"
 
 [build-dependencies]

--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.longbridge/mcp",
   "description": "US/HK markets — 145 tools: quotes, options, orders, fundamentals, screener, IPO, alerts & DCA",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.4.7",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.4.8",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",


### PR DESCRIPTION
## Summary

Version bump to 0.4.8. No functional changes.

Includes schema URL update in `server.json` (`2025-09-29` → `2025-12-11`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)