### PR TITLE
test(market): update trade_status label for code 123

### DIFF
--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -600,7 +600,7 @@ mod tests {
             (101, "Closed"),
             (103, "Morning Break"),
             (106, "Mid-Day Break"),
-            (123, "Realtime Quotes"),
+            (123, "Temporary Break"),
             (202, "Trading"),
             (204, "Closed"),
             (206, "Pre-Market"),


### PR DESCRIPTION
## Summary

The `660cf8c Update OpenAPI SDK for trade_status` SDK bump changed the `name()` output of `REALTIME_QUOTE` (code 123) from `"Realtime Quotes"` to `"Temporary Break"`. `trade_status_label` simply forwards the SDK's `.name()`, so the hardcoded expectation in `trade_status_label_matches_openapi_status` became stale. This updates the test case to match the SDK.

## Test plan

- `cargo test trade_status_label_matches_openapi_status` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)