### PR TITLE
fix(market): use OpenAPI trade status labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,8 +1520,8 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "longbridge"
-version = "4.3.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
+version = "4.3.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#1dac7937395386b5ea7dee24bfed933e48840aa5"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -1540,6 +1540,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "serde_repr",
  "strum",
  "strum_macros",
  "thiserror 2.0.18",
@@ -1555,8 +1556,8 @@ dependencies = [
 
 [[package]]
 name = "longbridge-candlesticks"
-version = "4.3.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
+version = "4.3.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#1dac7937395386b5ea7dee24bfed933e48840aa5"
 dependencies = [
  "bitflags 2.11.1",
  "num-traits",
@@ -1567,16 +1568,16 @@ dependencies = [
 
 [[package]]
 name = "longbridge-geo"
-version = "4.3.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
+version = "4.3.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#1dac7937395386b5ea7dee24bfed933e48840aa5"
 dependencies = [
  "reqwest 0.12.28",
 ]
 
 [[package]]
 name = "longbridge-httpcli"
-version = "4.3.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
+version = "4.3.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#1dac7937395386b5ea7dee24bfed933e48840aa5"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -1627,8 +1628,8 @@ dependencies = [
 
 [[package]]
 name = "longbridge-oauth"
-version = "4.3.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
+version = "4.3.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#1dac7937395386b5ea7dee24bfed933e48840aa5"
 dependencies = [
  "dirs",
  "futures-util",
@@ -1644,8 +1645,8 @@ dependencies = [
 
 [[package]]
 name = "longbridge-proto"
-version = "4.3.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
+version = "4.3.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#1dac7937395386b5ea7dee24bfed933e48840aa5"
 dependencies = [
  "prost",
  "serde",
@@ -1653,8 +1654,8 @@ dependencies = [
 
 [[package]]
 name = "longbridge-wscli"
-version = "4.3.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
+version = "4.3.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#1dac7937395386b5ea7dee24bfed933e48840aa5"
 dependencies = [
  "byteorder",
  "flate2",
@@ -2850,6 +2851,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/docs/mcp-annotations/group-a-market.md
+++ b/docs/mcp-annotations/group-a-market.md
@@ -194,7 +194,7 @@ mutating SDK method.
 - **Open World = true** — The security universe is maintained externally and served from the Longbridge backend over the network.
 
 ### market_status
-- **Read Only = true** — Returns the current trading status (Trading, Closed, Lunch Break, etc.) per market; pure read.
+- **Read Only = true** — Returns the current trading status (Trading, Closed, Mid-Day Break, Pre-Market, etc.) per market; pure read.
 - **Destructive = false** — Reading market status changes no state.
 - **Idempotent = true** — Repeated calls re-read the current status with no side effects.
 - **Open World = true** — Market status reflects live exchange state delivered by the Longbridge backend over the network.

--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -574,7 +574,7 @@
     },
     "market_status": {
       "title": "市场状态",
-      "description": "获取所有市场当前交易状态，返回 market_time[]{market, trade_status（Pre-Open/Trading/Lunch Break/Post-Trading/Closed 等）, timestamp}"
+      "description": "获取所有市场当前交易状态，返回 market_time[]{market, trade_status（Trading/Closed/Mid-Day Break/Pre-Market/Post-Market/Overnight 等）, timestamp}"
     },
     "market_temperature": {
       "title": "市场温度",

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -574,7 +574,7 @@
     },
     "market_status": {
       "title": "市場狀態",
-      "description": "獲取所有市場當前交易狀態，返回 market_time[]{market, trade_status（Pre-Open/Trading/Lunch Break/Post-Trading/Closed 等）, timestamp}"
+      "description": "獲取所有市場當前交易狀態，返回 market_time[]{market, trade_status（Trading/Closed/Mid-Day Break/Pre-Market/Post-Market/Overnight 等）, timestamp}"
     },
     "market_temperature": {
       "title": "市場溫度",

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -61,16 +61,10 @@ pub struct IndexSymbolParam {
 }
 
 fn trade_status_label(code: i64) -> &'static str {
-    match code {
-        101 => "Pre-Open",
-        102 | 103 | 105 | 202 | 203 => "Trading",
-        104 => "Lunch Break",
-        106 => "Post-Trading",
-        108 => "Closed",
-        201 => "Pre-Market",
-        204 => "Post-Market",
-        _ => "Unknown",
-    }
+    i32::try_from(code)
+        .map(longbridge::market::TradeStatus::from)
+        .unwrap_or_default()
+        .name()
 }
 
 pub async fn market_status(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
@@ -594,4 +588,28 @@ pub async fn rank_list(
         ],
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::trade_status_label;
+
+    #[test]
+    fn trade_status_label_matches_openapi_status() {
+        let cases = [
+            (101, "Closed"),
+            (103, "Morning Break"),
+            (106, "Mid-Day Break"),
+            (123, "Realtime Quotes"),
+            (202, "Trading"),
+            (204, "Closed"),
+            (206, "Pre-Market"),
+            (210, "Trading"),
+            (456, "Unknown"),
+        ];
+
+        for (code, expected) in cases {
+            assert_eq!(trade_status_label(code), expected, "code {code}");
+        }
+    }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1788,7 +1788,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::market::MarketStatusResponse>(),
-        description = "Get current market trading status for all markets. Returns market_time[]{market, trade_status (Pre-Open/Trading/Lunch Break/Post-Trading/Closed/Pre-Market/Post-Market), timestamp}."
+        description = "Get current market trading status for all markets. Returns market_time[]{market, trade_status (Trading/Closed/Mid-Day Break/Pre-Market/Post-Market/Overnight), timestamp}."
     )]
     async fn market_status(
         &self,

--- a/src/tools/output/market.rs
+++ b/src/tools/output/market.rs
@@ -44,8 +44,8 @@ pub struct MarketStatusEntry {
     /// Market code, e.g. "US" / "HK" / "CN" / "SG".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub market: Option<String>,
-    /// Trading status label: one of Pre-Open / Trading / Lunch Break /
-    /// Post-Trading / Closed / Pre-Market / Post-Market / Unknown.
+    /// Trading status label, e.g. Trading / Closed / Mid-Day Break /
+    /// Pre-Market / Post-Market / Overnight / Unknown.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trade_status: Option<String>,
     /// Status snapshot timestamp (RFC3339).


### PR DESCRIPTION
## Summary
- Use `longbridge::market::TradeStatus` as the single source for market status display labels.
- Update market status docs, output schema text, and zh-CN/zh-HK tool descriptions to match the OpenAPI labels.
- Add coverage for representative status codes including engine supplemental values.

Depends on longbridge/openapi#546.

## Test Plan
- `cargo test tools::market::tests --config 'patch."https://github.com/longbridge/openapi.git".longbridge.path="/Users/jason/work/openapi/rust"'`
- `cargo clippy --all-features --all-targets --config 'patch."https://github.com/longbridge/openapi.git".longbridge.path="/Users/jason/work/openapi/rust"'`
- `cargo test --config 'patch."https://github.com/longbridge/openapi.git".longbridge.path="/Users/jason/work/openapi/rust"'`
- `git diff --check`