### PR TITLE
fix: normalize SDK OffsetDateTime to RFC3339; quote tool default/doc fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,11 @@ clap = { version = "4", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
-time = { version = "0.3", features = ["formatting", "parsing"] }
+time = { version = "0.3", features = [
+    "formatting",
+    "parsing",
+    "serde-human-readable",
+] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -1,6 +1,8 @@
 //! Custom Serializer wrapper that transforms JSON output during serialization:
 //! - Field names -> snake_case
 //! - Fields ending with `_at` containing i64/u64 -> RFC3339 UTC string
+//! - Any string in `time`'s default `OffsetDateTime` shape (e.g.
+//!   `2026-06-02 20:00:00.0 +00:00:00`) -> RFC3339, regardless of field name
 //! - Field `counter_id` (string) -> renamed to `symbol`, value converted
 //! - Field `counter_ids` (array of strings) -> renamed to `symbols`, each converted
 //! - Fields `aaid` and `account_channel` -> value set to null
@@ -96,6 +98,31 @@ pub(crate) fn timestamp_to_rfc3339(ts: i64) -> String {
             .unwrap_or_else(|_| ts.to_string()),
         Err(_) => ts.to_string(),
     }
+}
+
+/// Convert a string emitted by `time`'s default human-readable `OffsetDateTime`
+/// serialization (e.g. `"2026-06-02 20:00:00.0 +00:00:00"`) into RFC3339.
+///
+/// SDK response types carry `OffsetDateTime` fields which serialize to this
+/// non-RFC3339 shape; our timestamp transform only handles unix-seconds, so
+/// such values would otherwise pass through unchanged. `time`'s `Serialize` and
+/// `Deserialize` for `OffsetDateTime` share one format and are symmetric, so we
+/// round-trip the string back through serde rather than hand-write a fragile
+/// parser. Returns `None` (leaving the value untouched) for anything that is
+/// not in this exact shape — including values already in RFC3339.
+pub(crate) fn datetime_str_to_rfc3339(s: &str) -> Option<String> {
+    // Fast reject: the format is `YYYY-MM-DD HH:MM:SS...` — digit-led, `-` at
+    // index 4, space at index 10. RFC3339 uses `T` at index 10, so it is
+    // rejected here and left as-is.
+    let b = s.as_bytes();
+    if b.len() < 19 || !b[0].is_ascii_digit() || b.get(4) != Some(&b'-') || b.get(10) != Some(&b' ')
+    {
+        return None;
+    }
+    let quoted = serde_json::to_string(s).ok()?;
+    let dt: time::OffsetDateTime = serde_json::from_str(&quoted).ok()?;
+    dt.format(&time::format_description::well_known::Rfc3339)
+        .ok()
 }
 
 /// Parse a string as a plausible unix-seconds timestamp. Returns `None` for
@@ -533,5 +560,53 @@ mod tests {
         assert_eq!(v["aaid"], serde_json::Value::Null);
         assert_eq!(v["account_channel"], serde_json::Value::Null);
         assert_eq!(v["plan_id"], "1");
+    }
+
+    #[test]
+    fn datetime_str_to_rfc3339_conversions() {
+        // time's default human-readable OffsetDateTime format -> RFC3339.
+        assert_eq!(
+            datetime_str_to_rfc3339("2026-06-02 20:00:00.0 +00:00:00").as_deref(),
+            Some("2026-06-02T20:00:00Z")
+        );
+        // Non-UTC offset is preserved.
+        assert_eq!(
+            datetime_str_to_rfc3339("2026-06-02 04:00:00.0 +08:00:00").as_deref(),
+            Some("2026-06-02T04:00:00+08:00")
+        );
+        // Already RFC3339 ('T' at index 10) -> left untouched.
+        assert_eq!(datetime_str_to_rfc3339("2026-06-02T20:00:00Z"), None);
+        // Plain strings / dates / unix seconds -> untouched.
+        assert_eq!(datetime_str_to_rfc3339("hello world"), None);
+        assert_eq!(datetime_str_to_rfc3339("2026-06-02"), None);
+        assert_eq!(datetime_str_to_rfc3339("1700000000"), None);
+    }
+
+    #[test]
+    fn offset_datetime_fields_serialize_as_rfc3339() {
+        use time::OffsetDateTime;
+        #[derive(Serialize)]
+        struct Data {
+            // Bare `timestamp` (Normal path) and `created_at` (_at Timestamp path)
+            // both carry SDK-style OffsetDateTime values.
+            timestamp: OffsetDateTime,
+            created_at: OffsetDateTime,
+        }
+        let dt = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+        let json = to_tool_json(&Data {
+            timestamp: dt,
+            created_at: dt,
+        })
+        .unwrap();
+        assert!(
+            json.contains("\"timestamp\":\"2023-11-14T22:13:20Z\""),
+            "got: {json}"
+        );
+        assert!(
+            json.contains("\"created_at\":\"2023-11-14T22:13:20Z\""),
+            "got: {json}"
+        );
+        // time's default separator/offset shape must not leak through.
+        assert!(!json.contains("+00:00:00"), "got: {json}");
     }
 }

