### PR TITLE
fix(tools): set explicit destructiveHint on all tools; document annot…

### DIFF
--- a/docs/mcp-annotations/README.md
+++ b/docs/mcp-annotations/README.md
@@ -1,0 +1,96 @@
+# MCP Tool Annotations — OpenAI Submission Review
+
+This directory addresses two items from the OpenAI MCP submission review for the
+Longbridge MCP server:
+
+1. **Every tool must explicitly set `readOnlyHint`, `openWorldHint`, and
+   `destructiveHint`.** (Mandatory — fixed in code.)
+2. **For each tool, justify why each explicit annotation value is accurate** and
+   does not misrepresent what the tool does. (Per-tool rationale, below.)
+
+It also notes the optional `outputSchema` recommendation (see the end).
+
+## 1. Code fix: every tool now sets the three required hints
+
+Before this change, the 123 read-only tools and `authenticate` declared
+`readOnlyHint` and `openWorldHint` (and `idempotentHint`) but **omitted
+`destructiveHint`**, which the review flagged as missing.
+
+We added the explicit value to every tool that lacked it
+(`src/tools/mod.rs`):
+
+- **123 read-only tools + `now`** → `destructive_hint = false`
+  (a read-only tool performs no updates at all, so it is non-destructive by
+  construction — see the MCP semantics note below).
+- **`authenticate`** → `destructive_hint = false`
+  (it establishes a session from a one-time code; it creates credentials, it
+  does not overwrite or delete existing data).
+
+The 22 mutating tools already declared `destructiveHint` explicitly and were
+left unchanged.
+
+After the change, all **146** tools set `readOnlyHint`, `destructiveHint`,
+`idempotentHint`, and `openWorldHint` explicitly. Verified by parsing
+`src/tools/mod.rs`; the crate compiles (`cargo check --all-features`, exit 0).
+
+## MCP annotation semantics (the basis for every justification)
+
+Per the [MCP spec — Tool Annotations](https://modelcontextprotocol.io/specification/draft/server/tools#tool):
+
+| Hint | Meaning |
+|------|---------|
+| `readOnlyHint = true` | The tool does not modify its environment — it is a pure read. |
+| `destructiveHint = true` | The tool may perform destructive (irreversible / overwriting / deleting) updates. `false` = updates are additive or non-destructive. Only meaningful when `readOnlyHint = false`; for a read-only tool it is trivially `false` because the tool performs no updates at all. |
+| `idempotentHint = true` | Repeated calls with the same arguments have no additional effect beyond the first. |
+| `openWorldHint = true` | The tool interacts with external entities outside the server's closed system. Here, **every** tool reaches the Longbridge market/brokerage backend over the network, whose responses change with the live market and are not controlled by this server — hence `true` everywhere. |
+
+## 2. Per-tool annotation justifications
+
+All 146 tools are covered (verified: no tool missing, no duplicates). The
+rationale is split by functional domain:
+
+| File | Domain | Tools |
+|------|--------|-------|
+| [`group-a-market.md`](group-a-market.md) | Market & quote data (read-only) | 38 |
+| [`group-b-account.md`](group-b-account.md) | Account & trade records (read-only) | 16 |
+| [`group-c-fundamentals.md`](group-c-fundamentals.md) | Fundamentals & research (read-only) | 40 |
+| [`group-d-content.md`](group-d-content.md) | News / screener / IPO / DCA / watchlist queries (read-only) | 29 |
+| [`group-e-mutating.md`](group-e-mutating.md) | Mutating tools (`readOnlyHint = false`) | 23 |
+
+Each entry gives a one-to-two sentence justification per explicit annotation
+value, grounded in what the tool actually does (verified against its
+implementation in `src/tools/*.rs`, not just its description).
+
+### Items the reviewers flagged for a second look
+
+The sub-agents that wrote the rationale surfaced a few values worth a conscious
+sign-off (all judged accurate, but they are the non-obvious ones):
+
+- **`screener_search`, `dca_check`, `quant_run`** issue an HTTP `POST` upstream
+  but are **read-only**: the POST body only carries input parameters; the call
+  computes/queries against live data and persists nothing. Annotated
+  `readOnlyHint = true` accordingly.
+- **`submit_order`** is annotated `destructiveHint = true`. Strictly, MCP's
+  `destructiveHint` concerns overwriting/deleting *existing* data, whereas
+  submitting an order is an *irreversible side effect*. We treat an action this
+  consequential as destructive; this is the one tool where a narrow reading of
+  the spec could differ.
+- **`sharelist_add` (`idempotentHint = false`) vs `sharelist_remove`
+  (`idempotentHint = true`)** — adding can create duplicate entries (not
+  idempotent); removing the same symbol twice has no further effect
+  (idempotent). The asymmetry is intentional.
+- **`withdrawals` / `deposits` / `bank_cards`** are **history/listing queries**
+  (GET only); they do not initiate fund movements. Annotated read-only.
+
+## 3. Optional: `outputSchema` recommendation
+
+The review also shows a non-blocking *"Recommended: Add an outputSchema"* notice
+on each tool. Currently **14** tools declare a typed `output_schema` (via
+`schema_for::<output::*>()`, defined in `src/tools/output.rs`); the remaining
+**132** do not.
+
+This is a recommendation, not a submission blocker. Adding output schemas for
+the rest is tracked separately — most return loosely-typed JSON proxied straight
+from the upstream Longbridge API, so each needs a typed `output::*` struct
+(matching the post-`to_tool_json` snake_case + RFC3339 shape) before its tool
+can reference it. See `src/tools/output.rs` for the established pattern.

--- a/docs/mcp-annotations/group-a-market.md
+++ b/docs/mcp-annotations/group-a-market.md
@@ -1,0 +1,260 @@
+# Group A — Market & Quote Data Tools: Annotation Accuracy Rationale
+
+This document justifies the explicit MCP tool annotations for the read-only
+market-data / quote tools. Every tool in this group declares the identical
+annotation set:
+
+```
+readOnlyHint    = true
+destructiveHint  = false
+idempotentHint   = true
+openWorldHint    = true
+```
+
+Annotation semantics applied throughout:
+
+- **readOnlyHint = true** — the tool only reads; it never modifies any
+  environment or state.
+- **destructiveHint = false** — the tool performs no destructive
+  (irreversible / overwriting / deleting) update. A read-only tool writes
+  nothing at all, so it is non-destructive by construction.
+- **idempotentHint = true** — repeated calls with the same arguments produce no
+  additional side effects (reading is inherently idempotent).
+- **openWorldHint = true** — the tool interacts with entities outside this
+  server: it reaches the Longbridge real-time quote / market backend over the
+  network, and the values returned change with the live market and are not
+  controlled by this server.
+
+Each tool dispatches to the SDK's `QuoteContext` / market endpoints via
+`extract_context(...)` and only ever issues a fetch; none of them call any
+mutating SDK method.
+
+---
+
+### now
+- **Read Only = true** — Returns the current UTC time as an RFC3339 string; it reads the system clock and writes nothing.
+- **Destructive = false** — Reading the clock changes no state, so nothing can be overwritten or deleted.
+- **Idempotent = true** — Calling it repeatedly only re-reads the clock; no side effects accumulate (the returned timestamp simply advances with real time).
+- **Open World = true** — The value reflects real wall-clock time outside this server's control, advancing independently of the server.
+
+### static_info
+- **Read Only = true** — Fetches static security metadata (symbol, names, exchange, type, lot_size, listed_date, delisted) for the given symbols; pure lookup, no writes.
+- **Destructive = false** — Only retrieves reference data; nothing is modified or removed.
+- **Idempotent = true** — Repeated calls with the same symbols return the same metadata and leave no side effects.
+- **Open World = true** — Reads listing/reference data from the Longbridge backend over the network; the data is maintained externally by exchanges/Longbridge.
+
+### quote
+- **Read Only = true** — Returns the latest price quote fields (last_done, open/high/low, volume, turnover, change, trade_status, timestamp) per symbol; it only reads live quotes.
+- **Destructive = false** — Reading quotes does not write, overwrite, or delete anything.
+- **Idempotent = true** — Re-querying the same symbols has no cumulative effect; each call just reads the current snapshot.
+- **Open World = true** — Quote values come from the live Longbridge quote feed over the network and change continuously with the market, outside server control.
+
+### option_quote
+- **Read Only = true** — Reads option quote data including Greeks (delta, gamma, theta, vega, rho), IV, and open_interest for up to 500 symbols; lookup only.
+- **Destructive = false** — Pure read of option market data; no state is altered.
+- **Idempotent = true** — Repeated identical queries return current values with no side effects.
+- **Open World = true** — Option quotes and Greeks are sourced live from the Longbridge backend over the network and vary with the market.
+
+### warrant_quote
+- **Read Only = true** — Reads warrant quote fields (price, volume, IV, delta, leverage_ratio, effective_leverage) per symbol; no writes.
+- **Destructive = false** — Retrieves warrant market data only; nothing is modified.
+- **Idempotent = true** — Repeated calls only re-read live data, with no accumulating effect.
+- **Open World = true** — Warrant quotes are fetched live from the Longbridge backend over the network and change with the market.
+
+### depth
+- **Read Only = true** — Returns the order-book depth (bid/ask price levels with volume and order_num) for a symbol; it only reads the order book.
+- **Destructive = false** — Reading the book places no order and changes no state.
+- **Idempotent = true** — Re-reading the depth has no side effects; each call is an independent snapshot read.
+- **Open World = true** — Order-book depth is live exchange data delivered through the Longbridge backend over the network, controlled by the market.
+
+### brokers
+- **Read Only = true** — Returns the HK broker queue (bid/ask broker IDs by position) for a symbol; a pure read of broker-queue data.
+- **Destructive = false** — Only reads queue data; nothing is written or deleted.
+- **Idempotent = true** — Repeated calls re-read the same live queue with no side effects.
+- **Open World = true** — Broker-queue data originates from HKEX via the Longbridge backend over the network and changes with the market.
+
+### participants
+- **Read Only = true** — Returns the HK market participant directory (broker_ids mapped to names); a static reference lookup.
+- **Destructive = false** — Read-only reference fetch; no modification of any state.
+- **Idempotent = true** — The same reference list is returned on repeat calls with no side effects.
+- **Open World = true** — The participant directory is maintained externally and retrieved from the Longbridge backend over the network.
+
+### trades
+- **Read Only = true** — Returns recent trade ticks (price, volume, timestamp, trade_type, direction; up to 1000) for a symbol; read-only.
+- **Destructive = false** — Reads historical/recent ticks only; no state is altered.
+- **Idempotent = true** — Repeated identical queries just re-read tick data, with no cumulative effect.
+- **Open World = true** — Trade ticks are live exchange data served by the Longbridge backend over the network.
+
+### intraday
+- **Read Only = true** — Returns intraday minute-by-minute price/volume series for a symbol; pure read.
+- **Destructive = false** — Reading the intraday line writes nothing and removes nothing.
+- **Idempotent = true** — Repeated calls re-read the series; no side effects accumulate.
+- **Open World = true** — Intraday data is sourced live from the Longbridge backend over the network and updates with the trading session.
+
+### candlesticks
+- **Read Only = true** — Returns OHLCV candlestick data for a symbol/period; it only reads K-line data.
+- **Destructive = false** — Pure read of price history; no state is modified.
+- **Idempotent = true** — Re-querying the same parameters returns the same/updated candles with no side effects.
+- **Open World = true** — Candlestick data comes from the Longbridge backend over the network and reflects external market activity.
+
+### history_candlesticks_by_offset
+- **Read Only = true** — Reads historical candlesticks anchored by an offset from a reference time; lookup only.
+- **Destructive = false** — Only retrieves historical K-line data; nothing is written.
+- **Idempotent = true** — Identical parameters yield the same historical window with no side effects.
+- **Open World = true** — Historical candles are fetched from the Longbridge backend over the network; the underlying data is externally maintained.
+
+### history_candlesticks_by_date
+- **Read Only = true** — Reads historical candlesticks for a given date range; pure read.
+- **Destructive = false** — Retrieves historical price data only; no modification of state.
+- **Idempotent = true** — The same date range returns the same data on repeat calls, with no side effects.
+- **Open World = true** — Historical data is retrieved from the Longbridge backend over the network, controlled by the exchange/Longbridge.
+
+### trading_days
+- **Read Only = true** — Returns trading and half-trading days for a market between two dates; a calendar lookup.
+- **Destructive = false** — Reading the trading calendar changes no state.
+- **Idempotent = true** — The same market and date range return the same calendar with no side effects.
+- **Open World = true** — The trading calendar is maintained externally and served from the Longbridge backend over the network.
+
+### option_chain_expiry_date_list
+- **Read Only = true** — Returns the list of option-chain expiry dates for a symbol; pure lookup.
+- **Destructive = false** — Only reads available expiries; nothing is written or deleted.
+- **Idempotent = true** — Repeated calls return the same expiry list with no side effects.
+- **Open World = true** — Expiry data is fetched from the Longbridge backend over the network and reflects externally listed contracts.
+
+### option_chain_info_by_date
+- **Read Only = true** — Returns the option chain (strikes with call/put quotes and Greeks) for an expiry date; read-only.
+- **Destructive = false** — Retrieves chain data only; no state is modified.
+- **Idempotent = true** — Identical queries re-read the chain with no cumulative effect.
+- **Open World = true** — Chain quotes and Greeks are live data from the Longbridge backend over the network and change with the market.
+
+### capital_flow
+- **Read Only = true** — Returns the same-day capital inflow/outflow/net-flow time series for a symbol; pure read.
+- **Destructive = false** — Reading capital-flow data writes nothing.
+- **Idempotent = true** — Repeated calls re-read the series with no side effects.
+- **Open World = true** — Capital-flow data is computed externally and served from the Longbridge backend over the network.
+
+### capital_distribution
+- **Read Only = true** — Returns capital-in/capital-out broken down by large/medium/small order size for a symbol; read-only.
+- **Destructive = false** — Pure read of distribution data; no modification.
+- **Idempotent = true** — The same symbol returns the current distribution on repeat calls, with no side effects.
+- **Open World = true** — Distribution data is sourced from the Longbridge backend over the network and reflects live market flow.
+
+### trading_session
+- **Read Only = true** — Returns the trading-session schedule (session windows and types) for all markets; a schedule lookup.
+- **Destructive = false** — Reading the schedule changes no state.
+- **Idempotent = true** — Returns the same schedule on repeat calls with no side effects.
+- **Open World = true** — Session schedules are defined by the exchanges and retrieved from the Longbridge backend over the network.
+
+### market_temperature
+- **Read Only = true** — Returns the current market sentiment temperature (temperature, valuation, sentiment, description, timestamp) for a market; read-only.
+- **Destructive = false** — Reads a computed sentiment metric; nothing is written.
+- **Idempotent = true** — Re-querying the same market re-reads the metric with no side effects.
+- **Open World = true** — The temperature is computed externally and served live from the Longbridge backend over the network.
+
+### history_market_temperature
+- **Read Only = true** — Returns the historical market-temperature time series for a market and date range; pure read.
+- **Destructive = false** — Retrieves historical sentiment data only; no state change.
+- **Idempotent = true** — The same market/date range returns the same series with no side effects.
+- **Open World = true** — Historical sentiment data is fetched from the Longbridge backend over the network.
+
+### watchlist
+- **Read Only = true** — Returns the user's existing watchlist groups and their securities; it only reads the watchlist and never modifies it. (Mutation is handled by the separate create/update/delete_watchlist_group tools, which are not in this group.)
+- **Destructive = false** — Reading the watchlist neither adds, removes, nor reorders any group or security.
+- **Idempotent = true** — Repeated calls return the current watchlist with no side effects.
+- **Open World = true** — The watchlist is stored in the user's Longbridge account and retrieved from the backend over the network.
+
+### filings
+- **Read Only = true** — Returns regulatory filings (8-K, 10-Q, 10-K, etc.) metadata and URLs for a symbol; pure lookup.
+- **Destructive = false** — Reads filing listings only; nothing is written or deleted.
+- **Idempotent = true** — Repeated identical queries return the same listing with no side effects.
+- **Open World = true** — Filing data originates from regulators and is served from the Longbridge backend over the network.
+
+### warrant_issuers
+- **Read Only = true** — Returns the HK warrant issuer directory (id and names); a static reference lookup.
+- **Destructive = false** — Read-only reference fetch; no modification.
+- **Idempotent = true** — Returns the same issuer list on repeat calls with no side effects.
+- **Open World = true** — The issuer directory is maintained externally and fetched from the Longbridge backend over the network.
+
+### warrant_list
+- **Read Only = true** — Returns a filtered list of warrants for an underlying symbol with their quote/term fields; read-only.
+- **Destructive = false** — Only reads the warrant list; no state is altered.
+- **Idempotent = true** — The same filter returns matching warrants on repeat calls with no side effects.
+- **Open World = true** — Warrant listings and quotes are live data from the Longbridge backend over the network.
+
+### calc_indexes
+- **Read Only = true** — Computes/returns requested financial indexes (e.g. PE, PB, LastDone, TurnoverRate) for the given symbols by reading market data; it performs no writes.
+- **Destructive = false** — The "calculation" is a derived read over market data; no environment state is modified.
+- **Idempotent = true** — The same symbols and indexes yield the same computed values with no side effects.
+- **Open World = true** — Inputs are live market values fetched from the Longbridge backend over the network, so outputs change with the market.
+
+### security_list
+- **Read Only = true** — Returns a paginated security list for a market/category; a directory lookup.
+- **Destructive = false** — Reads the listing only; nothing is written or removed.
+- **Idempotent = true** — The same market/category/page returns the same page with no side effects.
+- **Open World = true** — The security universe is maintained externally and served from the Longbridge backend over the network.
+
+### market_status
+- **Read Only = true** — Returns the current trading status (Trading, Closed, Lunch Break, etc.) per market; pure read.
+- **Destructive = false** — Reading market status changes no state.
+- **Idempotent = true** — Repeated calls re-read the current status with no side effects.
+- **Open World = true** — Market status reflects live exchange state delivered by the Longbridge backend over the network.
+
+### exchange_rate
+- **Read Only = true** — Returns current exchange rates for supported currency pairs; a pure read.
+- **Destructive = false** — Reading FX rates writes nothing.
+- **Idempotent = true** — Repeated calls re-read current rates with no side effects.
+- **Open World = true** — FX rates are sourced externally and served live from the Longbridge backend over the network.
+
+### ah_premium
+- **Read Only = true** — Returns the A/H share premium historical K-line (OHLC of the premium percentage); read-only.
+- **Destructive = false** — Retrieves historical premium data only; no modification.
+- **Idempotent = true** — The same parameters return the same series with no side effects.
+- **Open World = true** — A/H premium data is derived from live cross-market prices via the Longbridge backend over the network.
+
+### ah_premium_intraday
+- **Read Only = true** — Returns the intraday A/H premium time-share series (timestamp, premium_rate); pure read.
+- **Destructive = false** — Reads intraday premium data only; no state change.
+- **Idempotent = true** — Repeated calls re-read the series with no side effects.
+- **Open World = true** — Intraday premium values reflect live market prices from the Longbridge backend over the network.
+
+### trade_stats
+- **Read Only = true** — Returns the buy/sell/neutral volume distribution (price-volume profile) for a symbol; read-only.
+- **Destructive = false** — Reads statistics only; nothing is written.
+- **Idempotent = true** — The same symbol returns the current profile on repeat calls with no side effects.
+- **Open World = true** — Trade statistics are computed from live market data and served from the Longbridge backend over the network.
+
+### anomaly
+- **Read Only = true** — Returns market anomaly alerts (unusual price/volume changes) for a market or symbol; a pure read of detected anomalies.
+- **Destructive = false** — Reading alerts changes no state.
+- **Idempotent = true** — The same filter returns the current alert set on repeat calls with no side effects.
+- **Open World = true** — Anomaly detection runs externally and results are served live from the Longbridge backend over the network.
+
+### constituent
+- **Read Only = true** — Returns index constituents or an ETF's asset allocation (holdings, regional, asset-class, industry breakdowns); pure lookup.
+- **Destructive = false** — Reads constituent/allocation data only; nothing is modified.
+- **Idempotent = true** — The same index/ETF returns the same composition on repeat calls with no side effects.
+- **Open World = true** — Constituent and allocation data are maintained externally and fetched from the Longbridge backend over the network.
+
+### short_positions
+- **Read Only = true** — Returns short-interest history (open short positions, ratio, days_to_cover, etc.) for HK/US stocks; read-only.
+- **Destructive = false** — Reads short-interest data only; no state change.
+- **Idempotent = true** — The same symbol/count returns the same history on repeat calls with no side effects.
+- **Open World = true** — Short-interest data originates from FINRA (US) and HKEX (HK) and is served from the Longbridge backend over the network.
+
+### option_volume
+- **Read Only = true** — Returns real-time call/put volume stats (call/put volume, put_call_ratio, open interest, top contracts) for a US stock; pure read.
+- **Destructive = false** — Reads option-volume stats only; nothing is written.
+- **Idempotent = true** — Repeated calls re-read the current stats with no side effects.
+- **Open World = true** — Option-volume stats are live data from the Longbridge backend over the network and change with the market.
+
+### option_volume_daily
+- **Read Only = true** — Returns daily historical option volume/open-interest stats for a US stock; read-only.
+- **Destructive = false** — Retrieves historical option stats only; no modification.
+- **Idempotent = true** — The same symbol returns the same daily series on repeat calls with no side effects.
+- **Open World = true** — Daily option stats are fetched from the Longbridge backend over the network and reflect external market data.
+
+### top_movers
+- **Read Only = true** — Returns stocks whose price move exceeds the 20-trading-day standard deviation, with correlated news; a pure read of computed events.
+- **Destructive = false** — Reading the movers list changes no state.
+- **Idempotent = true** — The same parameters (markets/sort/limit/cursor) return the same page with no side effects; pagination is driven by the supplied cursor, not by mutation.
+- **Open World = true** — Top-mover events are computed externally from live market data and served from the Longbridge backend over the network.

--- a/docs/mcp-annotations/group-b-account.md
+++ b/docs/mcp-annotations/group-b-account.md
@@ -1,0 +1,143 @@
+# MCP Annotation Accuracy Justifications — Group B: Account & Trade-Record Queries
+
+This document justifies the explicit MCP tool annotations for the account and
+trade-record query tools in the Longbridge MCP server, for the OpenAI MCP
+submission review form. Every tool in this group is declared with:
+
+```
+read_only_hint = true
+destructive_hint = false
+idempotent_hint = true
+open_world_hint = true
+```
+
+Each section explains why every annotation value is accurate and does not
+misrepresent the tool's real behavior. Justifications are grounded in the
+verified implementation:
+
+- Tool definitions and annotations: `src/tools/mod.rs`
+- Implementations: `src/tools/trade.rs`, `src/tools/statement.rs`, `src/tools/atm.rs`
+- The HTTP helper `http_get_tool` (`src/tools/support/http_client.rs`) issues only `Method::GET`.
+
+All upstream calls in this group are read-only: they invoke SDK getters
+(`account_balance`, `stock_positions`, `cash_flow`, `statements`,
+`statement_download_url`, `estimate_max_purchase_quantity`, etc.) or plain HTTP
+GET requests against `/v1/account/...` and `/v1/asset/...` endpoints. None of
+them submit, modify, cancel, or transfer anything.
+
+---
+
+### account_balance
+- **Read Only = true** — Calls `TradeContext::account_balance(currency)` (`trade.rs:139`), a pure getter that returns cash balance and asset summary. It accepts only an optional currency filter and writes nothing to the account.
+- **Destructive = false** — It performs no update of any kind; there is no write path, so no data can be lost or overwritten.
+- **Idempotent = true** — Repeating the call with the same currency filter produces no additional side effects; it just re-reads the current balance.
+- **Open World = true** — It reaches the external Longbridge brokerage backend over the network. Balances reflect live market valuations and account activity outside this server's control, so successive reads may legitimately return different values.
+
+### stock_positions
+- **Read Only = true** — Calls `TradeContext::stock_positions(None)` (`trade.rs:151`), a getter returning current stock holdings. No parameters that mutate state; no write occurs.
+- **Destructive = false** — No update or deletion is performed; positions are only read.
+- **Idempotent = true** — Re-invoking it has no cumulative effect; it simply re-fetches the holdings snapshot.
+- **Open World = true** — Data comes from the remote Longbridge account backend and changes as fills/corporate actions occur outside this server.
+
+### fund_positions
+- **Read Only = true** — Calls `TradeContext::fund_positions(None)` (`trade.rs:157`), a getter for current fund holdings. It is parameterless apart from the implicit filter and never writes.
+- **Destructive = false** — No mutation; fund positions are only read.
+- **Idempotent = true** — Repeated calls re-read the same holdings with no side effects.
+- **Open World = true** — Backed by the external Longbridge backend; NAV and holding units update over time independently of this server.
+
+### margin_ratio
+- **Read Only = true** — Calls `TradeContext::margin_ratio(symbol)` (`trade.rs:163`), returning initial/maintenance/forced-liquidation margin factors for a symbol. It is a lookup; nothing is changed.
+- **Destructive = false** — No write or update; the factors are read-only reference values.
+- **Idempotent = true** — Querying the same symbol repeatedly yields the same kind of read with no side effects.
+- **Open World = true** — Margin factors are served by the remote Longbridge backend and may change per upstream risk policy, outside this server's control.
+
+### today_orders
+- **Read Only = true** — Calls `TradeContext::today_orders(opts)` (`trade.rs:175`) with an optional symbol filter; it lists orders placed today and does not create, modify, or cancel any order.
+- **Destructive = false** — Pure listing; no order is altered or removed.
+- **Idempotent = true** — Re-running the query (same filter) has no effect on orders or account state.
+- **Open World = true** — Reads live order state from the Longbridge backend, which changes as orders are submitted/filled elsewhere.
+
+### order_detail
+- **Read Only = true** — Calls `TradeContext::order_detail(order_id)` (`trade.rs:188`), fetching the details of one order by id. It only reads.
+- **Destructive = false** — No mutation of the order; status/quantities are reported, not changed.
+- **Idempotent = true** — Repeated lookups of the same order_id are side-effect free.
+- **Open World = true** — The order record lives on the remote brokerage backend and reflects real-time execution state outside this server.
+
+### today_executions
+- **Read Only = true** — Calls `TradeContext::today_executions` and `today_orders` (joined via `tokio::try_join!`, `trade.rs:211`) to list today's fills and annotate each with its order side. Both are getters; no execution or order is created or modified.
+- **Destructive = false** — The side annotation is computed in-memory on the returned data only; nothing upstream is written.
+- **Idempotent = true** — Re-querying the same filters re-reads fills with no cumulative side effects.
+- **Open World = true** — Execution data is fetched live from the Longbridge backend and grows as trades fill during the day.
+
+### history_orders
+- **Read Only = true** — Calls `TradeContext::history_orders(opts)` with a date range and optional symbol (`trade.rs:253`). It is a historical read; no order is touched.
+- **Destructive = false** — No write/update/delete; orders are only listed.
+- **Idempotent = true** — Same date range and filter re-read the same historical set with no side effects.
+- **Open World = true** — Historical order data resides on the remote Longbridge backend and is not controlled by this server.
+
+### history_executions
+- **Read Only = true** — Calls `TradeContext::history_executions` and `history_orders` (joined, `trade.rs:270`) to list historical fills and annotate side. Both are getters; nothing is mutated.
+- **Destructive = false** — Only in-memory enrichment of read data; no upstream write.
+- **Idempotent = true** — Repeating the date-range query is side-effect free.
+- **Open World = true** — Backed by the external Longbridge backend serving real historical trade records.
+
+### cash_flow
+- **Read Only = true** — Calls `TradeContext::cash_flow(opts)` over a date range (`trade.rs:316`), listing cash movement records (deposits, withdrawals, dividends). It reports past transactions; it does not initiate any cash movement.
+- **Destructive = false** — Pure listing of existing records; no write or update.
+- **Idempotent = true** — Re-querying the same date range re-reads the same records with no side effects.
+- **Open World = true** — Records come from the remote Longbridge backend and reflect account activity outside this server's control.
+
+### estimate_max_purchase_quantity
+- **Read Only = true** — Calls `TradeContext::estimate_max_purchase_quantity(opts)` (`trade.rs:444`). Despite taking order-like parameters (symbol, side, order_type, optional price), it only *estimates* the maximum buy/sell quantity (returns `cash_max_qty`, `margin_max_qty`). No order is constructed or submitted — confirmed by the implementation, which builds `EstimateMaxPurchaseQuantityOptions` and calls the estimation getter, never `submit_order`. The parameters are inputs to a calculation, not an order placement.
+- **Destructive = false** — It is a what-if calculation; no account state, position, or order is created or changed.
+- **Idempotent = true** — The same inputs return the same estimate (subject to live data) with no cumulative side effects.
+- **Open World = true** — The estimate is computed by the remote Longbridge backend using live buying power and margin data, which vary over time outside this server.
+
+### statement_list
+- **Read Only = true** — Calls `AssetContext::statements(options)` (`statement.rs:30`) to list available daily/monthly statements (id, type, date, status). It only enumerates existing statements.
+- **Destructive = false** — No statement is generated, deleted, or modified; the list is read-only.
+- **Idempotent = true** — Re-listing with the same parameters returns the same available statements with no side effects.
+- **Open World = true** — Statement metadata is served by the remote Longbridge backend, where new statements appear over time independently of this server.
+
+### statement_export
+- **Read Only = true** — Calls `AssetContext::statement_download_url(options)` (`statement.rs:75`). It only retrieves a pre-signed download URL for an existing statement file (keyed by `file_key` from `statement_list`); it returns `{url}` and does nothing else. It does not generate, alter, or move the statement, and it does not even download the file itself.
+- **Destructive = false** — Producing a download URL is non-destructive: the underlying statement data is unchanged, and no account state is touched.
+- **Idempotent = true** — Requesting the URL for the same `file_key` repeatedly is side-effect free (it yields a fresh pre-signed link to the same data each time, but no account or statement state changes).
+- **Open World = true** — The URL is minted by the remote Longbridge backend / object store, outside this server's control; the link is time-limited and externally managed.
+
+### bank_cards
+- **Read Only = true** — Calls `http_get_tool(client, "/v1/account/bank-cards", &[])` (`atm.rs:29`), an HTTP GET that *lists* the linked withdrawal bank cards (masked). It is a query of existing linked cards; it does not add, remove, or modify any card, and it does not initiate any transfer.
+- **Destructive = false** — Pure GET listing; no card is created/deleted/changed.
+- **Idempotent = true** — Repeating the GET returns the current card list with no side effects.
+- **Open World = true** — Card data is served by the remote Longbridge `/v1/account/bank-cards` endpoint, outside this server's control.
+
+### withdrawals
+- **Read Only = true** — Calls `http_get_tool(client, "/v1/account/withdrawals", ...)` with page/size/account_channel params (`atm.rs:35`). This is an HTTP GET that *lists withdrawal history*; it does **not** initiate a withdrawal. Confirmed by the implementation: it only issues a GET against the history endpoint with paging parameters.
+- **Destructive = false** — Listing past withdrawals changes nothing; no funds are moved.
+- **Idempotent = true** — Re-fetching the same page is side-effect free.
+- **Open World = true** — History is served by the remote Longbridge backend and grows as real withdrawals occur outside this server.
+
+### deposits
+- **Read Only = true** — Calls `http_get_tool(client, "/v1/account/deposits", ...)` with page/size/account_channel and optional states/currencies filters (`atm.rs:56`). This is an HTTP GET that *lists deposit history*; it does **not** initiate a deposit. Confirmed by the implementation: a GET against the history endpoint with filter/paging query params only.
+- **Destructive = false** — Listing past deposits changes nothing; no funds are moved.
+- **Idempotent = true** — Re-fetching the same filtered page produces no side effects.
+- **Open World = true** — History is served by the remote Longbridge backend and reflects real deposit activity outside this server's control.
+
+---
+
+## Verification note
+
+All three fund-related tools (`bank_cards`, `withdrawals`, `deposits`) were
+confirmed via source inspection to be **queries**, not fund-movement operations:
+each delegates to `http_get_tool`, which issues only `Method::GET`
+(`src/tools/support/http_client.rs:29`). There is no POST/PUT/DELETE and no
+"initiate withdrawal/deposit" path anywhere in `atm.rs`.
+
+Similarly, `estimate_max_purchase_quantity` was confirmed to call the SDK's
+estimation getter and never `submit_order`, and `statement_export` was confirmed
+to only return a pre-signed download URL.
+
+No tool in this group has an annotation value that appears inaccurate. All 16
+tools are genuine read-only queries and the declared
+`read_only_hint=true / destructive_hint=false / idempotent_hint=true /
+open_world_hint=true` set is accurate for each.

--- a/docs/mcp-annotations/group-c-fundamentals.md
+++ b/docs/mcp-annotations/group-c-fundamentals.md
@@ -1,0 +1,351 @@
+# Group C — Fundamentals & Research Data Tools: Annotation Accuracy Justification
+
+This document supports the OpenAI MCP submission review. It justifies, per tool, why each
+explicitly declared annotation value is accurate and does not misrepresent the tool's actual
+behavior.
+
+All tools in this group are **read-only fundamental/research data queries**. Each is implemented
+as a single HTTP `GET` request against the Longbridge fundamental/research backend (e.g.
+`GET /v1/quote/...`, `GET /v1/asset/cash/short-margin`) via the shared `http_get_tool` /
+`http_get_tool_unix` helpers. None of them issue any write, mutation, or side-effecting request.
+
+Shared annotation semantics for this group:
+
+- **readOnlyHint = true** — the tool only reads fundamental/research data; it never modifies any
+  state on the server or in the user's account.
+- **destructiveHint = false** — the tool performs no write or destructive update of any kind.
+- **idempotentHint = true** — calling with the same parameters repeatedly produces no additional
+  side effects (each call is just another read).
+- **openWorldHint = true** — the tool reaches an external Longbridge fundamental/research backend
+  over the network; the returned data tracks the market and issuer disclosures and is not under
+  this server's control.
+
+---
+
+### financial_report
+- **Read Only = true** — Performs `GET /v1/quote/financial-reports` to fetch income statement,
+  balance sheet, and cash flow data (kind IS/BS/CF/ALL; report_type af/saf/q1-q3/qf). Pure read.
+- **Destructive = false** — Retrieving published financial statements alters nothing.
+- **Idempotent = true** — Repeating the same symbol/kind/report_type returns the same statements
+  with no cumulative effect.
+- **Open World = true** — Statement data is sourced from issuer filings on the external Longbridge
+  backend and updates as new periods are disclosed; the server does not control it.
+
+### financial_statement
+- **Read Only = true** — Reads income statement, balance sheet, or cash flow (kind IS/BS/CF/ALL;
+  report af/saf/qf/q1-q3) for a security via a backend GET. No state is changed.
+- **Destructive = false** — Reading statement line items writes nothing.
+- **Idempotent = true** — Identical kind/report parameters yield the same statement data each call.
+- **Open World = true** — Backed by externally-disclosed issuer financials that change with each
+  reporting period, outside server control.
+
+### financial_report_latest
+- **Read Only = true** — Reads the latest report summary (period, revenue, net_income, eps, roe,
+  gross_margin, report_date). Query only.
+- **Destructive = false** — Fetching a summary modifies no data.
+- **Idempotent = true** — The same symbol returns the same latest-period summary until a new report
+  is disclosed; calling repeatedly has no side effect.
+- **Open World = true** — "Latest" reflects the most recent external disclosure on the Longbridge
+  backend and advances as issuers report; not server-controlled.
+
+### financial_report_snapshot
+- **Read Only = true** — Reads a report snapshot: text summary (report_desc), actual-vs-forecast
+  figures (fo_revenue/fo_ebit/fo_eps), and financial ratios (fr_*: ROE, margins, assets, cash
+  flow). Read-only fetch.
+- **Destructive = false** — No write occurs when reading the snapshot.
+- **Idempotent = true** — Same symbol/report parameter returns the same snapshot with no
+  accumulation.
+- **Open World = true** — Combines disclosed actuals and analyst forecasts from the external
+  backend; both update with the market and disclosures.
+
+### institution_rating
+- **Read Only = true** — Reads analyst rating summary (buy/outperform/hold/underperform/sell
+  counts, target_price, consensus_rating) plus the instratings list via backend GETs. No mutation.
+- **Destructive = false** — Reading the rating consensus changes nothing.
+- **Idempotent = true** — The same symbol returns the same consensus snapshot per call.
+- **Open World = true** — Analyst ratings originate from external research firms and are updated on
+  the Longbridge backend as firms publish; not server-controlled.
+
+### institution_rating_detail
+- **Read Only = true** — Reads per-institution historical ratings and target-price history
+  (analyst, firm, rating, target_price, timestamp). Query only.
+- **Destructive = false** — Retrieving historical ratings writes nothing.
+- **Idempotent = true** — Identical symbol parameter returns the same history each call.
+- **Open World = true** — Rating history is external research data that grows as firms issue new
+  ratings; outside server control.
+
+### institution_rating_history
+- **Read Only = true** — Reads target-price change history (firm, analyst, old_target, new_target,
+  date) and rating-change history (firm, old_rating, new_rating, date). Read-only.
+- **Destructive = false** — No state is altered by reading the change log.
+- **Idempotent = true** — Same symbol yields the same change history per call.
+- **Open World = true** — Change events come from external analyst actions surfaced on the backend;
+  they accrue with market activity, not server control.
+
+### institution_rating_industry_rank
+- **Read Only = true** — Reads peers ranked by analyst ratings within the same industry (symbol,
+  name, buy_count, sell_count, consensus_rating, target_price). Paginated read.
+- **Destructive = false** — Ranking peers reads only; nothing is written.
+- **Idempotent = true** — The same query/page returns the same ranked list with no side effect.
+- **Open World = true** — Rankings derive from external analyst ratings across the industry and
+  shift as ratings update; not server-controlled.
+
+### dividend
+- **Read Only = true** — Reads dividend history (ex_date, pay_date, record_date, dividend_type,
+  amount, currency, status) via `GET /v1/quote/dividends`. Pure read.
+- **Destructive = false** — Reading the payout record changes nothing.
+- **Idempotent = true** — The same symbol returns the same dividend history per call.
+- **Open World = true** — Dividend records are external issuer disclosures that extend as new
+  distributions are announced; outside server control.
+
+### dividend_detail
+- **Read Only = true** — Reads the detailed distribution scheme (period, cash_dividend,
+  stock_dividend, record_date, ex_date, pay_date, currency). Query only.
+- **Destructive = false** — Fetching distribution details writes nothing.
+- **Idempotent = true** — Same symbol returns the same scheme details per call.
+- **Open World = true** — Distribution details are sourced from external issuer disclosures and
+  update as schemes are declared; not server-controlled.
+
+### forecast_eps
+- **Read Only = true** — Reads EPS forecast/estimate history (forecast_start_date,
+  forecast_end_date, eps_estimate, eps_actual, surprise_pct, analyst_count). Read-only fetch.
+- **Destructive = false** — Reading forecasts and actuals modifies nothing.
+- **Idempotent = true** — The same symbol returns the same forecast series per call.
+- **Open World = true** — Estimates come from external analysts and actuals from issuer reports;
+  both update on the backend with market events, outside server control.
+
+### consensus
+- **Read Only = true** — Reads consensus estimates for upcoming periods (period,
+  revenue_estimate, eps_estimate, net_income_estimate, analyst_count, last_updated). Query only.
+- **Destructive = false** — Reading consensus estimates writes nothing.
+- **Idempotent = true** — Same symbol returns the same consensus snapshot per call.
+- **Open World = true** — Consensus figures aggregate external analyst estimates that revise over
+  time on the Longbridge backend; not server-controlled.
+
+### valuation
+- **Read Only = true** — Reads a valuation overview (PE/PB/PS/dividend_yield with current,
+  industry_avg, 5yr_avg, percentile) plus peer comparison via `GET /v1/quote/valuation`. Read-only.
+- **Destructive = false** — Reading valuation multiples changes nothing.
+- **Idempotent = true** — The same symbol returns the same valuation snapshot per call.
+- **Open World = true** — Multiples are derived from external market prices and financials and move
+  every trading day; outside server control.
+
+### valuation_history
+- **Read Only = true** — Reads a valuation time series (PE/PB/PS/dividend_yield {timestamp, value})
+  for long-term percentile analysis. Query only.
+- **Destructive = false** — Reading the historical series writes nothing.
+- **Idempotent = true** — Same symbol returns the same series per call.
+- **Open World = true** — The series extends as new market data accumulates on the external
+  backend; not server-controlled.
+
+### valuation_rank
+- **Read Only = true** — Reads the daily valuation rank (PE/PB/PS/dividend-yield industry
+  percentile) over a date range. Read-only fetch.
+- **Destructive = false** — Reading percentiles modifies nothing.
+- **Idempotent = true** — The same symbol/date-range returns the same ranks per call.
+- **Open World = true** — Ranks recompute daily from external market and peer data; outside server
+  control.
+
+### valuation_comparison
+- **Read Only = true** — Reads cross-stock valuation comparison (market_value, price_close, pe, pb,
+  ps, history) for a symbol against auto-selected or explicitly listed industry peers. Query only.
+- **Destructive = false** — Comparing valuations reads only; nothing is written.
+- **Idempotent = true** — The same symbol/comparison_symbols/currency returns the same comparison
+  per call.
+- **Open World = true** — Comparison data tracks external prices and fundamentals that update with
+  the market; not server-controlled.
+
+### industry_valuation
+- **Read Only = true** — Reads industry peer valuation (symbol, name, pe, pb, ps, dividend_yield,
+  history) via a backend GET. Read-only.
+- **Destructive = false** — Reading peer multiples writes nothing.
+- **Idempotent = true** — Same symbol returns the same peer valuation set per call.
+- **Open World = true** — Peer valuations follow external market data and change daily; outside
+  server control.
+
+### industry_valuation_dist
+- **Read Only = true** — Reads the industry PE/PB/PS distribution (min, p25, median, p75, max,
+  current_percentile). Query only.
+- **Destructive = false** — Reading the distribution modifies nothing.
+- **Idempotent = true** — The same symbol returns the same distribution snapshot per call.
+- **Open World = true** — Distribution recomputes from external sector data as the market moves;
+  not server-controlled.
+
+### company
+- **Read Only = true** — Reads the company profile (name, description, employees, CEO,
+  founded_year, website, exchange, industry, market_cap, business summary). Read-only fetch.
+- **Destructive = false** — Reading the profile writes nothing.
+- **Idempotent = true** — The same symbol returns the same profile per call.
+- **Open World = true** — Company data is maintained externally on the Longbridge backend and
+  updates with disclosures (e.g. market_cap moves daily); outside server control.
+
+### executive
+- **Read Only = true** — Reads executive and board information (name, title, appointed_date, age,
+  biography, compensation). Query only.
+- **Destructive = false** — Reading executive records modifies nothing.
+- **Idempotent = true** — Same symbol returns the same roster per call.
+- **Open World = true** — Executive data reflects external issuer disclosures and changes with
+  appointments/departures; not server-controlled.
+
+### shareholder
+- **Read Only = true** — Reads institutional shareholders (institution, shares, ratio, change,
+  change_type, reported_at). Read-only fetch.
+- **Destructive = false** — Reading holdings writes nothing.
+- **Idempotent = true** — Same symbol returns the same shareholder list per call.
+- **Open World = true** — Holdings come from external regulatory filings (e.g. 13F) and update each
+  reporting period; outside server control.
+
+### shareholder_top
+- **Read Only = true** — Reads the Top 20 major shareholders across reporting periods (period,
+  object_id, name, title, shares_held, percent_shares_held, shares_changed, filing_date). Read-only.
+- **Destructive = false** — Reading the top-holder list modifies nothing.
+- **Idempotent = true** — The same symbol returns the same top-holder data per call.
+- **Open World = true** — Top-holder data is sourced from external filings and revises each
+  reporting period; not server-controlled.
+
+### shareholder_detail
+- **Read Only = true** — Reads a single holder's holding and trade history by object_id (name,
+  owner_source, tradings with accum_buy/accum_sell/net_buy and trading_details, holding/trading
+  summaries). Query only.
+- **Destructive = false** — Reading a holder's history writes nothing.
+- **Idempotent = true** — The same object_id returns the same holder history per call.
+- **Open World = true** — Holder activity comes from external filings (13F / Form 4) and grows with
+  new disclosures; outside server control.
+
+### fund_holder
+- **Read Only = true** — Reads funds and ETFs holding a symbol (fund_name, fund_symbol, shares,
+  ratio, change, reported_at). Read-only fetch.
+- **Destructive = false** — Reading fund holdings modifies nothing.
+- **Idempotent = true** — Same symbol returns the same fund-holder list per call.
+- **Open World = true** — Fund-holding data derives from external filings and updates each
+  reporting period; not server-controlled.
+
+### corp_action
+- **Read Only = true** — Reads corporate actions (splits, buybacks, name changes) with action_type,
+  effective_date, ratio, description. Query only.
+- **Destructive = false** — Reading the corporate-action log writes nothing.
+- **Idempotent = true** — The same symbol returns the same action list per call.
+- **Open World = true** — Corporate actions are external issuer disclosures that accrue over time;
+  outside server control.
+
+### invest_relation
+- **Read Only = true** — Reads investor relations events/announcements (title, event_type,
+  event_date, url, description). Read-only fetch.
+- **Destructive = false** — Reading IR events modifies nothing.
+- **Idempotent = true** — Same symbol returns the same event list per call.
+- **Open World = true** — IR events are externally published and grow as the company announces;
+  not server-controlled.
+
+### operating
+- **Read Only = true** — Reads company operating metrics (HK stocks only) such as passenger
+  traffic, cargo volumes, or store counts (period, metric_name, value, unit). Query only.
+- **Destructive = false** — Reading operating metrics writes nothing.
+- **Idempotent = true** — The same symbol returns the same operating series per call.
+- **Open World = true** — Operating data is sourced from external issuer disclosures and updates
+  each period; outside server control.
+
+### broker_holding
+- **Read Only = true** — Reads top broker holdings for an HK stock (broker_name, holding_quantity,
+  holding_change, holding_ratio) for a period (rct_1/5/20/60), sourced from HKEX CCASS disclosure.
+  Read-only.
+- **Destructive = false** — Reading CCASS broker holdings modifies nothing.
+- **Idempotent = true** — Same symbol/period returns the same holdings per call.
+- **Open World = true** — Data comes from external HKEX CCASS participant disclosure that updates
+  daily; not server-controlled.
+
+### broker_holding_detail
+- **Read Only = true** — Reads the full broker holding list for an HK stock (broker_id,
+  broker_name, holding_quantity, holding_ratio, holding_change, date) from HKEX CCASS. Query only.
+- **Destructive = false** — Reading the detail list writes nothing.
+- **Idempotent = true** — Same symbol returns the same broker list per call.
+- **Open World = true** — Sourced from external HKEX CCASS disclosure updated daily; outside server
+  control.
+
+### broker_holding_daily
+- **Read Only = true** — Reads a specific broker's daily holding history in a symbol (date,
+  holding_quantity, holding_change, holding_ratio) from HKEX CCASS. Read-only fetch.
+- **Destructive = false** — Reading the daily history modifies nothing.
+- **Idempotent = true** — Same symbol/broker_id returns the same history per call.
+- **Open World = true** — Daily CCASS records accumulate from external HKEX disclosure; not
+  server-controlled.
+
+### finance_calendar
+- **Read Only = true** — Reads finance-calendar events (report/dividend/split/ipo/macrodata/closed)
+  by category, market, and date range via `GET /v1/quote/finance_calendar`. Read-only.
+- **Destructive = false** — Reading scheduled events writes nothing.
+- **Idempotent = true** — The same category/market/date-range returns the same events per call.
+- **Open World = true** — Calendar events (earnings dates, macro releases, holidays) are externally
+  scheduled and revised as schedules change; outside server control.
+
+### profit_analysis
+- **Read Only = true** — Reads a portfolio profit-and-loss analysis summary over an optional date
+  range. Query only; it computes/reads results without changing account state.
+- **Destructive = false** — Reading P&L analysis writes nothing to the account.
+- **Idempotent = true** — The same start/end range returns the same summary per call.
+- **Open World = true** — The analysis is computed on the external Longbridge backend from account
+  and market data that update over time; not server-controlled.
+
+### profit_analysis_detail
+- **Read Only = true** — Reads detailed per-symbol profit-and-loss analysis over an optional date
+  range. Read-only fetch.
+- **Destructive = false** — Reading per-symbol P&L modifies no account state.
+- **Idempotent = true** — The same symbol/range returns the same detail per call.
+- **Open World = true** — Computed on the external backend from account and market data that change
+  over time; outside server control.
+
+### business_segments
+- **Read Only = true** — Reads the current-period business segment revenue breakdown (name,
+  percent, total, currency). Query only.
+- **Destructive = false** — Reading the segment breakdown writes nothing.
+- **Idempotent = true** — The same symbol returns the same breakdown per call.
+- **Open World = true** — Segment data is sourced from external issuer disclosures and updates each
+  period; not server-controlled.
+
+### business_segments_history
+- **Read Only = true** — Reads historical segment revenue trends by period and category (date,
+  total, currency, business[], regionals[]). Read-only fetch.
+- **Destructive = false** — Reading the historical trend modifies nothing.
+- **Idempotent = true** — The same symbol returns the same historical series per call.
+- **Open World = true** — Historical segment data extends with each external disclosure; outside
+  server control.
+
+### institutional_views
+- **Read Only = true** — Reads the monthly institutional rating distribution timeline (date, buy,
+  outperform, hold, underperform, sell, total). Query only.
+- **Destructive = false** — Reading the rating timeline writes nothing.
+- **Idempotent = true** — The same symbol returns the same timeline per call.
+- **Open World = true** — The timeline aggregates external analyst ratings that change monthly;
+  not server-controlled.
+
+### industry_rank
+- **Read Only = true** — Reads an industry ranking list by market and indicator (leaders, trend,
+  heat, market cap, revenue, profit, growth) returning counter_id, name, chg, lists[]. Read-only.
+- **Destructive = false** — Reading the ranking modifies nothing.
+- **Idempotent = true** — The same market/indicator/sort_type returns the same ranking per call.
+- **Open World = true** — Rankings recompute from external market data and shift daily; outside
+  server control.
+
+### industry_peers
+- **Read Only = true** — Reads the hierarchical sub-sector peer tree for an industry group
+  (chain{name, counter_id, stock_num, chg, ytd_chg, next[]}, top{name, market}). Query only.
+- **Destructive = false** — Reading the peer tree writes nothing.
+- **Idempotent = true** — The same counter_id returns the same tree per call.
+- **Open World = true** — Peer-group structure and its change figures track external market data;
+  not server-controlled.
+
+### short_margin
+- **Read Only = true** — Reads short margin deposit details for the current account (margin_amount,
+  margin_rate, interest_rate, symbol, quantity per position) via
+  `GET /v1/asset/cash/short-margin`. Read-only.
+- **Destructive = false** — Reading short-margin details modifies no account or position state.
+- **Idempotent = true** — Repeated calls return the same margin details with no side effect.
+- **Open World = true** — Margin figures are maintained on the external Longbridge backend and
+  update with positions, rates, and market data; outside server control.
+
+### short_trades
+- **Read Only = true** — Reads daily short-sale volume history for HK or US stocks (timestamp,
+  short_vol, rate, close; US-only nasdaq_vol/nyse_vol; HK-only balance/market_vol). Read-only.
+- **Destructive = false** — Reading short-sale history writes nothing.
+- **Idempotent = true** — The same symbol/page parameters return the same history per call.
+- **Open World = true** — Data is sourced externally (US: FINRA/NASDAQ daily; HK: HKEX daily) and
+  extends each trading day; not server-controlled.

