### PR TITLE
feat(http): serve a dark landing page at / for browser requests

### DIFF
--- a/src/auth/landing.html
+++ b/src/auth/landing.html
@@ -1,0 +1,200 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Longbridge MCP Server</title>
+        <style>
+            * {
+                box-sizing: border-box;
+            }
+            :root {
+                --bg: #000;
+                --fg: #f5f5f5;
+                --muted: #8a8a8a;
+                --accent: #00dbb6;
+                --line: #1f1f1f;
+                --panel: #0c0c0c;
+            }
+            html,
+            body {
+                margin: 0;
+                background: var(--bg);
+            }
+            body {
+                font-family:
+                    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                    Helvetica, Arial, sans-serif;
+                color: var(--fg);
+                line-height: 1.5;
+                -webkit-font-smoothing: antialiased;
+                text-rendering: optimizeLegibility;
+            }
+            .wrap {
+                max-width: 720px;
+                margin: 0 auto;
+                padding: 36px 24px 40px;
+            }
+            .mono {
+                font-family:
+                    ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas,
+                    monospace;
+            }
+
+            .badge {
+                display: inline-block;
+                font-size: 0.66rem;
+                letter-spacing: 0.14em;
+                text-transform: uppercase;
+                color: #cfcfcf;
+                background: rgba(255, 255, 255, 0.06);
+                border: 1px solid var(--line);
+                padding: 3px 9px;
+                border-radius: 999px;
+                font-weight: 600;
+            }
+            h1 {
+                font-size: clamp(1.7rem, 4.5vw, 2.3rem);
+                line-height: 1.05;
+                margin: 14px 0 6px;
+                letter-spacing: -0.02em;
+            }
+            h1 .accent {
+                color: var(--accent);
+            }
+            .lede {
+                font-size: 0.98rem;
+                color: var(--muted);
+                margin: 0;
+                max-width: 60ch;
+            }
+
+            h2 {
+                font-size: 0.72rem;
+                letter-spacing: 0.16em;
+                text-transform: uppercase;
+                color: var(--muted);
+                margin: 26px 0 8px;
+                font-weight: 600;
+            }
+
+            dl.meta {
+                display: grid;
+                grid-template-columns: max-content 1fr;
+                border: 1px solid var(--line);
+                border-radius: 10px;
+                overflow: hidden;
+                margin: 0;
+            }
+            dl.meta dt,
+            dl.meta dd {
+                padding: 8px 16px;
+                border-top: 1px solid var(--line);
+                margin: 0;
+                font-size: 0.82rem;
+            }
+            dl.meta dt:first-of-type,
+            dl.meta dd:nth-of-type(1) {
+                border-top: 0;
+            }
+            dl.meta dt {
+                color: var(--muted);
+                letter-spacing: 0.04em;
+                background: var(--panel);
+                border-right: 1px solid var(--line);
+            }
+            dl.meta dd {
+                font-weight: 500;
+            }
+            dl.meta dd.url {
+                color: var(--accent);
+            }
+
+            pre {
+                background: var(--panel);
+                border: 1px solid var(--line);
+                border-radius: 9px;
+                padding: 12px 16px;
+                overflow-x: auto;
+                font-size: 0.82rem;
+                margin: 0;
+                color: #e8e8e8;
+            }
+            pre .c {
+                color: var(--accent);
+            }
+            .label {
+                color: var(--muted);
+                font-size: 0.85rem;
+                margin: 0 0 6px;
+            }
+
+            a {
+                color: var(--accent);
+                text-decoration: none;
+            }
+            a:hover {
+                text-decoration: underline;
+            }
+
+            footer {
+                margin-top: 28px;
+                color: var(--muted);
+                font-size: 0.82rem;
+            }
+            footer a {
+                color: var(--muted);
+            }
+        </style>
+    </head>
+    <body>
+        <div class="wrap">
+            <span class="badge">Model Context Protocol</span>
+            <h1>Longbridge <span class="accent">MCP</span> Server</h1>
+            <p class="lede">
+                Investment market insights — quotes, options, fundamentals, news
+                &amp; portfolio analytics for US &amp; HK markets, inside your
+                AI client. Add this URL to an MCP client; it isn't meant to be
+                browsed.
+            </p>
+
+            <h2>Server</h2>
+            <dl class="meta">
+                <dt>Name</dt>
+                <dd>Longbridge</dd>
+                <dt>Description</dt>
+                <dd>Investment market insights</dd>
+                <dt>Server URL</dt>
+                <dd class="url mono">https://mcp.longbridge.com</dd>
+                <dt>Authentication</dt>
+                <dd>OAuth</dd>
+            </dl>
+
+            <h2>Claude Code</h2>
+            <pre
+                class="mono"
+            >claude mcp add <span class="c">--transport</span> http longbridge https://mcp.longbridge.com</pre>
+
+            <h2>Codex</h2>
+            <pre
+                class="mono"
+            >codex mcp add longbridge <span class="c">--url</span> https://mcp.longbridge.com</pre>
+
+            <h2>Claude Desktop · Cursor · Zed</h2>
+            <p class="label">Add to your client's MCP server config:</p>
+            <pre
+                class="mono"
+            >{ <span class="c">"mcpServers"</span>: { <span class="c">"longbridge"</span>: { <span class="c">"url"</span>: "https://mcp.longbridge.com" } } }</pre>
+
+            <h2>Documentation</h2>
+            <p>
+                <a href="https://open.longbridge.com/docs/mcp"
+                    >open.longbridge.com/docs/mcp</a
+                >
+                — full setup, tool reference &amp; examples.
+            </p>
+
+            <footer>© <a href="https://longbridge.com">Longbridge</a></footer>
+        </div>
+    </body>
+</html>

