### PR TITLE
feat(quote): log WS quote tool calls via /v1/quote/cmd beacon

### DIFF
--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -91,6 +91,24 @@ pub struct McpContext {
     pub extra_headers: Vec<(String, String)>,
 }
 
+/// Server-side beacon endpoint. Quote operations flow over the WebSocket quote
+/// channel and never reach the HTTP access log; a request to this fake path lets
+/// the server record (and count) that a WS-backed quote tool ran. The path only
+/// needs to exist server-side to be logged.
+pub(crate) const QUOTE_CMD_PATH: &str = "/v1/quote/cmd";
+
+/// Send the tracking beacon over `client`. The (empty) body and any transport
+/// error are ignored — the server only needs the access-log entry. Extracted as
+/// its own awaitable function so the integration test can drive it against a
+/// local server deterministically.
+pub(crate) async fn send_quote_cmd(client: &longbridge::httpclient::HttpClient) {
+    let _ = client
+        .request(reqwest::Method::GET, QUOTE_CMD_PATH)
+        .response::<String>()
+        .send()
+        .await;
+}
+
 impl McpContext {
     /// This server's own identity as an RFC 9110 product token.
     const SELF_USER_AGENT: &'static str = concat!("longbridge-mcp/", env!("CARGO_PKG_VERSION"));
@@ -144,6 +162,29 @@ impl McpContext {
         // with our token by `user_agent`; set last so a forwarded header cannot
         // shadow it.
         client.header("user-agent", self.user_agent())
+    }
+
+    /// Fire a best-effort `GET /v1/quote/cmd` so the server records a log entry
+    /// for this WS-backed quote operation. Quote traffic flows over the
+    /// WebSocket quote channel and is therefore invisible to HTTP access logs;
+    /// this ping makes the call countable server-side. It reuses an `HttpClient`
+    /// carrying the same `user-agent`, OAuth token, and forwarded headers as the
+    /// real request, so no extra payload is needed. Fire-and-forget: spawned on
+    /// the runtime with its result and errors ignored, never blocking the call.
+    fn track_quote_cmd(&self) {
+        let client = self.create_http_client();
+        tokio::spawn(async move { send_quote_cmd(&client).await });
+    }
+
+    /// Build a `QuoteContext` and record the WS quote operation server-side via
+    /// [`track_quote_cmd`]. Use this instead of
+    /// `QuoteContext::new(self.create_config())` at every quote tool entry point
+    /// so the otherwise-unlogged WebSocket request is counted. The push receiver
+    /// is dropped immediately, matching the existing `let (ctx, _) = …` callers.
+    pub fn create_quote_context(&self) -> longbridge::quote::QuoteContext {
+        self.track_quote_cmd();
+        let (ctx, _) = longbridge::quote::QuoteContext::new(self.create_config());
+        ctx
     }
 
     /// Extracts `account_channel` from the JWT bearer token's `sub` claim.
@@ -3006,5 +3047,126 @@ mod tests {
     #[test]
     fn empty_map_returns_empty() {
         assert!(collect_headers(&HeaderMap::new()).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod quote_cmd_tests {
+    use super::{QUOTE_CMD_PATH, send_quote_cmd};
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Start a throwaway HTTP server on an ephemeral port that captures the raw
+    /// bytes of the first request, replies `200`, and hands the request back over
+    /// a oneshot channel. A real socket — no HTTP mocking — so the test exercises
+    /// the actual SDK `HttpClient` send path and survives future refactors.
+    async fn spawn_capture_server() -> (u16, tokio::sync::oneshot::Receiver<String>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = [0u8; 4096];
+            let mut data = Vec::new();
+            // Read until the end of the request headers.
+            while !data.windows(4).any(|w| w == b"\r\n\r\n") {
+                match socket.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => data.extend_from_slice(&buf[..n]),
+                }
+            }
+            let _ = socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .await;
+            let _ = socket.flush().await;
+            let _ = tx.send(String::from_utf8_lossy(&data).into_owned());
+        });
+        (port, rx)
+    }
+
+    /// `send_quote_cmd` must issue `GET /v1/quote/cmd` and carry whatever tracking
+    /// headers the client was built with, so the server can attribute the
+    /// otherwise-invisible WS quote tool call.
+    #[tokio::test]
+    async fn send_quote_cmd_hits_endpoint_with_tracking_headers() {
+        let (port, rx) = spawn_capture_server().await;
+
+        // Build a client the same way `create_http_client` does (token + UA),
+        // but pointed at the local capture server.
+        let oauth = longbridge::oauth::OAuth::from_token("test-token");
+        let config = longbridge::httpclient::HttpClientConfig::from_oauth(oauth)
+            .http_url(format!("http://127.0.0.1:{port}"));
+        let client = longbridge::httpclient::HttpClient::new(config)
+            .header("user-agent", "test-client/9.9 longbridge-mcp/test");
+
+        send_quote_cmd(&client).await;
+
+        let request = tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("capture server did not receive a request in time")
+            .expect("capture server dropped the request");
+
+        let request_line = request.lines().next().unwrap_or_default();
+        assert!(
+            request_line.starts_with(&format!("GET {QUOTE_CMD_PATH}")),
+            "expected `GET {QUOTE_CMD_PATH}`, got request line: {request_line}"
+        );
+        assert!(
+            request
+                .to_lowercase()
+                .contains("user-agent: test-client/9.9 longbridge-mcp/test"),
+            "tracking user-agent header missing; request was:\n{request}"
+        );
+    }
+
+    /// Recursively collect `.rs` files under `dir`.
+    fn rs_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut out = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    out.extend(rs_files(&path));
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    out.push(path);
+                }
+            }
+        }
+        out
+    }
+
+    /// Guard: every quote tool must obtain its `QuoteContext` via
+    /// `mctx.create_quote_context()` (which fires the `/v1/quote/cmd` beacon),
+    /// never `QuoteContext::new(...)` directly. The sole sanctioned constructor
+    /// call lives in `mod.rs` (the helper itself), so every other tool file must
+    /// be free of `QuoteContext::new(`. This makes "every WS quote tool is
+    /// tracked" an enforced invariant: a new tool that constructs its own
+    /// `QuoteContext` fails this test.
+    #[test]
+    fn quote_tools_use_tracking_context_constructor() {
+        let tools_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/tools");
+        // `mod.rs` defines `create_quote_context`, the one allowed constructor.
+        let helper_file = tools_dir.join("mod.rs");
+        let mut offenders = Vec::new();
+        for file in rs_files(&tools_dir) {
+            if file == helper_file {
+                continue;
+            }
+            let src = std::fs::read_to_string(&file).unwrap();
+            for (i, line) in src.lines().enumerate() {
+                if line.contains("QuoteContext::new(") {
+                    offenders.push(format!("{}:{}", file.display(), i + 1));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "quote tools must use `mctx.create_quote_context()` (fires the \
+             /v1/quote/cmd beacon), not `QuoteContext::new(...)` directly. \
+             Untracked constructor at:\n{}",
+            offenders.join("\n")
+        );
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -14,16 +14,30 @@ use crate::auth::middleware::{AgentEndpoint, BearerToken};
 use crate::error::Error;
 use crate::serialize::to_tool_json;
 
+tokio::task_local! {
+    /// The name of the tool currently executing, scoped around each tool call by
+    /// [`measured_tool_call`]. Read by [`McpContext::create_http_client`] and
+    /// [`McpContext::create_config`] to tag every upstream Longbridge request
+    /// with an `x-mcp-tool` header (the MCP equivalent of the CLI's `x-cli-cmd`),
+    /// so server-side stats can attribute requests per tool. Absent outside a
+    /// tool call (e.g. server init), in which case no tag is added.
+    pub(crate) static CURRENT_TOOL: String;
+}
+
 async fn measured_tool_call<F, Fut>(name: &str, f: F) -> Result<CallToolResult, McpError>
 where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = Result<CallToolResult, McpError>>,
 {
-    let start = std::time::Instant::now();
-    let result = f().await;
-    let duration = start.elapsed().as_secs_f64();
-    crate::metrics::record_tool_call(name, duration, result.is_err());
-    result
+    CURRENT_TOOL
+        .scope(name.to_string(), async move {
+            let start = std::time::Instant::now();
+            let result = f().await;
+            let duration = start.elapsed().as_secs_f64();
+            crate::metrics::record_tool_call(name, duration, result.is_err());
+            result
+        })
+        .await
 }
 
 mod alert;
@@ -109,6 +123,12 @@ pub(crate) async fn send_quote_cmd(client: &longbridge::httpclient::HttpClient) 
         .await;
 }
 
+/// Serializes tests that mutate the process-global `LONGBRIDGE_HTTP_URL` env var
+/// to redirect the SDK base URL at a local capture server. Multiple such tests
+/// run concurrently in one binary and would otherwise clobber each other's URL.
+#[cfg(test)]
+pub(crate) static HTTP_URL_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 impl McpContext {
     /// This server's own identity as an RFC 9110 product token.
     const SELF_USER_AGENT: &'static str = concat!("longbridge-mcp/", env!("CARGO_PKG_VERSION"));
@@ -144,6 +164,11 @@ impl McpContext {
             };
             config = config.language(lb_lang);
         }
+        // Tag the originating tool so server-side stats can attribute Context
+        // (REST + WS upgrade) requests per tool, mirroring the CLI's x-cli-cmd.
+        if let Ok(tool) = CURRENT_TOOL.try_with(|t| t.clone()) {
+            config = config.header("x-mcp-tool", tool.as_str());
+        }
         Arc::new(config)
     }
 
@@ -158,6 +183,11 @@ impl McpContext {
         for (key, value) in &self.extra_headers {
             client = client.header(key.as_str(), value.as_str());
         }
+        // Tag the originating tool so server-side stats can attribute requests
+        // per tool, mirroring the CLI's x-cli-cmd.
+        if let Ok(tool) = CURRENT_TOOL.try_with(|t| t.clone()) {
+            client = client.header("x-mcp-tool", tool.as_str());
+        }
         // Identify MCP-originated upstream requests. The client's UA is appended
         // with our token by `user_agent`; set last so a forwarded header cannot
         // shadow it.
@@ -168,9 +198,12 @@ impl McpContext {
     /// for this WS-backed quote operation. Quote traffic flows over the
     /// WebSocket quote channel and is therefore invisible to HTTP access logs;
     /// this ping makes the call countable server-side. It reuses an `HttpClient`
-    /// carrying the same `user-agent`, OAuth token, and forwarded headers as the
-    /// real request, so no extra payload is needed. Fire-and-forget: spawned on
-    /// the runtime with its result and errors ignored, never blocking the call.
+    /// from [`create_http_client`], which already carries the `user-agent`, OAuth
+    /// token, forwarded headers, and the `x-mcp-tool` tool tag (see
+    /// [`CURRENT_TOOL`]). Fire-and-forget: spawned on the runtime with its result
+    /// and errors ignored, never blocking the call. The client is built
+    /// synchronously here (reading the task-local before spawning), so the spawn
+    /// not inheriting task-locals is fine.
     fn track_quote_cmd(&self) {
         let client = self.create_http_client();
         tokio::spawn(async move { send_quote_cmd(&client).await });
@@ -3000,18 +3033,24 @@ mod tests {
             }
         });
 
-        // SDK reads the base URL from `LONGBRIDGE_HTTP_URL` (see httpclient config).
-        // SAFETY: single-threaded test setup; no other thread reads it here.
-        unsafe { std::env::set_var("LONGBRIDGE_HTTP_URL", format!("http://{addr}")) };
-
         let mctx = super::McpContext {
             token: "dummy-token".to_string(),
             language: None,
             client_user_agent: Some("claude-code/2.1.89 (cli)".to_string()),
             extra_headers: Vec::new(),
         };
-        let _ = mctx
-            .create_http_client()
+        // Build the client with the SDK base URL redirected at the local server.
+        // Serialized against other env-mutating tests; the guard is released
+        // before the await so it is never held across a suspension point.
+        let client = {
+            let _env_guard = super::HTTP_URL_ENV_LOCK.lock().unwrap();
+            // SAFETY: guarded by HTTP_URL_ENV_LOCK; set before build, cleared after.
+            unsafe { std::env::set_var("LONGBRIDGE_HTTP_URL", format!("http://{addr}")) };
+            let client = mctx.create_http_client();
+            unsafe { std::env::remove_var("LONGBRIDGE_HTTP_URL") };
+            client
+        };
+        let _ = client
             .request(reqwest::Method::GET, "/v1/ping")
             .response::<String>()
             .send()
@@ -3052,7 +3091,7 @@ mod tests {
 
 #[cfg(test)]
 mod quote_cmd_tests {
-    use super::{QUOTE_CMD_PATH, send_quote_cmd};
+    use super::{CURRENT_TOOL, HTTP_URL_ENV_LOCK, McpContext, QUOTE_CMD_PATH, send_quote_cmd};
     use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -3086,20 +3125,34 @@ mod quote_cmd_tests {
         (port, rx)
     }
 
-    /// `send_quote_cmd` must issue `GET /v1/quote/cmd` and carry whatever tracking
-    /// headers the client was built with, so the server can attribute the
-    /// otherwise-invisible WS quote tool call.
+    /// Every upstream request built within a tool scope must carry both the
+    /// synthesized `user-agent` (client UA chained with this server's token) and
+    /// an `x-mcp-tool` header naming the tool, so the server can attribute the
+    /// call per tool. Drives the real `create_http_client` path (which reads the
+    /// `CURRENT_TOOL` task-local set by `measured_tool_call`) and sends the beacon
+    /// to `GET /v1/quote/cmd` against a local server — no HTTP mocking.
     #[tokio::test]
-    async fn send_quote_cmd_hits_endpoint_with_tracking_headers() {
+    async fn upstream_request_carries_x_mcp_tool_and_user_agent() {
         let (port, rx) = spawn_capture_server().await;
 
-        // Build a client the same way `create_http_client` does (token + UA),
-        // but pointed at the local capture server.
-        let oauth = longbridge::oauth::OAuth::from_token("test-token");
-        let config = longbridge::httpclient::HttpClientConfig::from_oauth(oauth)
-            .http_url(format!("http://127.0.0.1:{port}"));
-        let client = longbridge::httpclient::HttpClient::new(config)
-            .header("user-agent", "test-client/9.9 longbridge-mcp/test");
+        let mctx = McpContext {
+            token: "test-token".to_string(),
+            language: None,
+            client_user_agent: Some("claude-test/1.0 (cli)".to_string()),
+            extra_headers: Vec::new(),
+        };
+
+        // Build the client inside a `CURRENT_TOOL` scope (as `measured_tool_call`
+        // does for real tool calls), with the SDK base URL redirected at the
+        // local server. `sync_scope` keeps the locked region free of any await.
+        let client = {
+            let _env_guard = HTTP_URL_ENV_LOCK.lock().unwrap();
+            // SAFETY: guarded by HTTP_URL_ENV_LOCK; set before build, cleared after.
+            unsafe { std::env::set_var("LONGBRIDGE_HTTP_URL", format!("http://127.0.0.1:{port}")) };
+            let client = CURRENT_TOOL.sync_scope("depth".to_string(), || mctx.create_http_client());
+            unsafe { std::env::remove_var("LONGBRIDGE_HTTP_URL") };
+            client
+        };
 
         send_quote_cmd(&client).await;
 
@@ -3107,6 +3160,7 @@ mod quote_cmd_tests {
             .await
             .expect("capture server did not receive a request in time")
             .expect("capture server dropped the request");
+        let lower = request.to_lowercase();
 
         let request_line = request.lines().next().unwrap_or_default();
         assert!(
@@ -3114,10 +3168,16 @@ mod quote_cmd_tests {
             "expected `GET {QUOTE_CMD_PATH}`, got request line: {request_line}"
         );
         assert!(
-            request
-                .to_lowercase()
-                .contains("user-agent: test-client/9.9 longbridge-mcp/test"),
-            "tracking user-agent header missing; request was:\n{request}"
+            lower.contains("x-mcp-tool: depth"),
+            "x-mcp-tool tracking header missing; request was:\n{request}"
+        );
+        let expected_ua = format!(
+            "user-agent: claude-test/1.0 (cli) longbridge-mcp/{}",
+            env!("CARGO_PKG_VERSION")
+        );
+        assert!(
+            lower.contains(&expected_ua.to_lowercase()),
+            "synthesized user-agent missing; request was:\n{request}"
         );
     }
 

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -1,5 +1,5 @@
 use longbridge::quote::{
-    QuoteContext, RequestCreateWatchlistGroup, RequestUpdateWatchlistGroup, SecuritiesUpdateMode,
+    RequestCreateWatchlistGroup, RequestUpdateWatchlistGroup, SecuritiesUpdateMode,
 };
 use rmcp::ErrorData as McpError;
 use rmcp::model::CallToolResult;
@@ -228,7 +228,7 @@ pub async fn static_info(
     mctx: &crate::tools::McpContext,
     p: SymbolsParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .static_info(p.symbols)
         .await
@@ -286,7 +286,7 @@ pub async fn quote(
     mctx: &crate::tools::McpContext,
     p: SymbolsParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx.quote(p.symbols).await.map_err(Error::longbridge)?;
     let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
     normalize_extended_sessions(&mut value);
@@ -297,7 +297,7 @@ pub async fn option_quote(
     mctx: &crate::tools::McpContext,
     p: SymbolsParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .option_quote(p.symbols)
         .await
@@ -309,7 +309,7 @@ pub async fn warrant_quote(
     mctx: &crate::tools::McpContext,
     p: SymbolsParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .warrant_quote(p.symbols)
         .await
@@ -321,7 +321,7 @@ pub async fn depth(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx.depth(p.symbol).await.map_err(Error::longbridge)?;
     tool_json(&result)
 }
@@ -330,13 +330,13 @@ pub async fn brokers(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx.brokers(p.symbol).await.map_err(Error::longbridge)?;
     tool_json(&result)
 }
 
 pub async fn participants(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx.participants().await.map_err(Error::longbridge)?;
     tool_json(&result)
 }
@@ -345,7 +345,7 @@ pub async fn trades(
     mctx: &crate::tools::McpContext,
     p: SymbolCountParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .trades(p.symbol, p.count)
         .await
@@ -361,7 +361,7 @@ pub async fn intraday(
         Some(s) => parse::parse_trade_sessions(s)?,
         None => longbridge::quote::TradeSessions::Intraday,
     };
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .intraday(p.symbol, sessions)
         .await
@@ -380,7 +380,7 @@ pub async fn candlesticks(
     } else {
         longbridge::quote::AdjustType::NoAdjust
     };
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .candlesticks(p.symbol, period, p.count, adjust, sessions)
         .await
@@ -399,7 +399,7 @@ pub async fn history_candlesticks_by_offset(
         Some(ref s) => Some(parse::parse_primitive_datetime(s)?),
         None => None,
     };
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .history_candlesticks_by_offset(
             p.symbol, period, adjust, p.forward, time, p.count, sessions,
@@ -424,7 +424,7 @@ pub async fn history_candlesticks_by_date(
         Some(ref s) => Some(parse::parse_date(s)?),
         None => None,
     };
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .history_candlesticks_by_date(p.symbol, period, adjust, start, end, sessions)
         .await
@@ -439,7 +439,7 @@ pub async fn trading_days(
     let market = parse::parse_market(&p.market)?;
     let start = parse::parse_date(&p.start)?;
     let end = parse::parse_date(&p.end)?;
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .trading_days(market, start, end)
         .await
@@ -451,7 +451,7 @@ pub async fn option_chain_expiry_date_list(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let dates = ctx
         .option_chain_expiry_date_list(p.symbol)
         .await
@@ -471,7 +471,7 @@ pub async fn option_chain_info_by_date(
     p: SymbolDateParam,
 ) -> Result<CallToolResult, McpError> {
     let date = parse::parse_date(&p.date)?;
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .option_chain_info_by_date(p.symbol, date)
         .await
@@ -483,7 +483,7 @@ pub async fn capital_flow(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .capital_flow(p.symbol)
         .await
@@ -495,7 +495,7 @@ pub async fn capital_distribution(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .capital_distribution(p.symbol)
         .await
@@ -521,7 +521,7 @@ pub async fn capital_distribution(
 }
 
 pub async fn trading_session(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx.trading_session().await.map_err(Error::longbridge)?;
     tool_json(&result)
 }
@@ -531,7 +531,7 @@ pub async fn market_temperature(
     p: MarketParam,
 ) -> Result<CallToolResult, McpError> {
     let market = parse::parse_market(&p.market)?;
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .market_temperature(market)
         .await
@@ -546,7 +546,7 @@ pub async fn history_market_temperature(
     let market = parse::parse_market(&p.market)?;
     let start = parse::parse_date(&p.start)?;
     let end = parse::parse_date(&p.end)?;
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .history_market_temperature(market, start, end)
         .await
@@ -555,7 +555,7 @@ pub async fn history_market_temperature(
 }
 
 pub async fn watchlist(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx.watchlist().await.map_err(Error::longbridge)?;
     tool_json(&result)
 }
@@ -564,13 +564,13 @@ pub async fn filings(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx.filings(p.symbol).await.map_err(Error::longbridge)?;
     tool_json(&result)
 }
 
 pub async fn warrant_issuers(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx.warrant_issuers().await.map_err(Error::longbridge)?;
     tool_json(&result)
 }
@@ -619,7 +619,7 @@ pub async fn warrant_list(
         })
         .transpose()?;
 
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let result = ctx
         .warrant_list(
             p.symbol,
@@ -664,7 +664,7 @@ pub async fn calc_indexes(
         .iter()
         .map(|s| parse::parse_calc_index(s))
         .collect::<Result<_, _>>()?;
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let mut result = ctx
         .calc_indexes(p.symbols, indexes)
         .await
@@ -697,7 +697,7 @@ pub async fn create_watchlist_group(
     if let Some(securities) = p.securities {
         req = req.securities(securities);
     }
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let id = ctx
         .create_watchlist_group(req)
         .await
@@ -709,7 +709,7 @@ pub async fn delete_watchlist_group(
     mctx: &crate::tools::McpContext,
     p: DeleteWatchlistGroupParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let id = p.id;
     ctx.delete_watchlist_group(id, p.purge)
         .await
@@ -735,7 +735,7 @@ pub async fn update_watchlist_group(
         };
         req = req.mode(mode);
     }
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     ctx.update_watchlist_group(req)
         .await
         .map_err(Error::longbridge)?;
@@ -751,7 +751,7 @@ pub async fn security_list(
         Some(ref s) => Some(parse::parse_security_list_category(s)?),
         None => None,
     };
-    let (ctx, _) = QuoteContext::new(mctx.create_config());
+    let ctx = mctx.create_quote_context();
     let all = ctx
         .security_list(market, category)
         .await


### PR DESCRIPTION
## What

Quote tools (`quote`, `depth`, `candlesticks`, `brokers`, `trades`, …) talk to Longbridge over the WebSocket quote channel, which produces no HTTP access-log entry — so server-side request statistics lose all WS-backed quote usage.

This fires a best-effort `GET /v1/quote/cmd` beacon whenever a quote tool builds its `QuoteContext`. The request carries the same `user-agent` and OAuth token as the real call, giving the server a log entry to attribute the otherwise-invisible WS operation. It is fire-and-forget: spawned on the runtime, errors ignored, and never blocks or delays the tool response.

## Per-tool attribution (`x-mcp-tool`)

Every upstream Longbridge request now carries an `x-mcp-tool` header naming the originating tool — the MCP analog of the CLI's `x-cli-cmd` — so server stats can group by tool. A `CURRENT_TOOL` task-local is scoped around each call in `measured_tool_call`; `create_http_client` / `create_config` read it when building requests. This covers **all** tools (the quote beacon plus every REST/WS context call), not just quote.

## Coverage

- All quote tools obtain their context via `McpContext::create_quote_context()` instead of `QuoteContext::new(...)`.
- `x-mcp-tool` is applied uniformly via the task-local, so trade / content / fundamental / asset / screener / etc. requests are tagged too.

## Tests

- Integration test stands up a real local HTTP server and asserts the beacon hits `GET /v1/quote/cmd` carrying both `x-mcp-tool` (from the task-local) and the synthesized `user-agent`, driving the real `create_http_client` path — no HTTP mocking.
- Guard test fails if any tool file calls `QuoteContext::new(` directly, enforcing that every WS quote tool stays tracked.

Verified live: the endpoint returns `200` on staging (`.xyz`), global (`.com`), and CN (`.cn`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