--- a/docs/mcp-annotations/group-d-content.md
+++ b/docs/mcp-annotations/group-d-content.md
@@ -1,0 +1,210 @@
+# MCP Annotation Accuracy Justification — Group D (Content / Community / Screener / IPO / DCA / Sharelist / Alert / Quant)
+
+All tools in this group are read-only query tools. Each declares the identical
+annotation set in `src/tools/mod.rs`:
+
+```
+read_only_hint = true
+destructive_hint = false
+idempotent_hint = true
+open_world_hint = true
+```
+
+Annotation semantics applied here:
+
+- **readOnlyHint = true** — the tool only fetches data; it does not modify any
+  state on the Longbridge backend.
+- **destructiveHint = false** — the tool performs no write, no deletion, and no
+  destructive update.
+- **idempotentHint = true** — calling the tool repeatedly with the same
+  arguments produces no additional side effects (each call is just another read).
+- **openWorldHint = true** — the tool reaches out over the network to the
+  external Longbridge backend, whose data (news feeds, community posts, screener
+  universe, IPO calendar, market rankings, account-scoped DCA/alert/IPO records)
+  changes in real time and is not under this server's control.
+
+Implementation note common to the whole group: every handler builds an HTTP
+client via `McpContext::create_http_client` and issues the upstream request,
+then serializes the response back to the caller. The handlers hold no local
+state and persist nothing. The mutating counterparts of these features
+(`topic_create`, `topic_create_reply`, `dca_create`/`dca_update`/`dca_pause`/
+`dca_resume`/`dca_stop`, `alert_add`/`alert_delete`/`alert_enable`/
+`alert_disable`, `sharelist_create`/`sharelist_delete`/`sharelist_add`/
+`sharelist_remove`/`sharelist_sort`) are deliberately **excluded** from this
+group and carry `read_only_hint = false` instead.
+
+---
+
+### news
+- **Read Only = true** — `content::news` issues a GET-style fetch for a symbol's latest news articles and returns `items[]{id, title, source, publish_time, summary, url, related_symbols}`. It only reads a news feed.
+- **Destructive = false** — Fetching articles writes or deletes nothing on the backend.
+- **Idempotent = true** — Re-querying the same symbol just re-reads the feed; no cumulative effect from repeated calls.
+- **Open World = true** — News content comes from the external Longbridge backend and updates continuously as new articles are published.
+
+### news_search
+- **Read Only = true** — `search::news_search` calls `http_get_tool` to run a keyword search and returns `news_list[]{id, title, description, source_name, publish_at, score}`. It is a search/read over the news corpus.
+- **Destructive = false** — A search query persists nothing and removes nothing.
+- **Idempotent = true** — The same keyword + cursor returns the same page slice; repeating the call adds no side effects.
+- **Open World = true** — Results are served by the external Longbridge search backend and shift as news is indexed.
+
+### topic
+- **Read Only = true** — `content::topic` lists community discussion topics for a symbol, returning `items[]{id, title, author, created_at, like_count, comment_count, content_summary}`. Read-only listing (creation is the separate `topic_create`, not in this group).
+- **Destructive = false** — Listing topics modifies no community data.
+- **Idempotent = true** — Repeated listing for the same symbol re-reads the same view; no accumulating effect.
+- **Open World = true** — Community topics live on the external Longbridge backend and are updated by other users in real time.
+
+### topic_detail
+- **Read Only = true** — `content::topic_detail` fetches one topic by `topic_id`, returning its full content and metadata. Pure read.
+- **Destructive = false** — Reading a topic does not edit or delete it.
+- **Idempotent = true** — Fetching the same `topic_id` repeatedly yields the same record with no side effects.
+- **Open World = true** — Topic data is hosted on the external Longbridge backend and may change as the post is edited or gains likes/comments.
+
+### topic_replies
+- **Read Only = true** — `content::topic_replies` reads the paginated reply list under a topic. It only retrieves replies (posting a reply is `topic_create_reply`, excluded from this group).
+- **Destructive = false** — Reading replies creates/removes nothing.
+- **Idempotent = true** — Same topic + page/size returns the same slice; repeating it has no effect.
+- **Open World = true** — Replies are stored on the external Longbridge backend and grow as users respond.
+
+### topic_search
+- **Read Only = true** — `search::topic_search` uses `http_get_tool` to search community topics by keyword and returns id/author/time/excerpt. Read-only search.
+- **Destructive = false** — A search persists nothing.
+- **Idempotent = true** — The same keyword query re-reads the index; no cumulative effect.
+- **Open World = true** — Topic search results come from the external Longbridge backend and vary as content is indexed.
+
+### screener_recommend_strategies
+- **Read Only = true** — `screener::screener_recommend_strategies` calls `http_get_tool` to list platform-preset screener strategies (`strategys[]{id, name, description, market, three_months_chg, risk}`). It only reads strategy metadata.
+- **Destructive = false** — Listing presets changes no state.
+- **Idempotent = true** — Repeated listing for the same market re-reads the same catalog.
+- **Open World = true** — Strategy presets and their `three_months_chg` figures are served by the external Longbridge backend and updated server-side.
+
+### screener_user_strategies
+- **Read Only = true** — `screener::screener_user_strategies` calls `http_get_tool` to list the current user's saved screener strategies. It reads saved-strategy metadata only; it does not create or modify strategies.
+- **Destructive = false** — Listing the user's saved strategies modifies nothing.
+- **Idempotent = true** — Repeated calls re-read the same saved list (absent independent user changes).
+- **Open World = true** — The saved list is account-scoped data held on the external Longbridge backend.
+
+### screener_strategy
+- **Read Only = true** — `screener::screener_strategy` calls `http_get_tool` to fetch a single strategy's filter conditions (`market`, `filter{filters[]{key, min, max, tech_values}}`). It inspects a strategy; it does not run or change it.
+- **Destructive = false** — Inspecting filter conditions writes nothing.
+- **Idempotent = true** — Fetching the same strategy id repeatedly returns the same conditions.
+- **Open World = true** — Strategy definitions are stored on the external Longbridge backend.
+
+### screener_search
+- **Read Only = true** — `screener::screener_search` runs a screener query and returns `{total, items[]{symbol, name, indicators[]}}`. In Mode A it first does a `GET` to load a strategy, then submits the filter set; the actual screen is a `POST` to `/v1/quote/ai/screener/search`. The POST is purely the transport for the filter conditions of a stateless search computation — it stores no strategy and mutates no account or universe data.
+- **Destructive = false** — Executing a screen creates/deletes nothing on the backend.
+- **Idempotent = true** — Running the same `strategy_id` or the same `conditions`/`sort`/`page` returns the same result set; repeating the search has no side effect.
+- **Open World = true** — The screen runs against the live Longbridge universe and indicator values on the external backend, which change with the market.
+
+### screener_indicators
+- **Read Only = true** — `screener::screener_indicators` calls `http_get_tool` against `/v1/quote/ai/screener/indicators` to return indicator metadata (`groups[]{group_name, indicators[]{id, key, name, unit, default_range, tech_values}}`). Pure metadata read.
+- **Destructive = false** — Reading the indicator catalog changes nothing.
+- **Idempotent = true** — The same (optional symbol) query re-reads the same schema.
+- **Open World = true** — Indicator metadata is supplied by the external Longbridge backend.
+
+### rank_categories
+- **Read Only = true** — `market::rank_categories` calls `http_get_tool` against `/v1/quote/market/rank/categories` and returns the leaderboard tab configuration (`first_tags[]{key, name, second_tags[]}`). Read-only configuration fetch.
+- **Destructive = false** — Reading category config modifies nothing.
+- **Idempotent = true** — Repeated calls return the same configuration.
+- **Open World = true** — Leaderboard category config is served by the external Longbridge backend.
+
+### rank_list
+- **Read Only = true** — `market::rank_list` calls `http_get_tool` to fetch the ranked stock list for a leaderboard tab key (`lists[]{symbol, name, last_done, chg, ...}`). It only reads the leaderboard.
+- **Destructive = false** — Reading rankings changes no state.
+- **Idempotent = true** — The same tab key + size re-reads the same leaderboard view.
+- **Open World = true** — Rankings are computed live on the external Longbridge backend and change with market activity (`updated_at` is returned).
+
+### ipo_subscriptions
+- **Read Only = true** — `ipo::ipo_subscriptions` issues two `http_get_tool` reads (`/v1/ipo/subscriptions` and `/v1/ipo/us/subscriptions`) and merges them. It lists IPOs in the subscription stage; it does **not** submit any subscription/application.
+- **Destructive = false** — Listing subscription-stage IPOs writes nothing.
+- **Idempotent = true** — Repeated calls re-read the same listings.
+- **Open World = true** — The subscription pipeline is maintained on the external Longbridge backend and changes as IPOs open/close.
+
+### ipo_calendar
+- **Read Only = true** — `ipo::ipo_calendar` calls `http_get_tool_unix` against `/v1/ipo/calendar` and returns scheduled/recent IPOs. Pure calendar read.
+- **Destructive = false** — Reading the calendar modifies nothing.
+- **Idempotent = true** — Repeated calls re-read the same calendar.
+- **Open World = true** — The IPO calendar is served by the external Longbridge backend and updated as schedules change.
+
+### ipo_listed
+- **Read Only = true** — `ipo::ipo_listed` issues two `http_get_tool` reads (`/v1/ipo/listed`, `/v1/ipo/us/listed`) for recently listed IPOs. Read-only.
+- **Destructive = false** — Listing recently listed IPOs changes nothing.
+- **Idempotent = true** — Same parameters re-read the same list.
+- **Open World = true** — Listing data and first-day returns come from the external Longbridge backend.
+
+### ipo_detail
+- **Read Only = true** — `ipo::ipo_detail` issues `http_get_tool` reads for `/v1/ipo/profile`, `/v1/ipo/timeline`, and `/v1/ipo/eligibility` and assembles the detail view. It only reads IPO information; checking eligibility is informational and submits no order.
+- **Destructive = false** — Reading detail/eligibility writes nothing.
+- **Idempotent = true** — The same symbol re-reads the same detail.
+- **Open World = true** — IPO profile/timeline/eligibility data is hosted on the external Longbridge backend.
+
+### ipo_orders
+- **Read Only = true** — `ipo::ipo_orders` issues `http_get_tool` reads against `/v1/ipo/orders` and `/v1/ipo/orders/history` to list existing IPO orders. It **queries** the user's IPO application records; it does not place or amend an order.
+- **Destructive = false** — Listing orders modifies no order.
+- **Idempotent = true** — Same filters re-read the same order list.
+- **Open World = true** — IPO orders are account-scoped records on the external Longbridge backend; their status changes server-side (e.g. allotment).
+
+### ipo_order_detail
+- **Read Only = true** — `ipo::ipo_order_detail` does a single `http_get_tool` read for one IPO order by id (`{order_id, symbol, allotted_quantity, status, ...}`). Pure read of an existing order record.
+- **Destructive = false** — Reading order detail changes nothing.
+- **Idempotent = true** — Fetching the same `order_id` repeatedly returns the same record.
+- **Open World = true** — The order record lives on the external Longbridge backend and its status may update server-side.
+
+### ipo_profit_loss
+- **Read Only = true** — `ipo::ipo_profit_loss` issues `http_get_tool` reads for `/v1/ipo/profit-loss` and `/v1/ipo/profit-loss/items` and returns a P/L summary and per-stock breakdown. Read-only reporting.
+- **Destructive = false** — Reading P/L figures modifies nothing.
+- **Idempotent = true** — Same period re-reads the same computed summary.
+- **Open World = true** — P/L is derived server-side on the external Longbridge backend from live valuations.
+
+### dca_list
+- **Read Only = true** — `dca::dca_list` calls `http_get_tool_unix` to list DCA (recurring investment) plans (`plans[]{plan_id, symbol, amount, frequency, status, next_execution_date}`). It only **lists** plans; creating/changing a plan is `dca_create`/`dca_update`/`dca_pause`/`dca_resume`/`dca_stop` (all excluded from this group with `read_only_hint = false`).
+- **Destructive = false** — Listing plans creates/modifies/stops nothing.
+- **Idempotent = true** — Same filters re-read the same plan list.
+- **Open World = true** — DCA plans are account-scoped records on the external Longbridge backend, advanced server-side on schedule.
+
+### dca_history
+- **Read Only = true** — `dca::dca_history` calls `http_get_tool` against `/v1/dailycoins/query-records` to return a plan's execution history (`executions[]{date, quantity, amount, price, status, order_id}`). Read-only history query.
+- **Destructive = false** — Reading execution history changes nothing.
+- **Idempotent = true** — Same `plan_id` re-reads the same records.
+- **Open World = true** — Execution history is stored on the external Longbridge backend and grows as the plan executes.
+
+### dca_stats
+- **Read Only = true** — `dca::dca_stats` calls `http_get_tool` against `/v1/dailycoins/statistic` and returns aggregate DCA statistics (`total_invested, total_value, total_return, ...`). Read-only aggregation.
+- **Destructive = false** — Reading statistics modifies nothing.
+- **Idempotent = true** — Same arguments re-read the same computed stats.
+- **Open World = true** — Statistics are computed server-side on the external Longbridge backend from live valuations.
+
+### dca_check
+- **Read Only = true** — `dca::dca_check` POSTs `{counter_ids:[...]}` to `/v1/dailycoins/batch-check-support` and returns `items[]{symbol, support_dca, reason}`. Despite the POST, this is a stateless eligibility **check** (a lookup keyed by the symbol list); it creates no plan and stores nothing. The POST is only the transport for the batch of symbols.
+- **Destructive = false** — Checking DCA support writes/deletes nothing.
+- **Idempotent = true** — The same symbol set returns the same support flags; repeating the check has no side effect.
+- **Open World = true** — Support flags are determined by the external Longbridge backend (per-instrument eligibility rules).
+
+### sharelist_list
+- **Read Only = true** — `sharelist::sharelist_list` calls `http_get_tool` against `/v1/sharelists` to list the user's own and subscribed community sharelists. Read-only listing (create/delete/add/remove/sort are excluded from this group).
+- **Destructive = false** — Listing sharelists modifies none of them.
+- **Idempotent = true** — Same count argument re-reads the same list.
+- **Open World = true** — Sharelists are community data on the external Longbridge backend, changed by their owners/followers.
+
+### sharelist_detail
+- **Read Only = true** — `sharelist::sharelist_detail` calls `http_get_tool` to fetch one sharelist by id, including its constituents and quote data. Pure read.
+- **Destructive = false** — Reading a sharelist's detail changes nothing.
+- **Idempotent = true** — Fetching the same id repeatedly returns the same view.
+- **Open World = true** — Sharelist content (constituents, live quotes, subscription status) is served by the external Longbridge backend.
+
+### sharelist_popular
+- **Read Only = true** — `sharelist::sharelist_popular` calls `http_get_tool` against `/v1/sharelists/popular` and returns trending sharelists sorted by popularity. Read-only.
+- **Destructive = false** — Reading popular lists modifies nothing.
+- **Idempotent = true** — Same count argument re-reads the same ranked view.
+- **Open World = true** — Popularity rankings are computed on the external Longbridge backend and shift with community activity.
+
+### alert_list
+- **Read Only = true** — `alert::alert_list` calls `http_get_tool` against `/v1/notify/reminders` and returns configured price alerts (`lists[]{counter_id, indicators[]{id, condition, price, frequency, enabled, triggered_at}}`). It only **lists** alerts; adding/deleting/enabling/disabling are `alert_add`/`alert_delete`/`alert_enable`/`alert_disable` (excluded from this group).
+- **Destructive = false** — Listing alerts changes no alert.
+- **Idempotent = true** — Repeated calls re-read the same alert configuration.
+- **Open World = true** — Alerts are account-scoped records on the external Longbridge backend; their `triggered_at`/`enabled` state updates server-side.
+
+### quant_run
+- **Read Only = true** — `quant::run_script` fetches historical K-line data for the symbol/period/date-range and runs the supplied indicator **script** server-side, returning the computed indicator/plot values as JSON. Although it issues a `POST` to `/v1/quant/run_script`, the request body is just the input (counter_id, time range, line_type, the script source, and `input_json`); the call is a stateless computation that reads K-line data and returns derived values. It persists nothing and modifies no account, watchlist, plan, or market state. The script runs against historical data only.
+- **Destructive = false** — Running the indicator script writes/deletes nothing on the backend; it produces a computed result and discards all working state.
+- **Idempotent = true** — Re-running the same script with the same symbol/period/range/input returns the same computed values; there is no cumulative effect (the only variability is normal backend data updates, which is the open-world property, not a side effect of the call).
+- **Open World = true** — The computation depends on live/historical K-line data served by the external Longbridge backend, which is not under this server's control.