--- a/src/auth/landing.html
+++ b/src/auth/landing.html
@@ -9,12 +9,12 @@
                 box-sizing: border-box;
             }
             :root {
-                --bg: #000;
+                --bg: #0a0e19;
                 --fg: #f5f5f5;
-                --muted: #8a8a8a;
+                --muted: #8b93a7;
                 --accent: #00dbb6;
-                --line: #1f1f1f;
-                --panel: #0c0c0c;
+                --line: #1e2535;
+                --panel: #111624;
             }
             html,
             body {

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -4,6 +4,7 @@ pub mod middleware;
 use std::sync::Arc;
 
 use axum::Router;
+use axum::response::Response;
 use rmcp::transport::streamable_http_server::session::never::NeverSessionManager;
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 
@@ -90,6 +91,41 @@ async fn health() -> axum::http::StatusCode {
     axum::http::StatusCode::OK
 }
 
+/// Human-facing landing page served at `/` for browser visits. Static
+/// onboarding text only — see the file for content.
+const LANDING_PAGE_HTML: &str = include_str!("landing.html");
+
+/// Serve [`LANDING_PAGE_HTML`] only for a browser navigation to `/`
+/// (a `GET` whose `Accept` header asks for `text/html`). Every other request —
+/// JSON-RPC `POST`, the SSE `GET` with `Accept: text/event-stream`, `Accept:
+/// */*`, any non-root path — falls through untouched to the wrapped MCP service,
+/// so client connection/installation is never affected. Layered ahead of the
+/// auth middleware so the page renders without credentials.
+async fn landing_or_mcp(req: axum::extract::Request, next: axum::middleware::Next) -> Response {
+    use axum::response::IntoResponse;
+
+    let is_browser_root = req.method() == axum::http::Method::GET
+        && req.uri().path() == "/"
+        && req
+            .headers()
+            .get(axum::http::header::ACCEPT)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|accept| accept.contains("text/html"));
+
+    if is_browser_root {
+        return (
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "text/html; charset=utf-8",
+            )],
+            LANDING_PAGE_HTML,
+        )
+            .into_response();
+    }
+
+    next.run(req).await
+}
+
 /// Domain-verification token for the OpenAI Apps directory, served as plain text
 /// at `/.well-known/openai-apps-challenge`. OpenAI fetches this path and expects
 /// the exact token back to confirm ownership of the deployment.
@@ -170,6 +206,11 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     let mcp_with_auth = make_mcp_with_auth(state.base_url.clone(), middleware::AuthMode::Required);
     let mcp_with_auth_root =
         make_mcp_with_auth(state.base_url.clone(), middleware::AuthMode::Required);
+    // Root mount, plus a thin front layer that serves the human landing page for
+    // browser GETs to `/`. All programmatic MCP traffic passes straight through.
+    let root_service = tower::ServiceBuilder::new()
+        .layer(axum::middleware::from_fn(landing_or_mcp))
+        .service(mcp_with_auth_root);
     // Optional-auth endpoint — same MCP server, but token-less requests are let
     // through so an OAuth-incapable client can call the `authenticate` tool.
     let mcp_agent = make_mcp_with_auth(state.base_url.clone(), middleware::AuthMode::Optional);
@@ -184,7 +225,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .nest_service("/agent", mcp_agent)
         .nest_service("/mcp", mcp_with_auth)
         // Also serve at root so deployments that omit the /mcp path prefix work.
-        .fallback_service(mcp_with_auth_root)
+        .fallback_service(root_service)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Browser visits to `/` (a `GET` whose `Accept` header asks for `text/html`) now render a dark onboarding page instead of falling through to the auth-gated MCP service. The page shows:

- **Server info**: Name `Longbridge`, Description `Investment market insights`, Server URL `https://mcp.longbridge.com`, Authentication `OAuth`
- **Install snippets**: Claude Code, Codex, and Claude Desktop / Cursor / Zed
- **Docs link**: `https://open.longbridge.com/docs/mcp`

Styling: pure black, brand accent `#00DBB6`, system fonts only (no third-party requests), compact enough to fit one screen.

## How

- New `src/auth/landing.html`, embedded via `include_str!`.
- A thin `landing_or_mcp` middleware layered ahead of the root `fallback_service`. It serves the page **only** for `GET /` with `Accept: text/html`; every other request — JSON-RPC `POST`, the SSE `GET` (`Accept: text/event-stream`), `Accept: */*`, any non-root path — passes through untouched. The layer sits ahead of auth so the page renders without credentials.

## Why it doesn't affect MCP clients

Verified locally:

| Request | Result |
|---|---|
| `GET /` `Accept: text/html` | 200 landing page |
| `POST /` initialize (no token) | 401 (unchanged) |
| `GET /` `Accept: text/event-stream` | passes to MCP (unchanged) |
| `GET /` `Accept: */*` | passes to MCP (unchanged) |
| `POST /mcp` initialize | 401 (unchanged) |
| `/agent` token-less handshake | 200 (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)