--- a/src/serialize/timestamp.rs
+++ b/src/serialize/timestamp.rs
@@ -39,6 +39,9 @@ impl<S: Serializer> Serializer for TimestampSerializer<S> {
         self.inner.serialize_str(&timestamp_to_rfc3339(v as i64))
     }
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        if let Some(rfc3339) = crate::serialize::datetime_str_to_rfc3339(v) {
+            return self.inner.serialize_str(&rfc3339);
+        }
         match try_parse_unix_string(v) {
             Some(ts) => self.inner.serialize_str(&timestamp_to_rfc3339(ts)),
             None => self.inner.serialize_str(v),

--- a/src/serialize/transform.rs
+++ b/src/serialize/transform.rs
@@ -38,8 +38,14 @@ impl<S: Serializer> Serializer for TransformSerializer<S> {
     delegate_simple!(serialize_f32, f32);
     delegate_simple!(serialize_f64, f64);
     delegate_simple!(serialize_char, char);
-    delegate_simple!(serialize_str, &str);
     delegate_simple!(serialize_bytes, &[u8]);
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        match crate::serialize::datetime_str_to_rfc3339(v) {
+            Some(rfc3339) => self.inner.serialize_str(&rfc3339),
+            None => self.inner.serialize_str(v),
+        }
+    }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
         self.inner.serialize_none()

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1040,7 +1040,7 @@ impl Longbridge {
         title = "Estimate Max Purchase Quantity",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::EstimateMaxQtyResponse>(),
-        description = "Estimate maximum buy/sell quantity for a symbol. Returns {cash_max_qty, margin_max_qty} (decimal strings). Requires symbol, side (Buy/Sell), order_type, and optionally price."
+        description = "Estimate maximum buy/sell quantity for a symbol. Returns {cash_max_qty, margin_max_qty} (decimal strings). Only symbol is required; side (case-insensitive Buy/Sell) defaults to Buy, order_type (case-insensitive) defaults to LO, and price is optional."
     )]
     async fn estimate_max_purchase_quantity(
         &self,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -427,7 +427,7 @@ impl Longbridge {
         title = "Broker Queue",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::BrokersResponse>(),
-        description = "Get broker queue (HK only). Returns bid_brokers/ask_brokers arrays, each with position (1-based) and broker_ids. Map broker IDs to names via participants."
+        description = "Get broker queue (HK stocks only). Returns bid_brokers/ask_brokers arrays, each with position (1-based) and broker_ids. Map broker IDs to names via participants."
     )]
     async fn brokers(
         &self,
@@ -486,7 +486,7 @@ impl Longbridge {
     #[tool(
         title = "Candlesticks",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
-        description = "Get candlestick data (OHLCV). period: 1m/5m/15m/30m/60m/day/week/month/year. trade_sessions: intraday/all"
+        description = "Get candlestick data (OHLCV). Only symbol is required; period defaults to day, count to 100 (max 1000), forward_adjust to false, trade_sessions to all. period: 1m/5m/15m/30m/60m/day/week/month/year. trade_sessions: intraday/all"
     )]
     async fn candlesticks(
         &self,
@@ -727,7 +727,7 @@ impl Longbridge {
     #[tool(
         title = "Calc Indexes",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
-        description = "Calculate financial indexes for symbols. Pass symbols and indexes (e.g. [\"PeTtmRatio\",\"PbRatio\",\"LastDone\",\"TurnoverRate\"]). Returns per-symbol index values."
+        description = "Calculate financial indexes for symbols. Pass symbols, and optionally indexes (e.g. [\"PeTtmRatio\",\"PbRatio\",\"LastDone\",\"TurnoverRate\"]). When indexes is omitted or empty, defaults to [\"LastDone\",\"ChangeValue\",\"ChangeRate\",\"Volume\",\"PeTtmRatio\",\"PbRatio\",\"DividendRatioTtm\",\"TurnoverRate\",\"TotalMarketValue\"]. Returns per-symbol index values."
     )]
     async fn calc_indexes(
         &self,
@@ -1360,7 +1360,7 @@ impl Longbridge {
     #[tool(
         title = "Broker Holding",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
-        description = "Get top broker holding data for a symbol. Returns items[]{broker_name, holding_quantity, holding_change, holding_ratio} for the given period (rct_1/rct_5/rct_20/rct_60)."
+        description = "Get top broker holding data for a symbol (HK stocks only; sourced from HKEX CCASS participant disclosure). Returns items[]{broker_name, holding_quantity, holding_change, holding_ratio} for the given period (rct_1/rct_5/rct_20/rct_60)."
     )]
     async fn broker_holding(
         &self,
@@ -1375,7 +1375,7 @@ impl Longbridge {
     #[tool(
         title = "Broker Holding Detail",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
-        description = "Get full broker holding detail list for a symbol. Returns items[]{broker_id, broker_name, holding_quantity, holding_ratio, holding_change, date}."
+        description = "Get full broker holding detail list for a symbol (HK stocks only; sourced from HKEX CCASS participant disclosure). Returns items[]{broker_id, broker_name, holding_quantity, holding_ratio, holding_change, date}."
     )]
     async fn broker_holding_detail(
         &self,
@@ -1393,7 +1393,7 @@ impl Longbridge {
     #[tool(
         title = "Broker Holding (Daily)",
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
-        description = "Get daily holding history for a specific broker (by broker_id) in a symbol. Returns items[]{date, holding_quantity, holding_change, holding_ratio}."
+        description = "Get daily holding history for a specific broker (by broker_id) in a symbol (HK stocks only; sourced from HKEX CCASS participant disclosure). Returns items[]{date, holding_quantity, holding_change, holding_ratio}."
     )]
     async fn broker_holding_daily(
         &self,

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -8,6 +8,7 @@ use rmcp::serde::Deserialize;
 
 use crate::counter::symbol_to_counter_id;
 use crate::error::Error;
+use crate::tools::output;
 use crate::tools::support::http_client::{http_get_tool, http_get_tool_unix};
 use crate::tools::support::parse;
 use crate::tools::support::tolerant::{
@@ -50,16 +51,33 @@ pub struct SymbolCountParam {
 pub struct CandlesticksParam {
     /// Security symbol, e.g. "700.HK"
     pub symbol: String,
-    /// Period: 1m, 5m, 15m, 30m, 60m, day, week, month, year
+    /// Period: 1m, 5m, 15m, 30m, 60m, day, week, month, year (default: day)
+    #[serde(default = "default_candlestick_period")]
     pub period: String,
-    /// Number of candlesticks (max 1000)
-    #[serde(deserialize_with = "tolerant_usize")]
+    /// Number of candlesticks (optional, max 1000; default 100)
+    #[serde(
+        default = "default_candlestick_count",
+        deserialize_with = "tolerant_usize"
+    )]
     pub count: usize,
-    /// Whether to forward-adjust for splits/dividends
-    #[serde(deserialize_with = "tolerant_bool")]
+    /// Whether to forward-adjust for splits/dividends (default: false / no adjust)
+    #[serde(default, deserialize_with = "tolerant_bool")]
     pub forward_adjust: bool,
-    /// Trade sessions: "intraday" (regular hours only) or "all" (include pre-market and post-market)
+    /// Trade sessions: "intraday" (regular hours only) or "all" (include pre-market and post-market; default "all")
+    #[serde(default = "default_trade_sessions")]
     pub trade_sessions: String,
+}
+
+fn default_candlestick_period() -> String {
+    "day".to_string()
+}
+
+fn default_candlestick_count() -> usize {
+    100
+}
+
+fn default_trade_sessions() -> String {
+    "all".to_string()
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -154,8 +172,8 @@ pub struct CalcIndexesParam {
     /// Security symbols, e.g. ["700.HK", "AAPL.US"]
     #[serde(deserialize_with = "tolerant_vec_string")]
     pub symbols: Vec<String>,
-    /// Calc indexes: LastDone, ChangeValue, ChangeRate, Volume, Turnover, YtdChangeRate, TurnoverRate, TotalMarketValue, CapitalFlow, Amplitude, VolumeRatio, PeTtmRatio, PbRatio, DividendRatioTtm, FiveDayChangeRate, TenDayChangeRate, HalfYearChangeRate, FiveMinutesChangeRate, ExpiryDate, StrikePrice, UpperStrikePrice, LowerStrikePrice, OutstandingQty, OutstandingRatio, Premium, ItmOtm, ImpliedVolatility, WarrantDelta, CallPrice, ToCallPrice, EffectiveLeverage, LeverageRatio, ConversionRatio, BalancePoint, OpenInterest, Delta, Gamma, Theta, Vega, Rho
-    #[serde(deserialize_with = "tolerant_vec_string")]
+    /// Calc indexes (optional; defaults to LastDone, ChangeValue, ChangeRate, Volume, PeTtmRatio, PbRatio, DividendRatioTtm, TurnoverRate, TotalMarketValue): LastDone, ChangeValue, ChangeRate, Volume, Turnover, YtdChangeRate, TurnoverRate, TotalMarketValue, CapitalFlow, Amplitude, VolumeRatio, PeTtmRatio, PbRatio, DividendRatioTtm, FiveDayChangeRate, TenDayChangeRate, HalfYearChangeRate, FiveMinutesChangeRate, ExpiryDate, StrikePrice, UpperStrikePrice, LowerStrikePrice, OutstandingQty, OutstandingRatio, Premium, ItmOtm, ImpliedVolatility, WarrantDelta, CallPrice, ToCallPrice, EffectiveLeverage, LeverageRatio, ConversionRatio, BalancePoint, OpenInterest, Delta, Gamma, Theta, Vega, Rho
+    #[serde(default, deserialize_with = "tolerant_vec_string")]
     pub indexes: Vec<String>,
 }
 
@@ -482,7 +500,24 @@ pub async fn capital_distribution(
         .capital_distribution(p.symbol)
         .await
         .map_err(Error::longbridge)?;
-    tool_json(&result)
+    let timestamp = result
+        .timestamp
+        .format(&time::format_description::well_known::Rfc3339)
+        .map_err(|e| Error::Other(e.to_string()))?;
+    let resp = output::CapitalDistributionResponse {
+        timestamp,
+        capital_in: output::CapitalDistribution {
+            large: result.capital_in.large.to_string(),
+            medium: result.capital_in.medium.to_string(),
+            small: result.capital_in.small.to_string(),
+        },
+        capital_out: output::CapitalDistribution {
+            large: result.capital_out.large.to_string(),
+            medium: result.capital_out.medium.to_string(),
+            small: result.capital_out.small.to_string(),
+        },
+    };
+    tool_json(&resp)
 }
 
 pub async fn trading_session(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
@@ -601,12 +636,31 @@ pub async fn warrant_list(
     tool_json(&result)
 }
 
+/// Default calc indexes when the caller omits `indexes`: common quote fields
+/// (last_done, change_value, change_rate, volume) plus the `longbridge
+/// calc-index` CLI valuation default (pe, pb, dps_rate, turnover_rate, mktcap).
+const DEFAULT_CALC_INDEXES: [&str; 9] = [
+    "LastDone",
+    "ChangeValue",
+    "ChangeRate",
+    "Volume",
+    "PeTtmRatio",
+    "PbRatio",
+    "DividendRatioTtm",
+    "TurnoverRate",
+    "TotalMarketValue",
+];
+
 pub async fn calc_indexes(
     mctx: &crate::tools::McpContext,
     p: CalcIndexesParam,
 ) -> Result<CallToolResult, McpError> {
-    let indexes: Vec<longbridge::quote::CalcIndex> = p
-        .indexes
+    let index_strs: Vec<&str> = if p.indexes.is_empty() {
+        DEFAULT_CALC_INDEXES.to_vec()
+    } else {
+        p.indexes.iter().map(String::as_str).collect()
+    };
+    let indexes: Vec<longbridge::quote::CalcIndex> = index_strs
         .iter()
         .map(|s| parse::parse_calc_index(s))
         .collect::<Result<_, _>>()?;

--- a/src/tools/trade.rs
+++ b/src/tools/trade.rs
@@ -118,12 +118,22 @@ pub struct CashFlowParam {
 pub struct EstimateMaxQtyParam {
     /// Security symbol, e.g. "700.HK"
     pub symbol: String,
-    /// Buy or Sell
+    /// Buy or Sell (case-insensitive; default: Buy)
+    #[serde(default = "default_order_side")]
     pub side: String,
-    /// Order type: LO (Limit Order) / ELO (Enhanced Limit Order) / MO (Market Order) / AO (At-auction) / ALO (At-auction Limit Order)
+    /// Order type, case-insensitive (default: LO): LO (Limit Order) / ELO (Enhanced Limit Order) / MO (Market Order) / AO (At-auction) / ALO (At-auction Limit Order)
+    #[serde(default = "default_order_type")]
     pub order_type: String,
     /// Limit price for limit-style orders. Omit for market orders.
     pub price: Option<String>,
+}
+
+fn default_order_side() -> String {
+    "Buy".to_string()
+}
+
+fn default_order_type() -> String {
+    "LO".to_string()
 }
 
 pub async fn account_balance(
@@ -439,12 +449,21 @@ pub async fn estimate_max_purchase_quantity(
     use longbridge::trade::{EstimateMaxPurchaseQuantityOptions, OrderSide, OrderType};
     use std::str::FromStr;
 
-    let side = p
-        .side
+    // SDK FromStr is case-sensitive ("Buy"/"LO"). Normalize first so callers can
+    // pass any case: side -> "Buy"/"Sell", order_type -> upper-case (all variants
+    // serialize as upper-case acronyms).
+    let side_norm = match p.side.trim().to_ascii_lowercase().as_str() {
+        "buy" => "Buy".to_string(),
+        "sell" => "Sell".to_string(),
+        _ => p.side.trim().to_string(),
+    };
+    let side = side_norm
         .parse::<OrderSide>()
         .map_err(|e| McpError::invalid_params(format!("invalid side: {e}"), None))?;
     let order_type = p
         .order_type
+        .trim()
+        .to_ascii_uppercase()
         .parse::<OrderType>()
         .map_err(|e| McpError::invalid_params(format!("invalid order_type: {e}"), None))?;
     let mut opts = EstimateMaxPurchaseQuantityOptions::new(p.symbol, order_type, side);


### PR DESCRIPTION
## Summary

Fixes a timestamp-format bug plus several quote-tool ergonomics issues surfaced while testing the MCP tools.

### `serialize`: SDK `OffsetDateTime` → RFC3339 (the main fix)
SDK response types carry `OffsetDateTime` fields. Under time's `serde-human-readable` feature they serialize to time's default shape (e.g. `2026-06-02 20:00:00.0 +00:00:00`), which is **not** RFC3339. The existing transform only converted `_at` unix-seconds fields, so these values passed through unchanged (e.g. `capital_distribution.timestamp`).

- Add `datetime_str_to_rfc3339` — recognizes time's default shape via a fast pre-check, then round-trips the string back through serde (time's `Serialize`/`Deserialize` share one format and are symmetric) and re-emits RFC3339. No fragile hand-written parser.
- Wire it into both `serialize_str` paths (`TransformSerializer` Normal-path + `TimestampSerializer` `_at`-path), so **any** field carrying this shape is fixed regardless of name — `capital_flow`, `trades`, `intraday`, `candlesticks`, order `*_at`, etc.
- `capital_distribution` now maps to its declared `output_schema` (`Decimal` → `String`, timestamp → RFC3339).
- Enables the `serde-human-readable` feature on `time` (already in the build tree via the SDK).

### Tool default / doc improvements
- **calc_indexes**: `indexes` is now optional, defaulting to common quote + valuation fields (`LastDone, ChangeValue, ChangeRate, Volume, PeTtmRatio, PbRatio, DividendRatioTtm, TurnoverRate, TotalMarketValue`).
- **candlesticks**: only `symbol` is required; `period=day`, `count=100`, `forward_adjust=false`, `trade_sessions=all` defaults aligned with the `longbridge` CLI.
- **broker holding / broker queue**: descriptions now state HK stocks only (sourced from HKEX CCASS participant disclosure), so callers don't try US/CN symbols.

## Testing
- `cargo test --bins` — 78 passed (incl. 2 new regression tests covering the time-default → RFC3339 conversion, non-UTC offsets, and pass-through of RFC3339 / plain strings / unix seconds).
- `cargo clippy --all-features --all-targets` — clean.
- `cargo +nightly fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)