--- a/docs/mcp-annotations/group-e-mutating.md
+++ b/docs/mcp-annotations/group-e-mutating.md
@@ -1,0 +1,239 @@
+# Group E — Mutating Tools: Annotation Accuracy Justification
+
+This document justifies the MCP tool annotation hints declared in `src/tools/mod.rs`
+for the **state-mutating** (write) tools of the Longbridge MCP server. Each annotation
+value below was read from the actual `#[tool(..., annotations(...))]` attribute in
+`mod.rs` and cross-checked against the implementation in the named module. All four
+hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) reflect
+real observed behavior.
+
+Annotation semantics used throughout:
+- **readOnlyHint = false** — the tool changes environment / remote state.
+- **destructiveHint = true** — the tool may delete, cancel, or overwrite existing data, or has an irreversible side effect; **= false** — the tool only appends or applies a reversible/toggle update.
+- **idempotentHint = true** — repeating the same call with the same arguments produces no effect beyond the first; **= false** — repeating produces additional side effects (a second order, a duplicate row).
+- **openWorldHint = true** — the tool interacts with an external system (the Longbridge brokerage / community / OpenAPI backend) rather than a closed local environment.
+
+Every tool in this group sets `openWorldHint = true` because each one issues an
+authenticated HTTPS request to a Longbridge backend (trade gateway, quote/watchlist
+service, alert service, DCA service, community sharelist/topic service, or the OAuth
+token endpoint). None operate on local-only state, so `openWorldHint = true` is
+accurate in every section and is not re-argued individually below beyond noting the
+specific backend touched.
+
+---
+
+## Section 1 — Create / append tools
+
+Declared values: `read_only_hint = false, destructive_hint = false, idempotent_hint = false, open_world_hint = true`.
+
+### authenticate
+Implementation: `src/tools/authenticate.rs::authenticate`.
+
+- **Read Only = false** — The call exchanges a one-time authorization code for an access token and establishes an authenticated session; it mutates session/credential state and unlocks the full tool set, so it is not read-only.
+- **Destructive = false** — It only establishes a new session (additive). It does not delete or overwrite any existing user data; an already-authenticated session is left untouched (the handler returns `already_authenticated` without altering credentials).
+- **Idempotent = false** — The one-time code packed from the Connect AI page can be consumed only once. A second exchange of the same `auth_code` against the token endpoint fails (the code is spent), so repeating the same call does not reproduce the first call's success. Accurately non-idempotent.
+- **Open World = true** — Performs an OAuth token exchange against the Longbridge authorization backend.
+
+### create_watchlist_group
+Implementation: `src/tools/quote.rs::create_watchlist_group` (`RequestCreateWatchlistGroup`).
+
+- **Read Only = false** — Creates a new watchlist group (and optionally pre-populates securities) on the remote account.
+- **Destructive = false** — Purely additive: it inserts a new group and never deletes or overwrites an existing one.
+- **Idempotent = false** — Each call creates a brand-new group with its own server-assigned `id`. Calling twice with the same `name` yields two distinct groups, an additional side effect beyond the first call.
+- **Open World = true** — Writes to the Longbridge watchlist service.
+
+### alert_add
+Implementation: `src/tools/alert.rs::alert_add`.
+
+- **Read Only = false** — Registers a new price alert on the account.
+- **Destructive = false** — Additive; it adds an alert and does not remove or overwrite any existing alert.
+- **Idempotent = false** — Each call creates a new alert object (returned in the response). Repeating with the same condition produces a second, duplicate alert.
+- **Open World = true** — Writes to the Longbridge alert service.
+
+### topic_create
+Implementation: `src/tools/content.rs::topic_create`.
+
+- **Read Only = false** — Publishes a new community discussion topic (post or article).
+- **Destructive = false** — Additive; it creates a new topic and does not modify or delete existing community content.
+- **Idempotent = false** — Each call posts a new topic with its own id. Repeating creates duplicate posts.
+- **Open World = true** — Writes to the Longbridge community backend.
+
+### topic_create_reply
+Implementation: `src/tools/content.rs::topic_create_reply`.
+
+- **Read Only = false** — Posts a reply under an existing topic (optionally nested under another reply).
+- **Destructive = false** — Additive; it appends a reply and does not alter or remove the parent topic or other replies.
+- **Idempotent = false** — Each call posts a new reply; repeating produces duplicate replies.
+- **Open World = true** — Writes to the Longbridge community backend.
+
+### dca_create
+Implementation: `src/tools/dca.rs::dca_create`.
+
+- **Read Only = false** — Creates a recurring (DCA) investment plan on the account.
+- **Destructive = false** — Additive; it creates a new plan and does not stop, overwrite, or delete any existing plan.
+- **Idempotent = false** — Each call creates a distinct plan with its own `plan_id`. Repeating yields multiple recurring plans, an additional ongoing side effect.
+- **Open World = true** — Writes to the Longbridge DCA/trade service.
+
+### sharelist_create
+Implementation: `src/tools/sharelist.rs::sharelist_create`.
+
+- **Read Only = false** — Creates a new community sharelist (name + optional description).
+- **Destructive = false** — Additive; it creates a new list and does not delete or overwrite existing lists.
+- **Idempotent = false** — Each call returns a newly created sharelist with its own id; repeating creates duplicate lists.
+- **Open World = true** — Writes to the Longbridge community sharelist service.
+
+### sharelist_add
+Implementation: `src/tools/sharelist.rs::sharelist_add` (`SharelistItemsParam`).
+
+- **Read Only = false** — Adds securities to an existing community sharelist.
+- **Destructive = false** — Additive; it appends symbols and does not remove or reorder existing constituents.
+- **Idempotent = false** — The annotation declares non-idempotent: the tool sends an add operation each time and does not de-duplicate on the client side, so repeated calls are treated as repeated add side effects rather than a guaranteed no-op. `idempotent_hint = false` is the conservative, accurate hint here.
+- **Open World = true** — Writes to the Longbridge community sharelist service.
+
+---
+
+## Section 2 — Destructive idempotent tools (delete / cancel / overwrite-update)
+
+Declared values: `read_only_hint = false, destructive_hint = true, idempotent_hint = true, open_world_hint = true`.
+
+### delete_watchlist_group
+Implementation: `src/tools/quote.rs::delete_watchlist_group` (`ctx.delete_watchlist_group(id, purge)`).
+
+- **Read Only = false** — Deletes a watchlist group from the account.
+- **Destructive = true** — It removes an existing group by id, and with `purge=true` also removes its securities from all other groups — irreversible data removal.
+- **Idempotent = true** — After the group is deleted, re-issuing the delete for the same id has no additional effect (the object is already gone); the final state is identical.
+- **Open World = true** — Mutates the Longbridge watchlist service.
+
+### cancel_order
+Implementation: `src/tools/trade.rs::cancel_order` (`ctx.cancel_order(order_id)`).
+
+- **Read Only = false** — Cancels an open brokerage order.
+- **Destructive = true** — Cancellation removes a pending order from the market — an irreversible state change to the order's lifecycle.
+- **Idempotent = true** — Once an order is cancelled, the target final state (cancelled) is fixed; a repeated cancel of the same `order_id` adds no further effect (it errors / no-ops because the order is already cancelled or filled, per the description), leaving the same end state.
+- **Open World = true** — Mutates state on the Longbridge trade gateway.
+
+### alert_delete
+Implementation: `src/tools/alert.rs::alert_delete`.
+
+- **Read Only = false** — Deletes a price alert.
+- **Destructive = true** — Removes an existing alert by id — irreversible removal.
+- **Idempotent = true** — After deletion, re-deleting the same `alert_id` produces the same end state (alert absent), no extra effect.
+- **Open World = true** — Mutates the Longbridge alert service.
+
+### dca_stop
+Implementation: `src/tools/dca.rs::dca_stop`.
+
+- **Read Only = false** — Permanently stops a DCA plan.
+- **Destructive = true** — The description states this "cannot be undone"; it terminates the plan irreversibly (distinct from the reversible `dca_pause`).
+- **Idempotent = true** — Once stopped, repeating the stop on the same `plan_id` leaves the plan in the same terminal stopped state with no additional effect.
+- **Open World = true** — Mutates the Longbridge DCA service.
+
+### sharelist_delete
+Implementation: `src/tools/sharelist.rs::sharelist_delete`.
+
+- **Read Only = false** — Deletes a community sharelist (own lists only).
+- **Destructive = true** — Removes an existing list — irreversible removal of the list and its membership.
+- **Idempotent = true** — After deletion, re-issuing for the same id yields the same end state (list absent).
+- **Open World = true** — Mutates the Longbridge community sharelist service.
+
+### sharelist_remove
+Implementation: `src/tools/sharelist.rs::sharelist_remove` (`SharelistItemsParam`).
+
+- **Read Only = false** — Removes securities from a community sharelist.
+- **Destructive = true** — Removes constituents from an existing list — a removal/deletion operation on existing data.
+- **Idempotent = true** — Removing the same symbols again converges to the same end state (those symbols absent from the list); a repeat has no further effect.
+- **Open World = true** — Mutates the Longbridge community sharelist service.
+
+### update_watchlist_group
+Implementation: `src/tools/quote.rs::update_watchlist_group` (`RequestUpdateWatchlistGroup`, modes add/remove/**replace**).
+
+- **Read Only = false** — Updates a watchlist group by id (rename, or modify securities).
+- **Destructive = true** — The `replace` mode overwrites the group's existing securities, and a rename overwrites the prior name — both can destroy/overwrite existing data, so the destructive hint is warranted.
+- **Idempotent = true** — Re-applying the same update (same `id`, same `name`/`securities`/`mode`) yields the same final group state; no incremental effect from repetition.
+- **Open World = true** — Mutates the Longbridge watchlist service.
+
+### replace_order
+Implementation: `src/tools/trade.rs::replace_order` (`ReplaceOrderOptions::new(order_id, quantity)`).
+
+- **Read Only = false** — Modifies an existing open order's quantity / price / trigger / trailing parameters.
+- **Destructive = true** — It overwrites the existing order's terms in place; the prior order parameters are replaced and not recoverable from this call.
+- **Idempotent = true** — Re-applying the same replacement parameters to the same `order_id` produces the same resulting order state; repeating does not stack additional changes.
+- **Open World = true** — Mutates state on the Longbridge trade gateway.
+
+### dca_update
+Implementation: `src/tools/dca.rs::dca_update` (`DcaUpdateParam`).
+
+- **Read Only = false** — Updates an existing DCA plan by `plan_id` (amount/frequency/schedule).
+- **Destructive = true** — It overwrites the plan's existing configuration; prior values are replaced, so it can overwrite existing data.
+- **Idempotent = true** — Applying the same update parameters again to the same `plan_id` converges to the same plan configuration; no extra effect.
+- **Open World = true** — Mutates the Longbridge DCA service.
+
+### sharelist_sort
+Implementation: `src/tools/sharelist.rs::sharelist_sort` (`SharelistItemsParam`).
+
+- **Read Only = false** — Reorders securities within a community sharelist.
+- **Destructive = true** — It overwrites the list's existing ordering with the supplied order — the previous arrangement is replaced.
+- **Idempotent = true** — Applying the same target ordering again yields the same final order; a repeat is a no-op on state.
+- **Open World = true** — Mutates the Longbridge community sharelist service.
+
+---
+
+## Section 3 — Non-destructive idempotent toggles (state switches)
+
+Declared values: `read_only_hint = false, destructive_hint = false, idempotent_hint = true, open_world_hint = true`.
+
+### alert_enable
+Implementation: `src/tools/alert.rs::alert_enable`.
+
+- **Read Only = false** — Sets an alert's enabled flag to `true` on the server.
+- **Destructive = false** — A reversible toggle; it changes a status flag and does not delete or overwrite alert data (it can be turned off again with `alert_disable`).
+- **Idempotent = true** — Enabling an already-enabled alert leaves the same end state (`enabled: true`); repeating adds no effect.
+- **Open World = true** — Mutates the Longbridge alert service.
+
+### alert_disable
+Implementation: `src/tools/alert.rs::alert_disable`.
+
+- **Read Only = false** — Sets an alert's enabled flag to `false`.
+- **Destructive = false** — Reversible toggle; the alert is preserved and can be re-enabled.
+- **Idempotent = true** — Disabling an already-disabled alert leaves the same end state (`enabled: false`).
+- **Open World = true** — Mutates the Longbridge alert service.
+
+### dca_pause
+Implementation: `src/tools/dca.rs::dca_pause`.
+
+- **Read Only = false** — Suspends a DCA plan (stops execution until resumed).
+- **Destructive = false** — Reversible: the description explicitly pairs it with `dca_resume`; the plan is preserved, only its run state is suspended. (Contrast with the irreversible `dca_stop`, which is destructive.)
+- **Idempotent = true** — Pausing an already-paused plan leaves the same suspended state.
+- **Open World = true** — Mutates the Longbridge DCA service.
+
+### dca_resume
+Implementation: `src/tools/dca.rs::dca_resume`.
+
+- **Read Only = false** — Resumes a suspended DCA plan's scheduled execution.
+- **Destructive = false** — Reversible toggle (can be paused again); preserves the plan.
+- **Idempotent = true** — Resuming an already-active plan leaves the same active state.
+- **Open World = true** — Mutates the Longbridge DCA service.
+
+---
+
+## Section 4 — Destructive non-idempotent tool (irreversible new side effect)
+
+Declared values: `read_only_hint = false, destructive_hint = true, idempotent_hint = false, open_world_hint = true`.
+
+### submit_order
+Implementation: `src/tools/trade.rs::submit_order` (`SubmitOrderOptions::new(...)` then submit).
+
+- **Read Only = false** — Submits a live buy/sell order to the brokerage.
+- **Destructive = true** — Placing an order has a real, irreversible market side effect (it can execute and move cash/positions); it is not a reversible or purely-additive bookkeeping change, so the destructive hint is appropriate for an action this consequential.
+- **Idempotent = false** — Each call creates a brand-new order (no client-side dedupe key). Calling twice with identical parameters submits two separate orders — an additional, potentially costly side effect — so it is correctly non-idempotent.
+- **Open World = true** — Submits to the Longbridge trade gateway.
+
+---
+
+## Verification summary
+
+All annotation values in this document were taken verbatim from
+`src/tools/mod.rs` and matched the implementations in `quote.rs`, `trade.rs`,
+`alert.rs`, `dca.rs`, `content.rs`, `sharelist.rs`, and `authenticate.rs`.
+No discrepancies were found between the declared annotation values and the
+prompt's stated values.

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -90,6 +90,15 @@ async fn health() -> axum::http::StatusCode {
     axum::http::StatusCode::OK
 }
 
+/// Domain-verification token for the OpenAI Apps directory, served as plain text
+/// at `/.well-known/openai-apps-challenge`. OpenAI fetches this path and expects
+/// the exact token back to confirm ownership of the deployment.
+const OPENAI_APPS_CHALLENGE: &str = "h5mgJvzRNVwtVXfT4QYbhlGhhNoni0WdHUFwIrZpbpE";
+
+async fn openai_apps_challenge() -> &'static str {
+    OPENAI_APPS_CHALLENGE
+}
+
 pub struct AppState {
     pub base_url: String,
 }
@@ -116,6 +125,11 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         );
 
     let health_route = Router::new().route("/health", axum::routing::get(health));
+
+    let openai_apps_challenge_route = Router::new().route(
+        "/.well-known/openai-apps-challenge",
+        axum::routing::get(openai_apps_challenge),
+    );
 
     let metrics_route = Router::new().route(
         "/metrics",
@@ -164,6 +178,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .merge(metadata_routes)
         .merge(server_card_route)
         .merge(health_route)
+        .merge(openai_apps_challenge_route)
         .merge(metrics_route)
         .merge(tools_route)
         .nest_service("/agent", mcp_agent)

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -506,6 +506,7 @@ impl Longbridge {
         title = "Authenticate",
         annotations(
             read_only_hint = false,
+            destructive_hint = false,
             idempotent_hint = false,
             open_world_hint = true
         ),
@@ -526,7 +527,7 @@ impl Longbridge {
     /// Get current UTC time in RFC3339 format.
     #[tool(
         title = "Current Time",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get current UTC time as an RFC3339 string (e.g. \"2025-01-15T08:30:00Z\"). Use to determine current date/time before making date-based queries."
     )]
     async fn now(&self) -> String {
@@ -538,7 +539,7 @@ impl Longbridge {
     /// Get basic information of securities.
     #[tool(
         title = "Security Static Info",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get static info for securities. Returns per symbol: symbol, name_cn, name_en, exchange (e.g. NASDAQ), type (e.g. US_Stock), lot_size, listed_date, delisted (bool)."
     )]
     async fn static_info(
@@ -553,7 +554,7 @@ impl Longbridge {
     /// Get the latest price quotes.
     #[tool(
         title = "Quote",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get latest price quotes. Returns per symbol: last_done, prev_close, open, high, low, volume, turnover, change_rate, change_value, trade_status, timestamp."
     )]
     async fn quote(
@@ -568,7 +569,7 @@ impl Longbridge {
     /// Get option quotes.
     #[tool(
         title = "Option Quote",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get option quotes (max 500 symbols). Returns last_done, prev_close, open, high, low, volume, turnover, implied_volatility, delta, gamma, theta, vega, rho, open_interest per symbol."
     )]
     async fn option_quote(
@@ -583,7 +584,7 @@ impl Longbridge {
     /// Get warrant quotes.
     #[tool(
         title = "Warrant Quote",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get warrant quotes. Returns last_done, prev_close, open, high, low, volume, turnover, implied_volatility, delta, leverage_ratio, effective_leverage per symbol."
     )]
     async fn warrant_quote(
@@ -598,7 +599,7 @@ impl Longbridge {
     /// Get the order book depth.
     #[tool(
         title = "Order Book Depth",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::DepthResponse>(),
         description = "Get order book depth for a symbol. Returns {bids[]{position, price, volume, order_num}, asks[]{position, price, volume, order_num}}. Up to 10 price levels."
     )]
@@ -614,7 +615,7 @@ impl Longbridge {
     /// Get broker queue data.
     #[tool(
         title = "Broker Queue",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::BrokersResponse>(),
         description = "Get broker queue (HK stocks only). Returns bid_brokers/ask_brokers arrays, each with position (1-based) and broker_ids. Map broker IDs to names via participants."
     )]
@@ -630,7 +631,7 @@ impl Longbridge {
     /// Get market participant broker information.
     #[tool(
         title = "Market Participants",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get HK market participant broker information. Returns participants[]{broker_ids[], name_en, name_cn, name_hk}. Use broker_ids to interpret broker queue data."
     )]
     async fn participants(
@@ -644,7 +645,7 @@ impl Longbridge {
     /// Get recent trades.
     #[tool(
         title = "Recent Trades",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get recent trades (max 1000). Returns trades[]{price, volume, timestamp, trade_type, direction} for the symbol."
     )]
     async fn trades(
@@ -659,7 +660,7 @@ impl Longbridge {
     /// Get intraday line data.
     #[tool(
         title = "Intraday Line",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get intraday minute-by-minute price/volume data. trade_sessions: \"intraday\" (default, regular hours) or \"all\" (include pre-market and post-market)"
     )]
     async fn intraday(
@@ -674,7 +675,7 @@ impl Longbridge {
     /// Get candlestick (K-line) data.
     #[tool(
         title = "Candlesticks",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get candlestick data (OHLCV). Only symbol is required; period defaults to day, count to 100 (max 1000), forward_adjust to false, trade_sessions to all. period: 1m/5m/15m/30m/60m/day/week/month/year. trade_sessions: intraday/all"
     )]
     async fn candlesticks(
@@ -689,7 +690,7 @@ impl Longbridge {
     /// Get historical candlesticks by offset.
     #[tool(
         title = "Historical Candlesticks by Offset",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get historical candlestick data by offset from a reference time. period: 1m/5m/15m/30m/60m/day/week/month/year"
     )]
     async fn history_candlesticks_by_offset(
@@ -707,7 +708,7 @@ impl Longbridge {
     /// Get historical candlesticks by date range.
     #[tool(
         title = "Historical Candlesticks by Date",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get historical candlestick data by date range. period: 1m/5m/15m/30m/60m/day/week/month/year"
     )]
     async fn history_candlesticks_by_date(
@@ -725,7 +726,7 @@ impl Longbridge {
     /// Get trading days between dates.
     #[tool(
         title = "Trading Days",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::TradingDaysResponse>(),
         description = "Get trading days for a market between dates. Returns trading_days[] and half_trading_days[] as \"yyyy-mm-dd\" strings. market: HK/US/CN/SG."
     )]
@@ -741,7 +742,7 @@ impl Longbridge {
     /// Get option chain expiry date list.
     #[tool(
         title = "Option Expiry Dates",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get option chain expiry dates for a symbol (e.g. AAPL.US). Returns expiry_dates[] as \"yyyy-mm-dd\" strings. Use with option_chain_info_by_date to get strikes and Greeks."
     )]
     async fn option_chain_expiry_date_list(
@@ -759,7 +760,7 @@ impl Longbridge {
     /// Get option chain info by expiry date.
     #[tool(
         title = "Option Chain by Date",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get option chain for an expiry date. Returns strikePrices[]{strike_price, call{symbol, last_done, iv, delta, gamma}, put{symbol, last_done, iv, delta, gamma}}."
     )]
     async fn option_chain_info_by_date(
@@ -777,7 +778,7 @@ impl Longbridge {
     /// Get capital flow of a security.
     #[tool(
         title = "Capital Flow",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get capital inflow/outflow time series. Returns items[]{timestamp, inflow, outflow, net_flow} for the symbol (same-day data)."
     )]
     async fn capital_flow(
@@ -792,7 +793,7 @@ impl Longbridge {
     /// Get capital distribution.
     #[tool(
         title = "Capital Distribution",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::CapitalDistributionResponse>(),
         description = "Get capital distribution for a symbol. Returns {timestamp, capital_in{large, medium, small}, capital_out{large, medium, small}} (decimal strings in settlement currency)."
     )]
@@ -811,7 +812,7 @@ impl Longbridge {
     /// Get trading session schedule.
     #[tool(
         title = "Trading Sessions",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get trading session schedule for all markets. Returns market_sessions[]{market, trade_sessions[]{beg_time, end_time, trade_session_type}}."
     )]
     async fn trading_session(
@@ -825,7 +826,7 @@ impl Longbridge {
     /// Get market temperature.
     #[tool(
         title = "Market Temperature",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::MarketTemperatureResponse>(),
         description = "Get current market sentiment temperature. Returns {temperature (0-100), description, valuation (0-100), sentiment (0-100), timestamp}. market: HK/US/CN/SG."
     )]
@@ -841,7 +842,7 @@ impl Longbridge {
     /// Get historical market temperature.
     #[tool(
         title = "Historical Market Temperature",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::HistoryMarketTemperatureResponse>(),
         description = "Get historical market temperature time series. Returns {type, list[]{temperature, description, valuation, sentiment, timestamp}} for the given market and date range."
     )]
@@ -860,7 +861,7 @@ impl Longbridge {
     /// Get watchlist groups.
     #[tool(
         title = "Watchlist",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get all watchlist groups and their securities. Returns groups[]{id, name, securities[]{symbol, market, name, watched_price, watched_at}}."
     )]
     async fn watchlist(&self, ctx: RequestContext<RoleServer>) -> Result<CallToolResult, McpError> {
@@ -871,7 +872,7 @@ impl Longbridge {
     /// Get filings for a symbol.
     #[tool(
         title = "Filings",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get regulatory filings (8-K, 10-Q, 10-K, etc.). Returns items[]{id, title, type, language, filing_date, url} for the symbol."
     )]
     async fn filings(
@@ -886,7 +887,7 @@ impl Longbridge {
     /// Get warrant issuers.
     #[tool(
         title = "Warrant Issuers",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get HK warrant issuer information. Returns issuers[]{id, name_en, name_cn}. Use id in warrant_list issuer filter."
     )]
     async fn warrant_issuers(
@@ -900,7 +901,7 @@ impl Longbridge {
     /// Get warrant list for a symbol.
     #[tool(
         title = "Warrant List",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get filtered warrant list for an underlying symbol. Returns warrants[]{symbol, name, last_done, change_rate, implied_volatility, expiry_date, strike_price, leverage_ratio, outstanding_ratio}."
     )]
     async fn warrant_list(
@@ -915,7 +916,7 @@ impl Longbridge {
     /// Calculate indexes for symbols.
     #[tool(
         title = "Calc Indexes",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Calculate financial indexes for symbols. Pass symbols, and optionally indexes (e.g. [\"PeTtmRatio\",\"PbRatio\",\"LastDone\",\"TurnoverRate\"]). When indexes is omitted or empty, defaults to [\"LastDone\",\"ChangeValue\",\"ChangeRate\",\"Volume\",\"PeTtmRatio\",\"PbRatio\",\"DividendRatioTtm\",\"TurnoverRate\",\"TotalMarketValue\"]. Returns per-symbol index values."
     )]
     async fn calc_indexes(
@@ -999,7 +1000,7 @@ impl Longbridge {
     /// Get security list by market and category.
     #[tool(
         title = "Security List",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get security list for a market. Supports market: US, HK, CN, SG. category: \"Overnight\" (default). page: 1-based page number (default 1). count: records per page (default 50). Returns {total, page, count, items[]{symbol, name_en, name_cn}}."
     )]
     async fn security_list(
@@ -1014,7 +1015,7 @@ impl Longbridge {
     /// Get account balance.
     #[tool(
         title = "Account Balance",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get account cash balance and asset summary. Returns balances[]{currency, total_cash, max_finance_amount, remaining_finance_amount, risk_level, margin_call}. Filter by currency (e.g. \"USD\", \"HKD\")."
     )]
     async fn account_balance(
@@ -1029,7 +1030,7 @@ impl Longbridge {
     /// Get stock positions.
     #[tool(
         title = "Stock Positions",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::StockPositionsResponse>(),
         description = "Get current stock positions across all channels. Returns list[].stock_info[]{symbol, symbol_name, quantity, available_quantity, currency, cost_price, market}."
     )]
@@ -1044,7 +1045,7 @@ impl Longbridge {
     /// Get fund positions.
     #[tool(
         title = "Fund Positions",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::FundPositionsResponse>(),
         description = "Get current fund positions. Returns list[].fund_info[]{symbol, symbol_name, currency, holding_units, current_net_asset_value, cost_net_asset_value, net_asset_value_day}."
     )]
@@ -1059,7 +1060,7 @@ impl Longbridge {
     /// Get margin ratio.
     #[tool(
         title = "Margin Ratio",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::MarginRatioResponse>(),
         description = "Get margin ratio for a symbol. Returns {im_factor (initial margin), mm_factor (maintenance margin), fm_factor (forced liquidation)} as decimal strings."
     )]
@@ -1075,7 +1076,7 @@ impl Longbridge {
     /// Get today's orders.
     #[tool(
         title = "Today's Orders",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get orders placed today. Returns orders[]{order_id, symbol, side, order_type, status, quantity, price, submitted_at, executed_quantity, executed_price}. Pass symbol to filter."
     )]
     async fn today_orders(
@@ -1090,7 +1091,7 @@ impl Longbridge {
     /// Get order detail.
     #[tool(
         title = "Order Detail",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::OrderDetailResponse>(),
         description = "Get detailed information about a specific order. Returns {order_id, symbol, status, side, order_type, quantity, price, executed_quantity, executed_price, submitted_at, time_in_force, msg}."
     )]
@@ -1126,7 +1127,7 @@ impl Longbridge {
     /// Get today's trade executions.
     #[tool(
         title = "Today's Executions",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get today's trade executions (fills). Returns executions[]{order_id, symbol, side, quantity, price, trade_done_at}. Pass symbol or order_id to filter."
     )]
     async fn today_executions(
@@ -1141,7 +1142,7 @@ impl Longbridge {
     /// Get historical orders (not including today).
     #[tool(
         title = "Historical Orders",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get historical orders between dates (excludes today). Returns orders[]{order_id, symbol, side, status, quantity, price, submitted_at}. start_at/end_at in RFC3339."
     )]
     async fn history_orders(
@@ -1156,7 +1157,7 @@ impl Longbridge {
     /// Get historical executions.
     #[tool(
         title = "Historical Executions",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get historical trade executions between dates. Returns executions[]{order_id, symbol, side, quantity, price, trade_done_at}. start_at/end_at in RFC3339."
     )]
     async fn history_executions(
@@ -1171,7 +1172,7 @@ impl Longbridge {
     /// Get cash flow records.
     #[tool(
         title = "Cash Flow",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get cash flow records (deposits, withdrawals, dividends). Returns items[]{transaction_type, amount, currency, balance, created_at, remark}. start_at/end_at in RFC3339."
     )]
     async fn cash_flow(
@@ -1227,7 +1228,7 @@ impl Longbridge {
     /// Estimate max purchase quantity.
     #[tool(
         title = "Estimate Max Purchase Quantity",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::EstimateMaxQtyResponse>(),
         description = "Estimate maximum buy/sell quantity for a symbol. Returns {cash_max_qty, margin_max_qty} (decimal strings). Only symbol is required; side (case-insensitive Buy/Sell) defaults to Buy, order_type (case-insensitive) defaults to LO, and price is optional."
     )]
@@ -1246,7 +1247,7 @@ impl Longbridge {
     /// Get financial reports (income statement, balance sheet, cash flow).
     #[tool(
         title = "Financial Report",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get financial reports (income statement, balance sheet, cash flow). kind: IS/BS/CF/ALL. report_type: af (annual), saf (semi-annual), q1/q2/q3, qf (quarterly full)."
     )]
     async fn financial_report(
@@ -1264,7 +1265,7 @@ impl Longbridge {
     /// Get institution rating summary (analyst consensus + target price).
     #[tool(
         title = "Institution Rating",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get institution rating summary. Returns analyst{buy, outperform, hold, underperform, sell counts, target_price, consensus_rating} and instratings list."
     )]
     async fn institution_rating(
@@ -1282,7 +1283,7 @@ impl Longbridge {
     /// Get institution rating detail (historical ratings and target prices).
     #[tool(
         title = "Institution Rating Detail",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get detailed historical institution ratings and target price history. Returns target.list[]{analyst, firm, rating, target_price, timestamp} per institution."
     )]
     async fn institution_rating_detail(
@@ -1300,7 +1301,7 @@ impl Longbridge {
     /// Get dividend history.
     #[tool(
         title = "Dividend",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get dividend history. Returns items[]{ex_date, pay_date, record_date, dividend_type, amount, currency, status} for the symbol."
     )]
     async fn dividend(
@@ -1315,7 +1316,7 @@ impl Longbridge {
     /// Get dividend distribution details.
     #[tool(
         title = "Dividend Detail",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get detailed dividend distribution scheme. Returns details[]{period, cash_dividend, stock_dividend, record_date, ex_date, pay_date, currency}."
     )]
     async fn dividend_detail(
@@ -1330,7 +1331,7 @@ impl Longbridge {
     /// Get EPS forecast data.
     #[tool(
         title = "Forecast EPS",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get EPS forecast and analyst estimate history. Returns items[]{forecast_start_date, forecast_end_date, eps_estimate, eps_actual, surprise_pct, analyst_count}."
     )]
     async fn forecast_eps(
@@ -1345,7 +1346,7 @@ impl Longbridge {
     /// Get financial consensus estimates.
     #[tool(
         title = "Analyst Consensus",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get financial consensus estimates. Returns items[]{period, revenue_estimate, eps_estimate, net_income_estimate, analyst_count, last_updated} for upcoming periods."
     )]
     async fn consensus(
@@ -1360,7 +1361,7 @@ impl Longbridge {
     /// Get valuation overview (PE, PB, PS, dividend yield).
     #[tool(
         title = "Valuation",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get valuation overview with peer comparison. Returns metrics.pe/pb/ps/dividend_yield{current, industry_avg, 5yr_avg, percentile} and peer comparison list."
     )]
     async fn valuation(
@@ -1375,7 +1376,7 @@ impl Longbridge {
     /// Get detailed valuation history.
     #[tool(
         title = "Valuation History",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get detailed valuation history time series. Returns history.metrics{pe/pb/ps/dividend_yield}[]{timestamp, value} for long-term percentile analysis."
     )]
     async fn valuation_history(
@@ -1393,7 +1394,7 @@ impl Longbridge {
     /// Get industry valuation comparison.
     #[tool(
         title = "Industry Valuation",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get industry valuation comparison for peers. Returns list[]{symbol, name, pe, pb, ps, dividend_yield, history[]{date, pe, pb}} for peers in the same industry."
     )]
     async fn industry_valuation(
@@ -1411,7 +1412,7 @@ impl Longbridge {
     /// Get industry valuation distribution.
     #[tool(
         title = "Industry Valuation Distribution",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get industry PE/PB/PS valuation distribution. Returns distributions{pe/pb/ps}{min, p25, median, p75, max, current_percentile} to see where the stock sits in its sector."
     )]
     async fn industry_valuation_dist(
@@ -1429,7 +1430,7 @@ impl Longbridge {
     /// Get company overview.
     #[tool(
         title = "Company Profile",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get company overview. Returns name, description, employees, CEO, founded_year, website, exchange, industry, market_cap, and business profile summary."
     )]
     async fn company(
@@ -1444,7 +1445,7 @@ impl Longbridge {
     /// Get company executives.
     #[tool(
         title = "Executive",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get company executive and board member information. Returns members[]{name, title, appointed_date, age, biography, compensation}."
     )]
     async fn executive(
@@ -1459,7 +1460,7 @@ impl Longbridge {
     /// Get shareholders.
     #[tool(
         title = "Shareholders",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get institutional shareholders for a symbol. Returns shareholders[]{institution, shares, ratio, change, change_type, reported_at}."
     )]
     async fn shareholder(
@@ -1474,7 +1475,7 @@ impl Longbridge {
     /// Get fund holders.
     #[tool(
         title = "Fund Holders",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get funds and ETFs that hold a given symbol. Returns fund_holders[]{fund_name, fund_symbol, shares, ratio, change, reported_at}."
     )]
     async fn fund_holder(
@@ -1489,7 +1490,7 @@ impl Longbridge {
     /// Get corporate actions.
     #[tool(
         title = "Corporate Actions",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get corporate actions (splits, buybacks, name changes). Returns items[]{action_type, effective_date, ratio, description} for the symbol."
     )]
     async fn corp_action(
@@ -1504,7 +1505,7 @@ impl Longbridge {
     /// Get investor relations events.
     #[tool(
         title = "Investor Relations",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get investor relations events and announcements. Returns items[]{title, event_type, event_date, url, description} for the symbol."
     )]
     async fn invest_relation(
@@ -1519,7 +1520,7 @@ impl Longbridge {
     /// Get operating metrics.
     #[tool(
         title = "Operating Performance",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get company operating metrics (HK stocks only). Returns items[]{period, metric_name, value, unit} such as passenger traffic, cargo volumes, or store counts."
     )]
     async fn operating(
@@ -1534,7 +1535,7 @@ impl Longbridge {
     /// Get market trading status.
     #[tool(
         title = "Market Status",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get current market trading status for all markets. Returns market_time[]{market, trade_status (Pre-Open/Trading/Lunch Break/Post-Trading/Closed/Pre-Market/Post-Market), timestamp}."
     )]
     async fn market_status(
@@ -1548,7 +1549,7 @@ impl Longbridge {
     /// Get broker holding data.
     #[tool(
         title = "Broker Holding",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get top broker holding data for a symbol (HK stocks only; sourced from HKEX CCASS participant disclosure). Returns items[]{broker_name, holding_quantity, holding_change, holding_ratio} for the given period (rct_1/rct_5/rct_20/rct_60)."
     )]
     async fn broker_holding(
@@ -1563,7 +1564,7 @@ impl Longbridge {
     /// Get broker holding detail.
     #[tool(
         title = "Broker Holding Detail",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get full broker holding detail list for a symbol (HK stocks only; sourced from HKEX CCASS participant disclosure). Returns items[]{broker_id, broker_name, holding_quantity, holding_ratio, holding_change, date}."
     )]
     async fn broker_holding_detail(
@@ -1581,7 +1582,7 @@ impl Longbridge {
     /// Get daily broker holding for a specific broker.
     #[tool(
         title = "Broker Holding (Daily)",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get daily holding history for a specific broker (by broker_id) in a symbol (HK stocks only; sourced from HKEX CCASS participant disclosure). Returns items[]{date, holding_quantity, holding_change, holding_ratio}."
     )]
     async fn broker_holding_daily(
@@ -1599,7 +1600,7 @@ impl Longbridge {
     /// Get AH premium K-line data.
     #[tool(
         title = "A/H Premium",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get A/H share premium historical K-line data. Returns items[]{timestamp, open, high, low, close} representing the premium percentage over the given period."
     )]
     async fn ah_premium(
@@ -1614,7 +1615,7 @@ impl Longbridge {
     /// Get AH premium intraday data.
     #[tool(
         title = "A/H Premium (Intraday)",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get A/H share premium intraday time-share data. Returns items[]{timestamp, premium_rate} showing the intraday A/H premium percentage minute by minute."
     )]
     async fn ah_premium_intraday(
@@ -1632,7 +1633,7 @@ impl Longbridge {
     /// Get trade statistics.
     #[tool(
         title = "Trade Statistics",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get trade statistics (buy/sell/neutral volume distribution). Returns items[]{price_range, buy_volume, sell_volume, neutral_volume} for price-volume profile."
     )]
     async fn trade_stats(
@@ -1647,7 +1648,7 @@ impl Longbridge {
     /// Get market anomalies.
     #[tool(
         title = "Market Anomaly",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get market anomaly alerts (unusual price/volume changes). market: HK/US/CN/SG. symbol: optional, filter to a specific stock. count: results per page (default 50, max 100). Returns changes[]{symbol, name, change_rate, volume, ...}, all_off."
     )]
     async fn anomaly(
@@ -1662,7 +1663,7 @@ impl Longbridge {
     /// Get index constituents or ETF asset allocation.
     #[tool(
         title = "Index Constituents / ETF Asset Allocation",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get the constituents of an index or the asset allocation of an ETF. For an index (e.g. HSI.HK, .DJI.US) returns constituents[]{symbol, name, last_done, change_rate, market_cap, weight}. For an ETF (e.g. QQQ.US, 2800.HK) returns the asset allocation as info[] grouped by asset_type: 1=Holdings (top constituents with code, symbol, holding_detail), 2=Regional (country/region breakdown), 3=AssetClass (stock/bond/cash etc.), 4=Industry (sector breakdown). Each group has report_date and lists[]{name, position_ratio, name_locales}; Holdings groups additionally include code, symbol and holding_detail{industry_name, index_name, holding_type_name}."
     )]
     async fn constituent(
@@ -1677,7 +1678,7 @@ impl Longbridge {
     /// Get finance calendar events.
     #[tool(
         title = "Financial Calendar",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get finance calendar events by category and date range. category: report (earnings + financials) / dividend / split (splits & reverse splits) / ipo / macrodata (CPI, NFP, rate decisions) / closed (market holidays). market: HK/US/CN/SG/JP/UK/DE/AU (optional). Keep the date range to 2 weeks or less; for longer periods split into multiple calls to avoid truncation."
     )]
     async fn finance_calendar(
@@ -1692,7 +1693,7 @@ impl Longbridge {
     /// Get exchange rates.
     #[tool(
         title = "Exchange Rate",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get exchange rates for all supported currencies. Returns list[]{from_currency, to_currency, rate, timestamp} covering USD, HKD, CNY, SGD and others."
     )]
     async fn exchange_rate(
@@ -1706,7 +1707,7 @@ impl Longbridge {
     /// Get profit analysis summary.
     #[tool(
         title = "Profit Analysis",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get portfolio profit and loss analysis summary. start/end: optional date range in yyyy-mm-dd format. Both must be provided together — passing only one returns empty results."
     )]
     async fn profit_analysis(
@@ -1721,7 +1722,7 @@ impl Longbridge {
     /// Get profit analysis detail for a symbol.
     #[tool(
         title = "Profit Analysis Detail",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get detailed profit and loss analysis for a specific symbol. start/end: optional date range in yyyy-mm-dd format. Both must be provided together — passing only one returns empty results."
     )]
     async fn profit_analysis_detail(
@@ -1739,7 +1740,7 @@ impl Longbridge {
     /// Get price alert list.
     #[tool(
         title = "List Price Alerts",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get all configured price alerts. Returns lists[]{counter_id, indicators[]{id, indicator_id, condition, price, frequency, enabled, triggered_at}}."
     )]
     async fn alert_list(
@@ -1833,7 +1834,7 @@ impl Longbridge {
     /// Get news for a symbol.
     #[tool(
         title = "News",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get latest news articles for a symbol. Returns items[]{id, title, source, publish_time, summary, url, related_symbols[]}."
     )]
     async fn news(
@@ -1848,7 +1849,7 @@ impl Longbridge {
     /// Get discussion topics for a symbol.
     #[tool(
         title = "Topic List",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get discussion topics for a symbol. Returns items[]{id, title, author, created_at, like_count, comment_count, content_summary}."
     )]
     async fn topic(
@@ -1863,7 +1864,7 @@ impl Longbridge {
     /// Get topic detail.
     #[tool(
         title = "Topic Detail",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get discussion topic detail by topic_id. Returns {id, title, content, author, created_at, like_count, comment_count, symbols[]}."
     )]
     async fn topic_detail(
@@ -1878,7 +1879,7 @@ impl Longbridge {
     /// Get topic replies.
     #[tool(
         title = "Topic Replies",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get replies to a discussion topic, paginated (page default 1, size default 20, range 1-50)"
     )]
     async fn topic_replies(
@@ -1936,7 +1937,7 @@ impl Longbridge {
     /// List account statements.
     #[tool(
         title = "Statement List",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "List available account statements (daily/monthly). Returns list[]{id, type (daily/monthly), date, status}. Use the id with statement_export to download."
     )]
     async fn statement_list(
@@ -1951,7 +1952,7 @@ impl Longbridge {
     /// Get the pre-signed download URL for a statement file.
     #[tool(
         title = "Export Statement",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::StatementUrlResponse>(),
         description = "Get a pre-signed download URL for a statement data file (obtained from statement_list). Returns {url}; fetch that URL to get the statement JSON."
     )]
@@ -1967,7 +1968,7 @@ impl Longbridge {
     /// Get short position (outstanding short) data for HK or US stocks.
     #[tool(
         title = "Short Positions",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get short interest history (open short positions) for HK or US stocks. Market inferred from symbol suffix. count: 1–100 (default 20). Unified data[]{timestamp(RFC3339), short_shares(open short position in shares), rate(decimal ratio e.g. 0.009=0.9%), close}. US-only: avg_daily_vol, days_to_cover. HK-only: balance(outstanding short position in HKD). US source: FINRA bi-weekly. HK source: HKEX daily."
     )]
     async fn short_positions(
@@ -1982,7 +1983,7 @@ impl Longbridge {
     /// Get real-time option call/put volume stats.
     #[tool(
         title = "Option Volume",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get real-time option call/put volume stats for a US stock. Returns {call_volume, put_volume, put_call_ratio, call_oi, put_oi} and top active contracts."
     )]
     async fn option_volume(
@@ -1997,7 +1998,7 @@ impl Longbridge {
     /// Get daily historical option volume stats.
     #[tool(
         title = "Option Volume (Daily)",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get daily historical option stats for a US stock. Returns items[]{date, call_volume, put_volume, put_call_vol_ratio, call_oi, put_oi, put_call_oi_ratio}."
     )]
     async fn option_volume_daily(
@@ -2015,7 +2016,7 @@ impl Longbridge {
     /// List DCA (recurring investment) plans.
     #[tool(
         title = "List DCA Plans",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "List DCA recurring investment plans. Returns plans[]{plan_id, symbol, amount, currency, frequency, status, next_execution_date}. Filter by status (Active/Suspended/Finished) or symbol."
     )]
     async fn dca_list(
@@ -2130,7 +2131,7 @@ impl Longbridge {
     /// Get DCA plan execution history.
     #[tool(
         title = "DCA Execution History",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get execution history records for a DCA plan by plan_id. Returns executions[]{date, quantity, amount, price, status, order_id}."
     )]
     async fn dca_history(
@@ -2145,7 +2146,7 @@ impl Longbridge {
     /// Get DCA statistics.
     #[tool(
         title = "DCA Statistics",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get DCA investment statistics. Returns {total_invested, total_value, total_return, return_rate, plan_count, items[]{symbol, invested, value, return_rate}}."
     )]
     async fn dca_stats(
@@ -2160,7 +2161,7 @@ impl Longbridge {
     /// Check if symbols support DCA.
     #[tool(
         title = "Check DCA Support",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Check whether given symbols support DCA recurring investment. Returns items[]{symbol, support_dca (bool), reason} for each queried symbol."
     )]
     async fn dca_check(
@@ -2175,7 +2176,7 @@ impl Longbridge {
     /// List community sharelists.
     #[tool(
         title = "List Sharelists",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "List user's own and subscribed community sharelists. Returns lists[]{id, name, description, symbol_count, is_owner, follower_count}."
     )]
     async fn sharelist_list(
@@ -2190,7 +2191,7 @@ impl Longbridge {
     /// Get sharelist detail.
     #[tool(
         title = "Sharelist Detail",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get community sharelist detail by id. Returns {id, name, description, constituents[]{symbol, name, last_done, change_rate}, quote data, subscription status}."
     )]
     async fn sharelist_detail(
@@ -2305,7 +2306,7 @@ impl Longbridge {
     /// Get popular community sharelists.
     #[tool(
         title = "Popular Sharelists",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get popular/trending community sharelists. Returns lists[]{id, name, description, symbol_count, follower_count, creator} sorted by popularity."
     )]
     async fn sharelist_popular(
@@ -2323,7 +2324,7 @@ impl Longbridge {
     /// Run a quant indicator script against historical K-line data on the server.
     #[tool(
         title = "Quant — Run Indicator Script",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Run a quant indicator script against historical K-line data on the server. Executes the script server-side and returns the computed indicator/plot values as JSON. Periods: 1m, 5m, 15m, 30m, 1h, day, week, month, year (default: day). The optional input parameter accepts a JSON array matching the order of input.*() calls in the script, e.g. \"[14,2.0]\"."
     )]
     async fn quant_run(
@@ -2338,7 +2339,7 @@ impl Longbridge {
     /// Search news by keyword.
     #[tool(
         title = "News Search",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Search news articles by keyword. Returns news_list[]{id, title, description, source_name, publish_at (RFC3339), score}. Paginate with score+publish_at_timestamp+id cursors."
     )]
     async fn news_search(
@@ -2353,7 +2354,7 @@ impl Longbridge {
     /// Search community topics by keyword.
     #[tool(
         title = "Topic Search",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Search community topics/posts by keyword. Returns id, author, time, and excerpt."
     )]
     async fn topic_search(
@@ -2368,7 +2369,7 @@ impl Longbridge {
     /// Get financial statements for a security.
     #[tool(
         title = "Financial Statements",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get financial statements (income statement, balance sheet, or cash flow) for a security. kind: IS/BS/CF/ALL. report: af (annual), saf (semi-annual), qf (quarterly full), q1/q2/q3."
     )]
     async fn financial_statement(
@@ -2386,7 +2387,7 @@ impl Longbridge {
     /// Get latest financial report summary for a security.
     #[tool(
         title = "Latest Financial Report",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get the latest financial report summary for a security. Returns {period, revenue, net_income, eps, roe, gross_margin, report_date} and key financial highlights."
     )]
     async fn financial_report_latest(
@@ -2404,7 +2405,7 @@ impl Longbridge {
     /// Get daily valuation rank (PE/PB percentile) for a security.
     #[tool(
         title = "Valuation Rank",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get daily valuation rank (PE/PB/PS/dividend yield industry percentile) for a security over a date range. start/end in yyyymmdd format."
     )]
     async fn valuation_rank(
@@ -2419,7 +2420,7 @@ impl Longbridge {
     /// Get institution rating history for a security.
     #[tool(
         title = "Institution Rating History",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get institution rating history. Returns target_history[]{firm, analyst, old_target, new_target, date} and evaluate_history[]{firm, old_rating, new_rating, date}."
     )]
     async fn institution_rating_history(
@@ -2437,7 +2438,7 @@ impl Longbridge {
     /// Get institution rating industry rank for a security.
     #[tool(
         title = "Institution Rating Industry Rank",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get peers ranked by institution analyst ratings in the same industry. Returns list[]{symbol, name, buy_count, sell_count, consensus_rating, target_price}. Paginated."
     )]
     async fn institution_rating_industry_rank(
@@ -2455,7 +2456,7 @@ impl Longbridge {
     /// Get short margin deposit details for the current account.
     #[tool(
         title = "Short Margin",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get short margin deposit details for the current account. Returns short positions with margin_amount, margin_rate, interest_rate, symbol, quantity per position."
     )]
     async fn short_margin(
@@ -2469,7 +2470,7 @@ impl Longbridge {
     /// List linked withdrawal bank cards.
     #[tool(
         title = "Bank Cards",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "List linked withdrawal bank cards for the current account. Returns cards[]{id, bank_name, account_number (masked), currency, status}."
     )]
     async fn bank_cards(
@@ -2483,7 +2484,7 @@ impl Longbridge {
     /// List withdrawal history.
     #[tool(
         title = "Withdrawals",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "List withdrawal history for the current account. Returns items[]{id, amount, currency, status, created_at, bank_name, account_number (masked)}."
     )]
     async fn withdrawals(
@@ -2498,7 +2499,7 @@ impl Longbridge {
     /// List deposit history.
     #[tool(
         title = "Deposits",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "List deposit history for the current account. Returns items[]{id, amount, currency, status, created_at, updated_at}. states: comma-separated (Pending/Finished/Failed). currencies: comma-separated codes."
     )]
     async fn deposits(
@@ -2513,7 +2514,7 @@ impl Longbridge {
     /// List IPO stocks currently in subscription stage (HK and US).
     #[tool(
         title = "IPO Subscriptions",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "List IPO stocks in subscription/pre-filing stage (HK+US). Returns items[]{symbol, name, market, sub_start_date, sub_end_date, listing_date, issue_price, min_lot_size}."
     )]
     async fn ipo_subscriptions(
@@ -2527,7 +2528,7 @@ impl Longbridge {
     /// Show the IPO calendar.
     #[tool(
         title = "IPO Calendar",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Show the IPO calendar. Returns items[]{symbol, name, market, sub_start_date, sub_end_date, listing_date, status} for upcoming and recent IPOs."
     )]
     async fn ipo_calendar(
@@ -2541,7 +2542,7 @@ impl Longbridge {
     /// List recently listed IPO stocks.
     #[tool(
         title = "IPO Listed",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "List recently listed IPO stocks (HK+US). Returns items[]{symbol, name, listing_date, issue_price, first_day_close, first_day_return, volume, market}."
     )]
     async fn ipo_listed(
@@ -2556,7 +2557,7 @@ impl Longbridge {
     /// Show IPO detail for a symbol.
     #[tool(
         title = "IPO Detail",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Show IPO detail for a symbol. Returns profile (business overview), timeline[]{event, date}, subscription eligibility, pricing_range, lot_size, allotment_rules."
     )]
     async fn ipo_detail(
@@ -2571,7 +2572,7 @@ impl Longbridge {
     /// List IPO orders (active and history).
     #[tool(
         title = "IPO Orders",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "List IPO orders (active+history). Returns orders[]{order_id, symbol, market, quantity, total_amount, status, submitted_at}. Filter by symbol, market, or status."
     )]
     async fn ipo_orders(
@@ -2586,7 +2587,7 @@ impl Longbridge {
     /// Show IPO order detail by order ID.
     #[tool(
         title = "IPO Order Detail",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Show detailed information for a specific IPO order by order_id. Returns {order_id, symbol, market, quantity, allotted_quantity, total_amount, status, submitted_at}."
     )]
     async fn ipo_order_detail(
@@ -2601,7 +2602,7 @@ impl Longbridge {
     /// Show IPO profit/loss summary and breakdown.
     #[tool(
         title = "IPO Profit / Loss",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Show IPO profit/loss summary and per-stock breakdown. Returns {total_cost, total_value, total_return, items[]{symbol, cost, current_value, return_rate}}. period: all/ytd/1y/3y."
     )]
     async fn ipo_profit_loss(
@@ -2616,7 +2617,7 @@ impl Longbridge {
     /// Get current-period business segment revenue breakdown.
     #[tool(
         title = "Business Segments",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get current-period business segment revenue breakdown for a symbol (name, percent, total, currency)"
     )]
     async fn business_segments(
@@ -2634,7 +2635,7 @@ impl Longbridge {
     /// Get historical business segment revenue trends.
     #[tool(
         title = "Business Segments History",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get historical business segment revenue trends (by period and category). Returns historical[].{date, total, currency, business[{name,percent,value}], regionals[{name,percent,value}]}"
     )]
     async fn business_segments_history(
@@ -2652,7 +2653,7 @@ impl Longbridge {
     /// Get monthly institutional rating distribution timeline.
     #[tool(
         title = "Institutional Views",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get monthly institutional rating distribution timeline. Returns months[]{date, buy, outperform, hold, underperform, sell, total} for trend analysis."
     )]
     async fn institutional_views(
@@ -2670,7 +2671,7 @@ impl Longbridge {
     /// Get industry ranking list by market and indicator.
     #[tool(
         title = "Industry Rank",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Industry ranking list by market (US/HK/CN/SG) and indicator (0=领涨/1=今日走势/2=人气/3=市值/4=营收/5=营收增长率/6=净利润/7=净利润增长率). sort_type: 0=单级 1=多层. Returns items[]{counter_id(BK/US/IN00258), name, chg, lists[]}. Pass counter_id directly to industry_peers."
     )]
     async fn industry_rank(
@@ -2685,7 +2686,7 @@ impl Longbridge {
     /// Get hierarchical industry peer group tree for an industry index symbol.
     #[tool(
         title = "Industry Peers",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Hierarchical sub-sector tree for an industry group. Accepts BK counter_id from industry_rank (e.g. BK/US/IN00258). Returns chain{name,counter_id,stock_num,chg,ytd_chg,next[{...}]} and top{name,market}. Each node shows stock count, daily change, and YTD change."
     )]
     async fn industry_peers(
@@ -2700,7 +2701,7 @@ impl Longbridge {
     /// Get financial report snapshot with actual vs forecast comparison.
     #[tool(
         title = "Financial Report Snapshot",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get financial report snapshot: report_desc (text summary), fo_revenue/fo_ebit/fo_eps (actual vs forecast with yoy/cmp), fr_* financial ratios (ROE, margins, assets, cash flow). report: qf/saf/af."
     )]
     async fn financial_report_snapshot(
@@ -2718,7 +2719,7 @@ impl Longbridge {
     /// Get Top 20 major shareholders with multi-period holdings.
     #[tool(
         title = "Top 20 Shareholders",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get Top 20 major shareholders (institutions, individuals, insiders) across reporting periods. Returns info[]{period, share_holders[]{object_id, name, title, shares_held, percent_shares_held, shares_changed, filing_date}}. Use object_id with shareholder_detail to drill into a holder's full trade history."
     )]
     async fn shareholder_top(
@@ -2733,7 +2734,7 @@ impl Longbridge {
     /// Get single shareholder's holding history and trade details by object_id.
     #[tool(
         title = "Shareholder Detail",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get a single shareholder's holding and trade history. Requires object_id from shareholder_top. Returns name, owner_source (Company/Institution/Person/Insider), tradings[]{period, accum_buy, accum_sell, net_buy, trading_details[]{trading_date, trading_type, trading_shares, trading_price, security_type, filing_date}}, holding_summary, holding_periods, trading_periods. Note: trading_details[] is empty for institutional (13F) holders — it is only populated for insider/individual filers (Form 4)."
     )]
     async fn shareholder_detail(
@@ -2751,7 +2752,7 @@ impl Longbridge {
     /// Compare valuation metrics across multiple stocks in the same industry.
     #[tool(
         title = "Stock Comparison",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Stock valuation comparison. Mode A (single): pass only symbol — server returns stock + auto-selected industry peers. Mode B (multi): pass symbol as primary + comparison_symbols (comma-separated, e.g. 'MSFT.US,GOOGL.US') for explicit peer comparison. currency: USD/HKD/CNY. Returns list[]{symbol, name, market_value, price_close, pe, pb, ps, history[]{date, pe, pb, ps}}."
     )]
     async fn valuation_comparison(
@@ -2769,7 +2770,7 @@ impl Longbridge {
     /// Get short-sale trade volume history for HK or US stocks.
     #[tool(
         title = "Short Trades",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get daily short-sale volume history for HK or US stocks. Market inferred from symbol suffix. last_timestamp: unix seconds (omit for latest). page_size: 1–100 (default 20). Unified data[]{timestamp(RFC3339), short_vol(daily short volume in shares), rate(decimal ratio e.g. 0.36=36%), close}. US-only: nasdaq_vol(NASDAQ short), nyse_vol(NYSE short). HK-only: balance(HKD), market_vol(total market volume that day). US source: FINRA/NASDAQ daily. HK source: HKEX daily."
     )]
     async fn short_trades(
@@ -2784,7 +2785,7 @@ impl Longbridge {
     /// Get top movers — stocks whose price exceeds the 20-day standard deviation.
     #[tool(
         title = "Top Movers",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get stocks whose price fluctuation exceeds the 20-trading-day standard deviation, with correlated news reasons. markets: comma-separated HK/US/CN/SG (omit=all). sort: 0=time 1=change-magnitude 2=popularity/heat (default). limit: results per page (default 20). next_params: pass next_params from previous response to paginate. Returns events[]{timestamp(RFC3339), alert_reason, alert_type, stock{symbol, name, change(decimal ratio e.g. 0.0445=+4.45%), last_done, labels[], intro}}, updated_at, next_params."
     )]
     async fn top_movers(
@@ -2799,7 +2800,7 @@ impl Longbridge {
     /// Get rank tab category configurations for the popularity leaderboard.
     #[tool(
         title = "Rank Categories",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get rank tab category configurations for the popularity leaderboard. Returns first_tags[]{key, name, second_tags[]{key, name, market}}. Pass a second_tags key (e.g. `hot_all-us`) to rank_list."
     )]
     async fn rank_categories(
@@ -2813,7 +2814,7 @@ impl Longbridge {
     /// Get ranked stock list by leaderboard tab key.
     #[tool(
         title = "Rank List",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get ranked stock list by leaderboard tab key. key: from rank_categories second_tags[].key (e.g. \"hot_all-us\", \"hot_up-hk\", \"trade_heat-us\"). market: inferred from key suffix (-us/-hk) or pass explicitly. size: results (default 20). Returns lists[]{symbol, name, last_done, chg(decimal), inflow, market_cap, pre_post_price, pre_post_chg, amplitude, turnover_rate, volume_rate, five_day_chg, ten_day_chg, twenty_day_chg, this_year_chg, industry, intro}, updated_at."
     )]
     async fn rank_list(
@@ -2828,7 +2829,7 @@ impl Longbridge {
     /// List platform-preset stock screener strategies.
     #[tool(
         title = "Screener Recommend Strategies",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "List platform-preset screener strategies. market: US|HK|CN|SG (default: US). Returns strategys[]{id, name, description, market, three_months_chg, risk}. Pass id to screener_search strategy_id to run, or screener_strategy to inspect filter conditions."
     )]
     async fn screener_recommend_strategies(
@@ -2846,7 +2847,7 @@ impl Longbridge {
     /// List user's own saved stock screener strategies.
     #[tool(
         title = "Screener User Strategies",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "List the current user's saved screener strategies. market: US|HK|CN|SG (default: US). Returns strategys[]{id, name, description, market, three_months_chg, risk}. Pass id to screener_search strategy_id to run, or screener_strategy to inspect conditions."
     )]
     async fn screener_user_strategies(
@@ -2864,7 +2865,7 @@ impl Longbridge {
     /// Get single screener strategy detail by id.
     #[tool(
         title = "Screener Strategy",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Inspect a screener strategy's filter conditions before running it. Returns market, filter{filters[]{key, min, max, tech_values}}. Use screener_search strategy_id to execute the strategy."
     )]
     async fn screener_strategy(
@@ -2882,7 +2883,7 @@ impl Longbridge {
     /// Execute a stock screener search by strategy or custom conditions.
     #[tool(
         title = "Screener Search",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Screen stocks. market: US|HK|CN|SG (Mode B required; Mode A uses strategy's market). Mode A: strategy_id from screener_recommend_strategies — auto-runs saved strategy. Mode B: conditions=[{\"key\":\"KEY\",\"min\":\"10\",\"max\":\"50\",\"tech_values\":{}},...]. extra_returns=[\"key\",...] adds display-only columns. sort_by_key: key name to sort by; sort_order: asc|desc (default desc). page: 0-based (default 0). Returns {total, items[]{symbol, name, indicators[]{key, name, value, unit}}}. Fundamental keys: pettm pbmrq roe roa netmargin salesgrowthyoy netincomegrowthyoy marketcap(亿) circulating_marketcap(亿) prevclose prevchg(%) divyld la epsttm netincome(亿) sales(亿) turnover_rate balance(万). Technical keys (call screener_indicators for tech_values schema): macd_day/week rsi_day/week kdj_day/week boll_day/week."
     )]
     async fn screener_search(
@@ -2897,7 +2898,7 @@ impl Longbridge {
     /// Get all available stock screener indicator metadata.
     #[tool(
         title = "Screener Indicators",
-        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = true),
+        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         description = "Get all available screener indicator keys with units and default value ranges. Technical indicators include a tech_values field showing available options (e.g. macd_day: {category:[goldenfork,deadcross], period:[day,week]}). Optional symbol (e.g. AAPL.US) narrows to stock-specific indicators. Returns groups[]{group_name, indicators[]{id, key, name, unit, default_range{min,max}, tech_values?{key:[{value,label},...]}}}."
     )]
     async fn screener_indicators(

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -527,7 +527,12 @@ impl Longbridge {
     /// Get current UTC time in RFC3339 format.
     #[tool(
         title = "Current Time",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get current UTC time as an RFC3339 string (e.g. \"2025-01-15T08:30:00Z\"). Use to determine current date/time before making date-based queries."
     )]
     async fn now(&self) -> String {
@@ -539,7 +544,12 @@ impl Longbridge {
     /// Get basic information of securities.
     #[tool(
         title = "Security Static Info",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get static info for securities. Returns per symbol: symbol, name_cn, name_en, exchange (e.g. NASDAQ), type (e.g. US_Stock), lot_size, listed_date, delisted (bool)."
     )]
     async fn static_info(
@@ -554,7 +564,12 @@ impl Longbridge {
     /// Get the latest price quotes.
     #[tool(
         title = "Quote",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get latest price quotes. Returns per symbol: last_done, prev_close, open, high, low, volume, turnover, change_rate, change_value, trade_status, timestamp."
     )]
     async fn quote(
@@ -569,7 +584,12 @@ impl Longbridge {
     /// Get option quotes.
     #[tool(
         title = "Option Quote",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get option quotes (max 500 symbols). Returns last_done, prev_close, open, high, low, volume, turnover, implied_volatility, delta, gamma, theta, vega, rho, open_interest per symbol."
     )]
     async fn option_quote(
@@ -584,7 +604,12 @@ impl Longbridge {
     /// Get warrant quotes.
     #[tool(
         title = "Warrant Quote",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get warrant quotes. Returns last_done, prev_close, open, high, low, volume, turnover, implied_volatility, delta, leverage_ratio, effective_leverage per symbol."
     )]
     async fn warrant_quote(
@@ -631,7 +656,12 @@ impl Longbridge {
     /// Get market participant broker information.
     #[tool(
         title = "Market Participants",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get HK market participant broker information. Returns participants[]{broker_ids[], name_en, name_cn, name_hk}. Use broker_ids to interpret broker queue data."
     )]
     async fn participants(
@@ -645,7 +675,12 @@ impl Longbridge {
     /// Get recent trades.
     #[tool(
         title = "Recent Trades",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get recent trades (max 1000). Returns trades[]{price, volume, timestamp, trade_type, direction} for the symbol."
     )]
     async fn trades(
@@ -660,7 +695,12 @@ impl Longbridge {
     /// Get intraday line data.
     #[tool(
         title = "Intraday Line",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get intraday minute-by-minute price/volume data. trade_sessions: \"intraday\" (default, regular hours) or \"all\" (include pre-market and post-market)"
     )]
     async fn intraday(
@@ -675,7 +715,12 @@ impl Longbridge {
     /// Get candlestick (K-line) data.
     #[tool(
         title = "Candlesticks",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get candlestick data (OHLCV). Only symbol is required; period defaults to day, count to 100 (max 1000), forward_adjust to false, trade_sessions to all. period: 1m/5m/15m/30m/60m/day/week/month/year. trade_sessions: intraday/all"
     )]
     async fn candlesticks(
@@ -690,7 +735,12 @@ impl Longbridge {
     /// Get historical candlesticks by offset.
     #[tool(
         title = "Historical Candlesticks by Offset",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get historical candlestick data by offset from a reference time. period: 1m/5m/15m/30m/60m/day/week/month/year"
     )]
     async fn history_candlesticks_by_offset(
@@ -708,7 +758,12 @@ impl Longbridge {
     /// Get historical candlesticks by date range.
     #[tool(
         title = "Historical Candlesticks by Date",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get historical candlestick data by date range. period: 1m/5m/15m/30m/60m/day/week/month/year"
     )]
     async fn history_candlesticks_by_date(
@@ -742,7 +797,12 @@ impl Longbridge {
     /// Get option chain expiry date list.
     #[tool(
         title = "Option Expiry Dates",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get option chain expiry dates for a symbol (e.g. AAPL.US). Returns expiry_dates[] as \"yyyy-mm-dd\" strings. Use with option_chain_info_by_date to get strikes and Greeks."
     )]
     async fn option_chain_expiry_date_list(
@@ -760,7 +820,12 @@ impl Longbridge {
     /// Get option chain info by expiry date.
     #[tool(
         title = "Option Chain by Date",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get option chain for an expiry date. Returns strikePrices[]{strike_price, call{symbol, last_done, iv, delta, gamma}, put{symbol, last_done, iv, delta, gamma}}."
     )]
     async fn option_chain_info_by_date(
@@ -778,7 +843,12 @@ impl Longbridge {
     /// Get capital flow of a security.
     #[tool(
         title = "Capital Flow",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get capital inflow/outflow time series. Returns items[]{timestamp, inflow, outflow, net_flow} for the symbol (same-day data)."
     )]
     async fn capital_flow(
@@ -812,7 +882,12 @@ impl Longbridge {
     /// Get trading session schedule.
     #[tool(
         title = "Trading Sessions",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get trading session schedule for all markets. Returns market_sessions[]{market, trade_sessions[]{beg_time, end_time, trade_session_type}}."
     )]
     async fn trading_session(
@@ -861,7 +936,12 @@ impl Longbridge {
     /// Get watchlist groups.
     #[tool(
         title = "Watchlist",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get all watchlist groups and their securities. Returns groups[]{id, name, securities[]{symbol, market, name, watched_price, watched_at}}."
     )]
     async fn watchlist(&self, ctx: RequestContext<RoleServer>) -> Result<CallToolResult, McpError> {
@@ -872,7 +952,12 @@ impl Longbridge {
     /// Get filings for a symbol.
     #[tool(
         title = "Filings",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get regulatory filings (8-K, 10-Q, 10-K, etc.). Returns items[]{id, title, type, language, filing_date, url} for the symbol."
     )]
     async fn filings(
@@ -887,7 +972,12 @@ impl Longbridge {
     /// Get warrant issuers.
     #[tool(
         title = "Warrant Issuers",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get HK warrant issuer information. Returns issuers[]{id, name_en, name_cn}. Use id in warrant_list issuer filter."
     )]
     async fn warrant_issuers(
@@ -901,7 +991,12 @@ impl Longbridge {
     /// Get warrant list for a symbol.
     #[tool(
         title = "Warrant List",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get filtered warrant list for an underlying symbol. Returns warrants[]{symbol, name, last_done, change_rate, implied_volatility, expiry_date, strike_price, leverage_ratio, outstanding_ratio}."
     )]
     async fn warrant_list(
@@ -916,7 +1011,12 @@ impl Longbridge {
     /// Calculate indexes for symbols.
     #[tool(
         title = "Calc Indexes",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Calculate financial indexes for symbols. Pass symbols, and optionally indexes (e.g. [\"PeTtmRatio\",\"PbRatio\",\"LastDone\",\"TurnoverRate\"]). When indexes is omitted or empty, defaults to [\"LastDone\",\"ChangeValue\",\"ChangeRate\",\"Volume\",\"PeTtmRatio\",\"PbRatio\",\"DividendRatioTtm\",\"TurnoverRate\",\"TotalMarketValue\"]. Returns per-symbol index values."
     )]
     async fn calc_indexes(
@@ -1000,7 +1100,12 @@ impl Longbridge {
     /// Get security list by market and category.
     #[tool(
         title = "Security List",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get security list for a market. Supports market: US, HK, CN, SG. category: \"Overnight\" (default). page: 1-based page number (default 1). count: records per page (default 50). Returns {total, page, count, items[]{symbol, name_en, name_cn}}."
     )]
     async fn security_list(
@@ -1015,7 +1120,12 @@ impl Longbridge {
     /// Get account balance.
     #[tool(
         title = "Account Balance",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get account cash balance and asset summary. Returns balances[]{currency, total_cash, max_finance_amount, remaining_finance_amount, risk_level, margin_call}. Filter by currency (e.g. \"USD\", \"HKD\")."
     )]
     async fn account_balance(
@@ -1076,7 +1186,12 @@ impl Longbridge {
     /// Get today's orders.
     #[tool(
         title = "Today's Orders",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get orders placed today. Returns orders[]{order_id, symbol, side, order_type, status, quantity, price, submitted_at, executed_quantity, executed_price}. Pass symbol to filter."
     )]
     async fn today_orders(
@@ -1127,7 +1242,12 @@ impl Longbridge {
     /// Get today's trade executions.
     #[tool(
         title = "Today's Executions",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get today's trade executions (fills). Returns executions[]{order_id, symbol, side, quantity, price, trade_done_at}. Pass symbol or order_id to filter."
     )]
     async fn today_executions(
@@ -1142,7 +1262,12 @@ impl Longbridge {
     /// Get historical orders (not including today).
     #[tool(
         title = "Historical Orders",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get historical orders between dates (excludes today). Returns orders[]{order_id, symbol, side, status, quantity, price, submitted_at}. start_at/end_at in RFC3339."
     )]
     async fn history_orders(
@@ -1157,7 +1282,12 @@ impl Longbridge {
     /// Get historical executions.
     #[tool(
         title = "Historical Executions",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get historical trade executions between dates. Returns executions[]{order_id, symbol, side, quantity, price, trade_done_at}. start_at/end_at in RFC3339."
     )]
     async fn history_executions(
@@ -1172,7 +1302,12 @@ impl Longbridge {
     /// Get cash flow records.
     #[tool(
         title = "Cash Flow",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get cash flow records (deposits, withdrawals, dividends). Returns items[]{transaction_type, amount, currency, balance, created_at, remark}. start_at/end_at in RFC3339."
     )]
     async fn cash_flow(
@@ -1247,7 +1382,12 @@ impl Longbridge {
     /// Get financial reports (income statement, balance sheet, cash flow).
     #[tool(
         title = "Financial Report",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get financial reports (income statement, balance sheet, cash flow). kind: IS/BS/CF/ALL. report_type: af (annual), saf (semi-annual), q1/q2/q3, qf (quarterly full)."
     )]
     async fn financial_report(
@@ -1265,7 +1405,12 @@ impl Longbridge {
     /// Get institution rating summary (analyst consensus + target price).
     #[tool(
         title = "Institution Rating",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get institution rating summary. Returns analyst{buy, outperform, hold, underperform, sell counts, target_price, consensus_rating} and instratings list."
     )]
     async fn institution_rating(
@@ -1283,7 +1428,12 @@ impl Longbridge {
     /// Get institution rating detail (historical ratings and target prices).
     #[tool(
         title = "Institution Rating Detail",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get detailed historical institution ratings and target price history. Returns target.list[]{analyst, firm, rating, target_price, timestamp} per institution."
     )]
     async fn institution_rating_detail(
@@ -1301,7 +1451,12 @@ impl Longbridge {
     /// Get dividend history.
     #[tool(
         title = "Dividend",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get dividend history. Returns items[]{ex_date, pay_date, record_date, dividend_type, amount, currency, status} for the symbol."
     )]
     async fn dividend(
@@ -1316,7 +1471,12 @@ impl Longbridge {
     /// Get dividend distribution details.
     #[tool(
         title = "Dividend Detail",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get detailed dividend distribution scheme. Returns details[]{period, cash_dividend, stock_dividend, record_date, ex_date, pay_date, currency}."
     )]
     async fn dividend_detail(
@@ -1331,7 +1491,12 @@ impl Longbridge {
     /// Get EPS forecast data.
     #[tool(
         title = "Forecast EPS",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get EPS forecast and analyst estimate history. Returns items[]{forecast_start_date, forecast_end_date, eps_estimate, eps_actual, surprise_pct, analyst_count}."
     )]
     async fn forecast_eps(
@@ -1346,7 +1511,12 @@ impl Longbridge {
     /// Get financial consensus estimates.
     #[tool(
         title = "Analyst Consensus",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get financial consensus estimates. Returns items[]{period, revenue_estimate, eps_estimate, net_income_estimate, analyst_count, last_updated} for upcoming periods."
     )]
     async fn consensus(
@@ -1361,7 +1531,12 @@ impl Longbridge {
     /// Get valuation overview (PE, PB, PS, dividend yield).
     #[tool(
         title = "Valuation",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get valuation overview with peer comparison. Returns metrics.pe/pb/ps/dividend_yield{current, industry_avg, 5yr_avg, percentile} and peer comparison list."
     )]
     async fn valuation(
@@ -1376,7 +1551,12 @@ impl Longbridge {
     /// Get detailed valuation history.
     #[tool(
         title = "Valuation History",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get detailed valuation history time series. Returns history.metrics{pe/pb/ps/dividend_yield}[]{timestamp, value} for long-term percentile analysis."
     )]
     async fn valuation_history(
@@ -1394,7 +1574,12 @@ impl Longbridge {
     /// Get industry valuation comparison.
     #[tool(
         title = "Industry Valuation",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get industry valuation comparison for peers. Returns list[]{symbol, name, pe, pb, ps, dividend_yield, history[]{date, pe, pb}} for peers in the same industry."
     )]
     async fn industry_valuation(
@@ -1412,7 +1597,12 @@ impl Longbridge {
     /// Get industry valuation distribution.
     #[tool(
         title = "Industry Valuation Distribution",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get industry PE/PB/PS valuation distribution. Returns distributions{pe/pb/ps}{min, p25, median, p75, max, current_percentile} to see where the stock sits in its sector."
     )]
     async fn industry_valuation_dist(
@@ -1430,7 +1620,12 @@ impl Longbridge {
     /// Get company overview.
     #[tool(
         title = "Company Profile",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get company overview. Returns name, description, employees, CEO, founded_year, website, exchange, industry, market_cap, and business profile summary."
     )]
     async fn company(
@@ -1445,7 +1640,12 @@ impl Longbridge {
     /// Get company executives.
     #[tool(
         title = "Executive",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get company executive and board member information. Returns members[]{name, title, appointed_date, age, biography, compensation}."
     )]
     async fn executive(
@@ -1460,7 +1660,12 @@ impl Longbridge {
     /// Get shareholders.
     #[tool(
         title = "Shareholders",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get institutional shareholders for a symbol. Returns shareholders[]{institution, shares, ratio, change, change_type, reported_at}."
     )]
     async fn shareholder(
@@ -1475,7 +1680,12 @@ impl Longbridge {
     /// Get fund holders.
     #[tool(
         title = "Fund Holders",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get funds and ETFs that hold a given symbol. Returns fund_holders[]{fund_name, fund_symbol, shares, ratio, change, reported_at}."
     )]
     async fn fund_holder(
@@ -1490,7 +1700,12 @@ impl Longbridge {
     /// Get corporate actions.
     #[tool(
         title = "Corporate Actions",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get corporate actions (splits, buybacks, name changes). Returns items[]{action_type, effective_date, ratio, description} for the symbol."
     )]
     async fn corp_action(
@@ -1505,7 +1720,12 @@ impl Longbridge {
     /// Get investor relations events.
     #[tool(
         title = "Investor Relations",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get investor relations events and announcements. Returns items[]{title, event_type, event_date, url, description} for the symbol."
     )]
     async fn invest_relation(
@@ -1520,7 +1740,12 @@ impl Longbridge {
     /// Get operating metrics.
     #[tool(
         title = "Operating Performance",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get company operating metrics (HK stocks only). Returns items[]{period, metric_name, value, unit} such as passenger traffic, cargo volumes, or store counts."
     )]
     async fn operating(
@@ -1535,7 +1760,12 @@ impl Longbridge {
     /// Get market trading status.
     #[tool(
         title = "Market Status",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get current market trading status for all markets. Returns market_time[]{market, trade_status (Pre-Open/Trading/Lunch Break/Post-Trading/Closed/Pre-Market/Post-Market), timestamp}."
     )]
     async fn market_status(
@@ -1549,7 +1779,12 @@ impl Longbridge {
     /// Get broker holding data.
     #[tool(
         title = "Broker Holding",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get top broker holding data for a symbol (HK stocks only; sourced from HKEX CCASS participant disclosure). Returns items[]{broker_name, holding_quantity, holding_change, holding_ratio} for the given period (rct_1/rct_5/rct_20/rct_60)."
     )]
     async fn broker_holding(
@@ -1564,7 +1799,12 @@ impl Longbridge {
     /// Get broker holding detail.
     #[tool(
         title = "Broker Holding Detail",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get full broker holding detail list for a symbol (HK stocks only; sourced from HKEX CCASS participant disclosure). Returns items[]{broker_id, broker_name, holding_quantity, holding_ratio, holding_change, date}."
     )]
     async fn broker_holding_detail(
@@ -1582,7 +1822,12 @@ impl Longbridge {
     /// Get daily broker holding for a specific broker.
     #[tool(
         title = "Broker Holding (Daily)",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get daily holding history for a specific broker (by broker_id) in a symbol (HK stocks only; sourced from HKEX CCASS participant disclosure). Returns items[]{date, holding_quantity, holding_change, holding_ratio}."
     )]
     async fn broker_holding_daily(
@@ -1600,7 +1845,12 @@ impl Longbridge {
     /// Get AH premium K-line data.
     #[tool(
         title = "A/H Premium",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get A/H share premium historical K-line data. Returns items[]{timestamp, open, high, low, close} representing the premium percentage over the given period."
     )]
     async fn ah_premium(
@@ -1615,7 +1865,12 @@ impl Longbridge {
     /// Get AH premium intraday data.
     #[tool(
         title = "A/H Premium (Intraday)",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get A/H share premium intraday time-share data. Returns items[]{timestamp, premium_rate} showing the intraday A/H premium percentage minute by minute."
     )]
     async fn ah_premium_intraday(
@@ -1633,7 +1888,12 @@ impl Longbridge {
     /// Get trade statistics.
     #[tool(
         title = "Trade Statistics",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get trade statistics (buy/sell/neutral volume distribution). Returns items[]{price_range, buy_volume, sell_volume, neutral_volume} for price-volume profile."
     )]
     async fn trade_stats(
@@ -1648,7 +1908,12 @@ impl Longbridge {
     /// Get market anomalies.
     #[tool(
         title = "Market Anomaly",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get market anomaly alerts (unusual price/volume changes). market: HK/US/CN/SG. symbol: optional, filter to a specific stock. count: results per page (default 50, max 100). Returns changes[]{symbol, name, change_rate, volume, ...}, all_off."
     )]
     async fn anomaly(
@@ -1663,7 +1928,12 @@ impl Longbridge {
     /// Get index constituents or ETF asset allocation.
     #[tool(
         title = "Index Constituents / ETF Asset Allocation",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get the constituents of an index or the asset allocation of an ETF. For an index (e.g. HSI.HK, .DJI.US) returns constituents[]{symbol, name, last_done, change_rate, market_cap, weight}. For an ETF (e.g. QQQ.US, 2800.HK) returns the asset allocation as info[] grouped by asset_type: 1=Holdings (top constituents with code, symbol, holding_detail), 2=Regional (country/region breakdown), 3=AssetClass (stock/bond/cash etc.), 4=Industry (sector breakdown). Each group has report_date and lists[]{name, position_ratio, name_locales}; Holdings groups additionally include code, symbol and holding_detail{industry_name, index_name, holding_type_name}."
     )]
     async fn constituent(
@@ -1678,7 +1948,12 @@ impl Longbridge {
     /// Get finance calendar events.
     #[tool(
         title = "Financial Calendar",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get finance calendar events by category and date range. category: report (earnings + financials) / dividend / split (splits & reverse splits) / ipo / macrodata (CPI, NFP, rate decisions) / closed (market holidays). market: HK/US/CN/SG/JP/UK/DE/AU (optional). Keep the date range to 2 weeks or less; for longer periods split into multiple calls to avoid truncation."
     )]
     async fn finance_calendar(
@@ -1693,7 +1968,12 @@ impl Longbridge {
     /// Get exchange rates.
     #[tool(
         title = "Exchange Rate",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get exchange rates for all supported currencies. Returns list[]{from_currency, to_currency, rate, timestamp} covering USD, HKD, CNY, SGD and others."
     )]
     async fn exchange_rate(
@@ -1707,7 +1987,12 @@ impl Longbridge {
     /// Get profit analysis summary.
     #[tool(
         title = "Profit Analysis",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get portfolio profit and loss analysis summary. start/end: optional date range in yyyy-mm-dd format. Both must be provided together — passing only one returns empty results."
     )]
     async fn profit_analysis(
@@ -1722,7 +2007,12 @@ impl Longbridge {
     /// Get profit analysis detail for a symbol.
     #[tool(
         title = "Profit Analysis Detail",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get detailed profit and loss analysis for a specific symbol. start/end: optional date range in yyyy-mm-dd format. Both must be provided together — passing only one returns empty results."
     )]
     async fn profit_analysis_detail(
@@ -1740,7 +2030,12 @@ impl Longbridge {
     /// Get price alert list.
     #[tool(
         title = "List Price Alerts",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get all configured price alerts. Returns lists[]{counter_id, indicators[]{id, indicator_id, condition, price, frequency, enabled, triggered_at}}."
     )]
     async fn alert_list(
@@ -1834,7 +2129,12 @@ impl Longbridge {
     /// Get news for a symbol.
     #[tool(
         title = "News",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get latest news articles for a symbol. Returns items[]{id, title, source, publish_time, summary, url, related_symbols[]}."
     )]
     async fn news(
@@ -1849,7 +2149,12 @@ impl Longbridge {
     /// Get discussion topics for a symbol.
     #[tool(
         title = "Topic List",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get discussion topics for a symbol. Returns items[]{id, title, author, created_at, like_count, comment_count, content_summary}."
     )]
     async fn topic(
@@ -1864,7 +2169,12 @@ impl Longbridge {
     /// Get topic detail.
     #[tool(
         title = "Topic Detail",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get discussion topic detail by topic_id. Returns {id, title, content, author, created_at, like_count, comment_count, symbols[]}."
     )]
     async fn topic_detail(
@@ -1879,7 +2189,12 @@ impl Longbridge {
     /// Get topic replies.
     #[tool(
         title = "Topic Replies",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get replies to a discussion topic, paginated (page default 1, size default 20, range 1-50)"
     )]
     async fn topic_replies(
@@ -1937,7 +2252,12 @@ impl Longbridge {
     /// List account statements.
     #[tool(
         title = "Statement List",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "List available account statements (daily/monthly). Returns list[]{id, type (daily/monthly), date, status}. Use the id with statement_export to download."
     )]
     async fn statement_list(
@@ -1968,7 +2288,12 @@ impl Longbridge {
     /// Get short position (outstanding short) data for HK or US stocks.
     #[tool(
         title = "Short Positions",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get short interest history (open short positions) for HK or US stocks. Market inferred from symbol suffix. count: 1–100 (default 20). Unified data[]{timestamp(RFC3339), short_shares(open short position in shares), rate(decimal ratio e.g. 0.009=0.9%), close}. US-only: avg_daily_vol, days_to_cover. HK-only: balance(outstanding short position in HKD). US source: FINRA bi-weekly. HK source: HKEX daily."
     )]
     async fn short_positions(
@@ -1983,7 +2308,12 @@ impl Longbridge {
     /// Get real-time option call/put volume stats.
     #[tool(
         title = "Option Volume",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get real-time option call/put volume stats for a US stock. Returns {call_volume, put_volume, put_call_ratio, call_oi, put_oi} and top active contracts."
     )]
     async fn option_volume(
@@ -1998,7 +2328,12 @@ impl Longbridge {
     /// Get daily historical option volume stats.
     #[tool(
         title = "Option Volume (Daily)",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get daily historical option stats for a US stock. Returns items[]{date, call_volume, put_volume, put_call_vol_ratio, call_oi, put_oi, put_call_oi_ratio}."
     )]
     async fn option_volume_daily(
@@ -2016,7 +2351,12 @@ impl Longbridge {
     /// List DCA (recurring investment) plans.
     #[tool(
         title = "List DCA Plans",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "List DCA recurring investment plans. Returns plans[]{plan_id, symbol, amount, currency, frequency, status, next_execution_date}. Filter by status (Active/Suspended/Finished) or symbol."
     )]
     async fn dca_list(
@@ -2131,7 +2471,12 @@ impl Longbridge {
     /// Get DCA plan execution history.
     #[tool(
         title = "DCA Execution History",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get execution history records for a DCA plan by plan_id. Returns executions[]{date, quantity, amount, price, status, order_id}."
     )]
     async fn dca_history(
@@ -2146,7 +2491,12 @@ impl Longbridge {
     /// Get DCA statistics.
     #[tool(
         title = "DCA Statistics",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get DCA investment statistics. Returns {total_invested, total_value, total_return, return_rate, plan_count, items[]{symbol, invested, value, return_rate}}."
     )]
     async fn dca_stats(
@@ -2161,7 +2511,12 @@ impl Longbridge {
     /// Check if symbols support DCA.
     #[tool(
         title = "Check DCA Support",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Check whether given symbols support DCA recurring investment. Returns items[]{symbol, support_dca (bool), reason} for each queried symbol."
     )]
     async fn dca_check(
@@ -2176,7 +2531,12 @@ impl Longbridge {
     /// List community sharelists.
     #[tool(
         title = "List Sharelists",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "List user's own and subscribed community sharelists. Returns lists[]{id, name, description, symbol_count, is_owner, follower_count}."
     )]
     async fn sharelist_list(
@@ -2191,7 +2551,12 @@ impl Longbridge {
     /// Get sharelist detail.
     #[tool(
         title = "Sharelist Detail",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get community sharelist detail by id. Returns {id, name, description, constituents[]{symbol, name, last_done, change_rate}, quote data, subscription status}."
     )]
     async fn sharelist_detail(
@@ -2306,7 +2671,12 @@ impl Longbridge {
     /// Get popular community sharelists.
     #[tool(
         title = "Popular Sharelists",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get popular/trending community sharelists. Returns lists[]{id, name, description, symbol_count, follower_count, creator} sorted by popularity."
     )]
     async fn sharelist_popular(
@@ -2324,7 +2694,12 @@ impl Longbridge {
     /// Run a quant indicator script against historical K-line data on the server.
     #[tool(
         title = "Quant — Run Indicator Script",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Run a quant indicator script against historical K-line data on the server. Executes the script server-side and returns the computed indicator/plot values as JSON. Periods: 1m, 5m, 15m, 30m, 1h, day, week, month, year (default: day). The optional input parameter accepts a JSON array matching the order of input.*() calls in the script, e.g. \"[14,2.0]\"."
     )]
     async fn quant_run(
@@ -2339,7 +2714,12 @@ impl Longbridge {
     /// Search news by keyword.
     #[tool(
         title = "News Search",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Search news articles by keyword. Returns news_list[]{id, title, description, source_name, publish_at (RFC3339), score}. Paginate with score+publish_at_timestamp+id cursors."
     )]
     async fn news_search(
@@ -2354,7 +2734,12 @@ impl Longbridge {
     /// Search community topics by keyword.
     #[tool(
         title = "Topic Search",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Search community topics/posts by keyword. Returns id, author, time, and excerpt."
     )]
     async fn topic_search(
@@ -2369,7 +2754,12 @@ impl Longbridge {
     /// Get financial statements for a security.
     #[tool(
         title = "Financial Statements",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get financial statements (income statement, balance sheet, or cash flow) for a security. kind: IS/BS/CF/ALL. report: af (annual), saf (semi-annual), qf (quarterly full), q1/q2/q3."
     )]
     async fn financial_statement(
@@ -2387,7 +2777,12 @@ impl Longbridge {
     /// Get latest financial report summary for a security.
     #[tool(
         title = "Latest Financial Report",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get the latest financial report summary for a security. Returns {period, revenue, net_income, eps, roe, gross_margin, report_date} and key financial highlights."
     )]
     async fn financial_report_latest(
@@ -2405,7 +2800,12 @@ impl Longbridge {
     /// Get daily valuation rank (PE/PB percentile) for a security.
     #[tool(
         title = "Valuation Rank",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get daily valuation rank (PE/PB/PS/dividend yield industry percentile) for a security over a date range. start/end in yyyymmdd format."
     )]
     async fn valuation_rank(
@@ -2420,7 +2820,12 @@ impl Longbridge {
     /// Get institution rating history for a security.
     #[tool(
         title = "Institution Rating History",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get institution rating history. Returns target_history[]{firm, analyst, old_target, new_target, date} and evaluate_history[]{firm, old_rating, new_rating, date}."
     )]
     async fn institution_rating_history(
@@ -2438,7 +2843,12 @@ impl Longbridge {
     /// Get institution rating industry rank for a security.
     #[tool(
         title = "Institution Rating Industry Rank",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get peers ranked by institution analyst ratings in the same industry. Returns list[]{symbol, name, buy_count, sell_count, consensus_rating, target_price}. Paginated."
     )]
     async fn institution_rating_industry_rank(
@@ -2456,7 +2866,12 @@ impl Longbridge {
     /// Get short margin deposit details for the current account.
     #[tool(
         title = "Short Margin",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get short margin deposit details for the current account. Returns short positions with margin_amount, margin_rate, interest_rate, symbol, quantity per position."
     )]
     async fn short_margin(
@@ -2470,7 +2885,12 @@ impl Longbridge {
     /// List linked withdrawal bank cards.
     #[tool(
         title = "Bank Cards",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "List linked withdrawal bank cards for the current account. Returns cards[]{id, bank_name, account_number (masked), currency, status}."
     )]
     async fn bank_cards(
@@ -2484,7 +2904,12 @@ impl Longbridge {
     /// List withdrawal history.
     #[tool(
         title = "Withdrawals",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "List withdrawal history for the current account. Returns items[]{id, amount, currency, status, created_at, bank_name, account_number (masked)}."
     )]
     async fn withdrawals(
@@ -2499,7 +2924,12 @@ impl Longbridge {
     /// List deposit history.
     #[tool(
         title = "Deposits",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "List deposit history for the current account. Returns items[]{id, amount, currency, status, created_at, updated_at}. states: comma-separated (Pending/Finished/Failed). currencies: comma-separated codes."
     )]
     async fn deposits(
@@ -2514,7 +2944,12 @@ impl Longbridge {
     /// List IPO stocks currently in subscription stage (HK and US).
     #[tool(
         title = "IPO Subscriptions",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "List IPO stocks in subscription/pre-filing stage (HK+US). Returns items[]{symbol, name, market, sub_start_date, sub_end_date, listing_date, issue_price, min_lot_size}."
     )]
     async fn ipo_subscriptions(
@@ -2528,7 +2963,12 @@ impl Longbridge {
     /// Show the IPO calendar.
     #[tool(
         title = "IPO Calendar",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Show the IPO calendar. Returns items[]{symbol, name, market, sub_start_date, sub_end_date, listing_date, status} for upcoming and recent IPOs."
     )]
     async fn ipo_calendar(
@@ -2542,7 +2982,12 @@ impl Longbridge {
     /// List recently listed IPO stocks.
     #[tool(
         title = "IPO Listed",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "List recently listed IPO stocks (HK+US). Returns items[]{symbol, name, listing_date, issue_price, first_day_close, first_day_return, volume, market}."
     )]
     async fn ipo_listed(
@@ -2557,7 +3002,12 @@ impl Longbridge {
     /// Show IPO detail for a symbol.
     #[tool(
         title = "IPO Detail",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Show IPO detail for a symbol. Returns profile (business overview), timeline[]{event, date}, subscription eligibility, pricing_range, lot_size, allotment_rules."
     )]
     async fn ipo_detail(
@@ -2572,7 +3022,12 @@ impl Longbridge {
     /// List IPO orders (active and history).
     #[tool(
         title = "IPO Orders",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "List IPO orders (active+history). Returns orders[]{order_id, symbol, market, quantity, total_amount, status, submitted_at}. Filter by symbol, market, or status."
     )]
     async fn ipo_orders(
@@ -2587,7 +3042,12 @@ impl Longbridge {
     /// Show IPO order detail by order ID.
     #[tool(
         title = "IPO Order Detail",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Show detailed information for a specific IPO order by order_id. Returns {order_id, symbol, market, quantity, allotted_quantity, total_amount, status, submitted_at}."
     )]
     async fn ipo_order_detail(
@@ -2602,7 +3062,12 @@ impl Longbridge {
     /// Show IPO profit/loss summary and breakdown.
     #[tool(
         title = "IPO Profit / Loss",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Show IPO profit/loss summary and per-stock breakdown. Returns {total_cost, total_value, total_return, items[]{symbol, cost, current_value, return_rate}}. period: all/ytd/1y/3y."
     )]
     async fn ipo_profit_loss(
@@ -2617,7 +3082,12 @@ impl Longbridge {
     /// Get current-period business segment revenue breakdown.
     #[tool(
         title = "Business Segments",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get current-period business segment revenue breakdown for a symbol (name, percent, total, currency)"
     )]
     async fn business_segments(
@@ -2635,7 +3105,12 @@ impl Longbridge {
     /// Get historical business segment revenue trends.
     #[tool(
         title = "Business Segments History",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get historical business segment revenue trends (by period and category). Returns historical[].{date, total, currency, business[{name,percent,value}], regionals[{name,percent,value}]}"
     )]
     async fn business_segments_history(
@@ -2653,7 +3128,12 @@ impl Longbridge {
     /// Get monthly institutional rating distribution timeline.
     #[tool(
         title = "Institutional Views",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get monthly institutional rating distribution timeline. Returns months[]{date, buy, outperform, hold, underperform, sell, total} for trend analysis."
     )]
     async fn institutional_views(
@@ -2671,7 +3151,12 @@ impl Longbridge {
     /// Get industry ranking list by market and indicator.
     #[tool(
         title = "Industry Rank",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Industry ranking list by market (US/HK/CN/SG) and indicator (0=领涨/1=今日走势/2=人气/3=市值/4=营收/5=营收增长率/6=净利润/7=净利润增长率). sort_type: 0=单级 1=多层. Returns items[]{counter_id(BK/US/IN00258), name, chg, lists[]}. Pass counter_id directly to industry_peers."
     )]
     async fn industry_rank(
@@ -2686,7 +3171,12 @@ impl Longbridge {
     /// Get hierarchical industry peer group tree for an industry index symbol.
     #[tool(
         title = "Industry Peers",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Hierarchical sub-sector tree for an industry group. Accepts BK counter_id from industry_rank (e.g. BK/US/IN00258). Returns chain{name,counter_id,stock_num,chg,ytd_chg,next[{...}]} and top{name,market}. Each node shows stock count, daily change, and YTD change."
     )]
     async fn industry_peers(
@@ -2701,7 +3191,12 @@ impl Longbridge {
     /// Get financial report snapshot with actual vs forecast comparison.
     #[tool(
         title = "Financial Report Snapshot",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get financial report snapshot: report_desc (text summary), fo_revenue/fo_ebit/fo_eps (actual vs forecast with yoy/cmp), fr_* financial ratios (ROE, margins, assets, cash flow). report: qf/saf/af."
     )]
     async fn financial_report_snapshot(
@@ -2719,7 +3214,12 @@ impl Longbridge {
     /// Get Top 20 major shareholders with multi-period holdings.
     #[tool(
         title = "Top 20 Shareholders",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get Top 20 major shareholders (institutions, individuals, insiders) across reporting periods. Returns info[]{period, share_holders[]{object_id, name, title, shares_held, percent_shares_held, shares_changed, filing_date}}. Use object_id with shareholder_detail to drill into a holder's full trade history."
     )]
     async fn shareholder_top(
@@ -2734,7 +3234,12 @@ impl Longbridge {
     /// Get single shareholder's holding history and trade details by object_id.
     #[tool(
         title = "Shareholder Detail",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get a single shareholder's holding and trade history. Requires object_id from shareholder_top. Returns name, owner_source (Company/Institution/Person/Insider), tradings[]{period, accum_buy, accum_sell, net_buy, trading_details[]{trading_date, trading_type, trading_shares, trading_price, security_type, filing_date}}, holding_summary, holding_periods, trading_periods. Note: trading_details[] is empty for institutional (13F) holders — it is only populated for insider/individual filers (Form 4)."
     )]
     async fn shareholder_detail(
@@ -2752,7 +3257,12 @@ impl Longbridge {
     /// Compare valuation metrics across multiple stocks in the same industry.
     #[tool(
         title = "Stock Comparison",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Stock valuation comparison. Mode A (single): pass only symbol — server returns stock + auto-selected industry peers. Mode B (multi): pass symbol as primary + comparison_symbols (comma-separated, e.g. 'MSFT.US,GOOGL.US') for explicit peer comparison. currency: USD/HKD/CNY. Returns list[]{symbol, name, market_value, price_close, pe, pb, ps, history[]{date, pe, pb, ps}}."
     )]
     async fn valuation_comparison(
@@ -2770,7 +3280,12 @@ impl Longbridge {
     /// Get short-sale trade volume history for HK or US stocks.
     #[tool(
         title = "Short Trades",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get daily short-sale volume history for HK or US stocks. Market inferred from symbol suffix. last_timestamp: unix seconds (omit for latest). page_size: 1–100 (default 20). Unified data[]{timestamp(RFC3339), short_vol(daily short volume in shares), rate(decimal ratio e.g. 0.36=36%), close}. US-only: nasdaq_vol(NASDAQ short), nyse_vol(NYSE short). HK-only: balance(HKD), market_vol(total market volume that day). US source: FINRA/NASDAQ daily. HK source: HKEX daily."
     )]
     async fn short_trades(
@@ -2785,7 +3300,12 @@ impl Longbridge {
     /// Get top movers — stocks whose price exceeds the 20-day standard deviation.
     #[tool(
         title = "Top Movers",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get stocks whose price fluctuation exceeds the 20-trading-day standard deviation, with correlated news reasons. markets: comma-separated HK/US/CN/SG (omit=all). sort: 0=time 1=change-magnitude 2=popularity/heat (default). limit: results per page (default 20). next_params: pass next_params from previous response to paginate. Returns events[]{timestamp(RFC3339), alert_reason, alert_type, stock{symbol, name, change(decimal ratio e.g. 0.0445=+4.45%), last_done, labels[], intro}}, updated_at, next_params."
     )]
     async fn top_movers(
@@ -2800,7 +3320,12 @@ impl Longbridge {
     /// Get rank tab category configurations for the popularity leaderboard.
     #[tool(
         title = "Rank Categories",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get rank tab category configurations for the popularity leaderboard. Returns first_tags[]{key, name, second_tags[]{key, name, market}}. Pass a second_tags key (e.g. `hot_all-us`) to rank_list."
     )]
     async fn rank_categories(
@@ -2814,7 +3339,12 @@ impl Longbridge {
     /// Get ranked stock list by leaderboard tab key.
     #[tool(
         title = "Rank List",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get ranked stock list by leaderboard tab key. key: from rank_categories second_tags[].key (e.g. \"hot_all-us\", \"hot_up-hk\", \"trade_heat-us\"). market: inferred from key suffix (-us/-hk) or pass explicitly. size: results (default 20). Returns lists[]{symbol, name, last_done, chg(decimal), inflow, market_cap, pre_post_price, pre_post_chg, amplitude, turnover_rate, volume_rate, five_day_chg, ten_day_chg, twenty_day_chg, this_year_chg, industry, intro}, updated_at."
     )]
     async fn rank_list(
@@ -2829,7 +3359,12 @@ impl Longbridge {
     /// List platform-preset stock screener strategies.
     #[tool(
         title = "Screener Recommend Strategies",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "List platform-preset screener strategies. market: US|HK|CN|SG (default: US). Returns strategys[]{id, name, description, market, three_months_chg, risk}. Pass id to screener_search strategy_id to run, or screener_strategy to inspect filter conditions."
     )]
     async fn screener_recommend_strategies(
@@ -2847,7 +3382,12 @@ impl Longbridge {
     /// List user's own saved stock screener strategies.
     #[tool(
         title = "Screener User Strategies",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "List the current user's saved screener strategies. market: US|HK|CN|SG (default: US). Returns strategys[]{id, name, description, market, three_months_chg, risk}. Pass id to screener_search strategy_id to run, or screener_strategy to inspect conditions."
     )]
     async fn screener_user_strategies(
@@ -2865,7 +3405,12 @@ impl Longbridge {
     /// Get single screener strategy detail by id.
     #[tool(
         title = "Screener Strategy",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Inspect a screener strategy's filter conditions before running it. Returns market, filter{filters[]{key, min, max, tech_values}}. Use screener_search strategy_id to execute the strategy."
     )]
     async fn screener_strategy(
@@ -2883,7 +3428,12 @@ impl Longbridge {
     /// Execute a stock screener search by strategy or custom conditions.
     #[tool(
         title = "Screener Search",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Screen stocks. market: US|HK|CN|SG (Mode B required; Mode A uses strategy's market). Mode A: strategy_id from screener_recommend_strategies — auto-runs saved strategy. Mode B: conditions=[{\"key\":\"KEY\",\"min\":\"10\",\"max\":\"50\",\"tech_values\":{}},...]. extra_returns=[\"key\",...] adds display-only columns. sort_by_key: key name to sort by; sort_order: asc|desc (default desc). page: 0-based (default 0). Returns {total, items[]{symbol, name, indicators[]{key, name, value, unit}}}. Fundamental keys: pettm pbmrq roe roa netmargin salesgrowthyoy netincomegrowthyoy marketcap(亿) circulating_marketcap(亿) prevclose prevchg(%) divyld la epsttm netincome(亿) sales(亿) turnover_rate balance(万). Technical keys (call screener_indicators for tech_values schema): macd_day/week rsi_day/week kdj_day/week boll_day/week."
     )]
     async fn screener_search(
@@ -2898,7 +3448,12 @@ impl Longbridge {
     /// Get all available stock screener indicator metadata.
     #[tool(
         title = "Screener Indicators",
-        annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
         description = "Get all available screener indicator keys with units and default value ranges. Technical indicators include a tech_values field showing available options (e.g. macd_day: {category:[goldenfork,deadcross], period:[day,week]}). Optional symbol (e.g. AAPL.US) narrows to stock-specific indicators. Returns groups[]{group_name, indicators[]{id, key, name, unit, default_range{min,max}, tech_values?{key:[{value,label},...]}}}."
     )]
     async fn screener_indicators(


### PR DESCRIPTION
…ation rationale

OpenAI MCP submission review requires every tool to explicitly declare readOnlyHint, openWorldHint, and destructiveHint. The 123 read-only tools and `authenticate` previously omitted destructiveHint.

- Add `destructive_hint = false` to all 123 read-only tools + `authenticate` (read-only tools perform no updates; authenticate creates a session, not a destructive overwrite). All 146 tools now set the three required hints.
- Add docs/mcp-annotations/: per-tool justification for every explicit annotation value (grounded in each tool's implementation), plus a README summarizing the fix, MCP annotation semantics, and the optional outputSchema recommendation.