### PR TITLE
fix: bound quote ws context pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,20 +617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,12 +998,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1626,7 +1606,6 @@ dependencies = [
  "base64 0.22.1",
  "bs58",
  "clap",
- "dashmap",
  "longbridge",
  "prometheus",
  "reqwest 0.12.28",
@@ -1637,6 +1616,7 @@ dependencies = [
  "serde",
  "serde-transcode",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "time",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ base64 = "0.22"
 bs58 = "0.5"
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 serde-transcode = "1.1"
-dashmap = "6"
 anyhow = "1"
 rustls = { version = "0.23", features = ["ring"] }
-
+sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ These are **advanced settings** — most users do not need to change them. They 
 | `LONGBRIDGE_HTTP_URL` | `https://openapi.longbridge.com` | Longbridge API base URL (also used for OAuth metadata) |
 | `LONGBRIDGE_QUOTE_WS_URL` | `wss://openapi-quote.longbridge.com/v2` | Quote WebSocket endpoint |
 | `LONGBRIDGE_TRADE_WS_URL` | `wss://openapi-trade.longbridge.com/v2` | Trade WebSocket endpoint |
+| `LONGBRIDGE_MCP_QUOTE_WS_IDLE_TTL_SECS` | `600` | Idle seconds before a cached quote WebSocket context is evicted |
+| `LONGBRIDGE_MCP_QUOTE_WS_MAX_CONTEXTS` | `1024` | Maximum cached quote WebSocket contexts per server process |
 | `LONGBRIDGE_LOG_PATH` | *(none)* | SDK internal log path |
 
 ## Authentication

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-Longbridge MCP Server is a **stateless** Rust service that exposes Longbridge financial data and trading capabilities through the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP). It translates MCP tool calls into Longbridge SDK and HTTP API calls, handling authentication, JSON response transformation, and metrics collection.
+Longbridge MCP Server is a Rust service with no durable session state that exposes Longbridge financial data and trading capabilities through the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP). It translates MCP tool calls into Longbridge SDK and HTTP API calls, handling authentication, JSON response transformation, metrics collection, and a bounded process-local quote WebSocket context cache.
 
 ```
 ┌─────────────┐         ┌──────────────────────┐         ┌──────────────────┐
 │  MCP Client │  HTTP   │  Longbridge MCP      │  SDK /  │  Longbridge      │
 │ (Claude,    │ Bearer  │  Server              │  HTTP   │  OpenAPI         │
 │  etc.)      │────────▶│                      │────────▶│                  │
-│             │◀────────│  (stateless)         │◀────────│  (quote, trade,  │
+│             │◀────────│  (no durable state)  │◀────────│  (quote, trade,  │
 │             │  JSON   │                      │  JSON   │   content, etc.) │
 └─────────────┘         └──────────────────────┘         └──────────────────┘
                                │
@@ -23,7 +23,7 @@ Longbridge MCP Server is a **stateless** Rust service that exposes Longbridge fi
 
 ## Design Principles
 
-1. **Stateless** — No sessions, no database. Each request carries a Bearer token; the server creates SDK contexts on the fly and discards them after use.
+1. **No durable server state** — No sessions and no database. Each request carries a Bearer token. HTTP and trade contexts are created on demand; quote WebSocket contexts are cached per authenticated identity inside each process with an idle TTL and maximum size so concurrent quote tools share one upstream connection.
 
 2. **Direct OAuth** — The server does not proxy OAuth. It publishes [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) Protected Resource Metadata pointing MCP clients directly to Longbridge's OAuth authorization server.
 
@@ -41,11 +41,11 @@ Longbridge MCP Server is a **stateless** Rust service that exposes Longbridge fi
 4. Tool handler:
    a. Extracts McpContext (token + Accept-Language) from request
    b. Creates Config via OAuth::from_token(token)
-   c. Creates QuoteContext / TradeContext / HttpClient as needed
+   c. Reuses or creates a cached QuoteContext, or creates TradeContext / HttpClient as needed
    d. Calls the Longbridge SDK or HTTP API
    e. Serializes the response through TransformSerializer
    f. Returns CallToolResult with transformed JSON
-   g. Config and contexts are dropped (connections closed)
+   g. HTTP/trade contexts are dropped; cached quote contexts stay until idle TTL, token rotation, explicit eviction, or capacity pressure
 
 5. Response flows back through rmcp → axum → MCP Client
 ```
@@ -213,12 +213,14 @@ The server reads configuration from CLI arguments (highest priority), a JSON con
 | `base_url` | Public URL for OAuth metadata (**required for public deployments**) |
 | `tls_cert` / `tls_key` | Enable HTTPS with PEM certificate and key |
 | `LONGBRIDGE_HTTP_URL` | Override Longbridge API endpoint (env var) |
+| `LONGBRIDGE_MCP_QUOTE_WS_IDLE_TTL_SECS` | Idle TTL for cached quote WebSocket contexts (default: 600) |
+| `LONGBRIDGE_MCP_QUOTE_WS_MAX_CONTEXTS` | Maximum cached quote WebSocket contexts per process (default: 1024) |
 
 ## Deployment
 
 The server is designed for containerized deployment:
 
 - Single static binary (no runtime dependencies beyond CA certificates)
-- No persistent state (no volumes needed for data)
+- No persistent state; the process-local quote WebSocket cache is bounded and disposable
 - Horizontal scaling: any number of instances behind a load balancer
 - Health check: `GET /metrics` returns 200

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,6 @@
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use prometheus::{Encoder, HistogramVec, IntCounterVec, Opts, Registry, TextEncoder};
+use prometheus::{Encoder, HistogramVec, IntCounterVec, IntGauge, Opts, Registry, TextEncoder};
 
 use std::sync::LazyLock;
 
@@ -39,6 +39,29 @@ static TOOL_CALL_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
     histogram
 });
 
+static QUOTE_WS_POOL_EVENTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new(
+            "mcp_quote_ws_pool_events_total",
+            "Quote WebSocket context pool events",
+        ),
+        &["event"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static QUOTE_WS_POOL_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "mcp_quote_ws_pool_entries",
+        "Current cached quote WebSocket contexts in this process",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
 pub fn record_tool_call(tool_name: &str, duration_secs: f64, is_error: bool) {
     TOOL_CALLS_TOTAL.with_label_values(&[tool_name]).inc();
     TOOL_CALL_DURATION
@@ -47,6 +70,16 @@ pub fn record_tool_call(tool_name: &str, duration_secs: f64, is_error: bool) {
     if is_error {
         TOOL_CALL_ERRORS_TOTAL.with_label_values(&[tool_name]).inc();
     }
+}
+
+pub fn record_quote_ws_pool_event(event: &str, count: u64) {
+    QUOTE_WS_POOL_EVENTS_TOTAL
+        .with_label_values(&[event])
+        .inc_by(count);
+}
+
+pub fn set_quote_ws_pool_entries(entries: usize) {
+    QUOTE_WS_POOL_ENTRIES.set(entries as i64);
 }
 
 pub async fn metrics_handler() -> impl IntoResponse {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -232,7 +232,9 @@ impl McpContext {
     /// server-side access logs.
     pub async fn get_quote_context(&self) -> longbridge::quote::QuoteContext {
         self.track_quote_cmd();
-        crate::ws_pool::get_or_init_quote(&self.token, self.create_config()).await
+        // Pass a lazy closure: create_config() is only called on a cache miss.
+        // Cache hits avoid the Arc<Config> allocation entirely.
+        crate::ws_pool::get_or_init_quote(&self.token, || self.create_config()).await
     }
 
     /// Extracts `account_channel` from the JWT bearer token's `sub` claim.
@@ -4159,13 +4161,21 @@ mod quote_cmd_tests {
     /// `QuoteContext` fails this test.
     #[test]
     fn quote_tools_use_tracking_context_constructor() {
-        let tools_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/tools");
-        // `mod.rs` defines `get_quote_context`; quote tools should not construct
-        // quote contexts directly.
-        let helper_file = tools_dir.join("mod.rs");
+        // Scan all of src/ so files outside src/tools/ (e.g. a future
+        // src/subscriptions.rs) are also caught.
+        // Allowed construction sites:
+        //   - src/ws_pool.rs       — the sanctioned pool that wraps QuoteContext::new
+        //   - src/tools/mod.rs     — this file (defines get_quote_context; comments
+        //                            reference QuoteContext::new() in doc strings)
+        let src_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let allowed: std::collections::HashSet<_> = [
+            src_dir.join("ws_pool.rs"),
+            src_dir.join("tools").join("mod.rs"),
+        ]
+        .into();
         let mut offenders = Vec::new();
-        for file in rs_files(&tools_dir) {
-            if file == helper_file {
+        for file in rs_files(&src_dir) {
+            if allowed.contains(&file) {
                 continue;
             }
             let src = std::fs::read_to_string(&file).unwrap();
@@ -4177,8 +4187,9 @@ mod quote_cmd_tests {
         }
         assert!(
             offenders.is_empty(),
-            "quote tools must use `mctx.get_quote_context()` (fires the \
-             /v1/quote/cmd beacon), not `QuoteContext::new(...)` directly. \
+            "QuoteContext::new() is only allowed in src/ws_pool.rs. \
+             All other code must use `mctx.get_quote_context()` so calls go \
+             through the connection pool and the /v1/quote/cmd beacon. \
              Untracked constructor at:\n{}",
             offenders.join("\n")
         );

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -227,7 +227,6 @@ impl McpContext {
         tokio::spawn(async move { send_quote_cmd(&client).await });
     }
 
-    /// Return the cached `QuoteContext` for this token, creating it on first
     /// Return the cached `QuoteContext` for this token, creating one on first
     /// use. Also fires the WS beacon so the quote operation appears in
     /// server-side access logs.
@@ -4152,16 +4151,17 @@ mod quote_cmd_tests {
     }
 
     /// Guard: every quote tool must obtain its `QuoteContext` via
-    /// `mctx.create_quote_context()` (which fires the `/v1/quote/cmd` beacon),
+    /// `mctx.get_quote_context()` (which fires the `/v1/quote/cmd` beacon),
     /// never `QuoteContext::new(...)` directly. The sole sanctioned constructor
-    /// call lives in `mod.rs` (the helper itself), so every other tool file must
+    /// call lives outside `src/tools`, so every tool file must
     /// be free of `QuoteContext::new(`. This makes "every WS quote tool is
     /// tracked" an enforced invariant: a new tool that constructs its own
     /// `QuoteContext` fails this test.
     #[test]
     fn quote_tools_use_tracking_context_constructor() {
         let tools_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/tools");
-        // `mod.rs` defines `create_quote_context`, the one allowed constructor.
+        // `mod.rs` defines `get_quote_context`; quote tools should not construct
+        // quote contexts directly.
         let helper_file = tools_dir.join("mod.rs");
         let mut offenders = Vec::new();
         for file in rs_files(&tools_dir) {
@@ -4177,7 +4177,7 @@ mod quote_cmd_tests {
         }
         assert!(
             offenders.is_empty(),
-            "quote tools must use `mctx.create_quote_context()` (fires the \
+            "quote tools must use `mctx.get_quote_context()` (fires the \
              /v1/quote/cmd beacon), not `QuoteContext::new(...)` directly. \
              Untracked constructor at:\n{}",
             offenders.join("\n")

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -237,6 +237,13 @@ impl McpContext {
         crate::ws_pool::get_or_init_quote(&self.token, || self.create_config()).await
     }
 
+    /// Evict the cached `QuoteContext` for this token. Call this after any
+    /// Longbridge error on a quote API so the next request creates a fresh
+    /// WebSocket connection rather than reusing a broken one.
+    pub fn evict_quote_context(&self) {
+        crate::ws_pool::evict(&self.token);
+    }
+
     /// Extracts `account_channel` from the JWT bearer token's `sub` claim.
     /// Falls back to `"lb"` when the token cannot be decoded.
     pub fn account_channel(&self) -> String {

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -229,10 +229,10 @@ pub async fn static_info(
     p: SymbolsParam,
 ) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx
-        .static_info(p.symbols)
-        .await
-        .map_err(Error::longbridge)?;
+    let result = ctx.static_info(p.symbols).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -287,7 +287,10 @@ pub async fn quote(
     p: SymbolsParam,
 ) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx.quote(p.symbols).await.map_err(Error::longbridge)?;
+    let result = ctx.quote(p.symbols).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
     normalize_extended_sessions(&mut value);
     tool_json(&value)
@@ -298,10 +301,10 @@ pub async fn option_quote(
     p: SymbolsParam,
 ) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx
-        .option_quote(p.symbols)
-        .await
-        .map_err(Error::longbridge)?;
+    let result = ctx.option_quote(p.symbols).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -310,10 +313,10 @@ pub async fn warrant_quote(
     p: SymbolsParam,
 ) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx
-        .warrant_quote(p.symbols)
-        .await
-        .map_err(Error::longbridge)?;
+    let result = ctx.warrant_quote(p.symbols).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -322,7 +325,10 @@ pub async fn depth(
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx.depth(p.symbol).await.map_err(Error::longbridge)?;
+    let result = ctx.depth(p.symbol).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -331,13 +337,19 @@ pub async fn brokers(
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx.brokers(p.symbol).await.map_err(Error::longbridge)?;
+    let result = ctx.brokers(p.symbol).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
 pub async fn participants(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx.participants().await.map_err(Error::longbridge)?;
+    let result = ctx.participants().await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -346,10 +358,10 @@ pub async fn trades(
     p: SymbolCountParam,
 ) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx
-        .trades(p.symbol, p.count)
-        .await
-        .map_err(Error::longbridge)?;
+    let result = ctx.trades(p.symbol, p.count).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -362,10 +374,10 @@ pub async fn intraday(
         None => longbridge::quote::TradeSessions::Intraday,
     };
     let ctx = mctx.get_quote_context().await;
-    let result = ctx
-        .intraday(p.symbol, sessions)
-        .await
-        .map_err(Error::longbridge)?;
+    let result = ctx.intraday(p.symbol, sessions).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -384,7 +396,10 @@ pub async fn candlesticks(
     let result = ctx
         .candlesticks(p.symbol, period, p.count, adjust, sessions)
         .await
-        .map_err(Error::longbridge)?;
+        .map_err(|e| {
+            mctx.evict_quote_context();
+            Error::longbridge(e)
+        })?;
     tool_json(&result)
 }
 
@@ -405,7 +420,10 @@ pub async fn history_candlesticks_by_offset(
             p.symbol, period, adjust, p.forward, time, p.count, sessions,
         )
         .await
-        .map_err(Error::longbridge)?;
+        .map_err(|e| {
+            mctx.evict_quote_context();
+            Error::longbridge(e)
+        })?;
     tool_json(&result)
 }
 
@@ -428,7 +446,10 @@ pub async fn history_candlesticks_by_date(
     let result = ctx
         .history_candlesticks_by_date(p.symbol, period, adjust, start, end, sessions)
         .await
-        .map_err(Error::longbridge)?;
+        .map_err(|e| {
+            mctx.evict_quote_context();
+            Error::longbridge(e)
+        })?;
     tool_json(&result)
 }
 
@@ -440,10 +461,10 @@ pub async fn trading_days(
     let start = parse::parse_date(&p.start)?;
     let end = parse::parse_date(&p.end)?;
     let ctx = mctx.get_quote_context().await;
-    let result = ctx
-        .trading_days(market, start, end)
-        .await
-        .map_err(Error::longbridge)?;
+    let result = ctx.trading_days(market, start, end).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -455,7 +476,10 @@ pub async fn option_chain_expiry_date_list(
     let dates = ctx
         .option_chain_expiry_date_list(p.symbol)
         .await
-        .map_err(Error::longbridge)?;
+        .map_err(|e| {
+            mctx.evict_quote_context();
+            Error::longbridge(e)
+        })?;
     let strs: Vec<String> = dates
         .into_iter()
         .map(|d| {
@@ -475,7 +499,10 @@ pub async fn option_chain_info_by_date(
     let result = ctx
         .option_chain_info_by_date(p.symbol, date)
         .await
-        .map_err(Error::longbridge)?;
+        .map_err(|e| {
+            mctx.evict_quote_context();
+            Error::longbridge(e)
+        })?;
     tool_json(&result)
 }
 
@@ -484,10 +511,10 @@ pub async fn capital_flow(
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx
-        .capital_flow(p.symbol)
-        .await
-        .map_err(Error::longbridge)?;
+    let result = ctx.capital_flow(p.symbol).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -496,10 +523,10 @@ pub async fn capital_distribution(
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx
-        .capital_distribution(p.symbol)
-        .await
-        .map_err(Error::longbridge)?;
+    let result = ctx.capital_distribution(p.symbol).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     let timestamp = result
         .timestamp
         .format(&time::format_description::well_known::Rfc3339)
@@ -522,7 +549,10 @@ pub async fn capital_distribution(
 
 pub async fn trading_session(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx.trading_session().await.map_err(Error::longbridge)?;
+    let result = ctx.trading_session().await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -532,10 +562,10 @@ pub async fn market_temperature(
 ) -> Result<CallToolResult, McpError> {
     let market = parse::parse_market(&p.market)?;
     let ctx = mctx.get_quote_context().await;
-    let result = ctx
-        .market_temperature(market)
-        .await
-        .map_err(Error::longbridge)?;
+    let result = ctx.market_temperature(market).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -550,13 +580,19 @@ pub async fn history_market_temperature(
     let result = ctx
         .history_market_temperature(market, start, end)
         .await
-        .map_err(Error::longbridge)?;
+        .map_err(|e| {
+            mctx.evict_quote_context();
+            Error::longbridge(e)
+        })?;
     tool_json(&result)
 }
 
 pub async fn watchlist(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx.watchlist().await.map_err(Error::longbridge)?;
+    let result = ctx.watchlist().await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -565,13 +601,19 @@ pub async fn filings(
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx.filings(p.symbol).await.map_err(Error::longbridge)?;
+    let result = ctx.filings(p.symbol).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
 pub async fn warrant_issuers(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx.warrant_issuers().await.map_err(Error::longbridge)?;
+    let result = ctx.warrant_issuers().await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -632,7 +674,10 @@ pub async fn warrant_list(
             statuses.as_deref(),
         )
         .await
-        .map_err(Error::longbridge)?;
+        .map_err(|e| {
+            mctx.evict_quote_context();
+            Error::longbridge(e)
+        })?;
     tool_json(&result)
 }
 
@@ -665,10 +710,10 @@ pub async fn calc_indexes(
         .map(|s| parse::parse_calc_index(s))
         .collect::<Result<_, _>>()?;
     let ctx = mctx.get_quote_context().await;
-    let mut result = ctx
-        .calc_indexes(p.symbols, indexes)
-        .await
-        .map_err(Error::longbridge)?;
+    let mut result = ctx.calc_indexes(p.symbols, indexes).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
 
     // Normalize Greeks to match Longbridge app display values:
     // - theta: API returns annualized value (×252), divide by 252 for per-trading-day
@@ -698,10 +743,10 @@ pub async fn create_watchlist_group(
         req = req.securities(securities);
     }
     let ctx = mctx.get_quote_context().await;
-    let id = ctx
-        .create_watchlist_group(req)
-        .await
-        .map_err(Error::longbridge)?;
+    let id = ctx.create_watchlist_group(req).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&serde_json::json!({ "id": id }))
 }
 
@@ -711,9 +756,10 @@ pub async fn delete_watchlist_group(
 ) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
     let id = p.id;
-    ctx.delete_watchlist_group(id, p.purge)
-        .await
-        .map_err(Error::longbridge)?;
+    ctx.delete_watchlist_group(id, p.purge).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&serde_json::json!({ "id": id, "deleted": true }))
 }
 
@@ -736,9 +782,10 @@ pub async fn update_watchlist_group(
         req = req.mode(mode);
     }
     let ctx = mctx.get_quote_context().await;
-    ctx.update_watchlist_group(req)
-        .await
-        .map_err(Error::longbridge)?;
+    ctx.update_watchlist_group(req).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&serde_json::json!({ "id": id, "updated": true }))
 }
 
@@ -752,10 +799,10 @@ pub async fn security_list(
         None => None,
     };
     let ctx = mctx.get_quote_context().await;
-    let all = ctx
-        .security_list(market, category)
-        .await
-        .map_err(Error::longbridge)?;
+    let all = ctx.security_list(market, category).await.map_err(|e| {
+        mctx.evict_quote_context();
+        Error::longbridge(e)
+    })?;
 
     let page = p.page.unwrap_or(1).max(1);
     let count = p.count.unwrap_or(50).max(1);

--- a/src/ws_pool.rs
+++ b/src/ws_pool.rs
@@ -3,28 +3,497 @@
 //! `QuoteContext` opens a persistent WebSocket connection to Longbridge.
 //! Creating one per tool call would exhaust the server-side per-account
 //! connection limit under concurrent load.  This module caches one
-//! `QuoteContext` per OAuth token so all tool calls from the same session
-//! share a single connection.
+//! `QuoteContext` per authenticated identity so all quote tool calls from the
+//! same user in this process share a single connection.
 
-use std::sync::{Arc, LazyLock};
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
-use dashmap::DashMap;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE};
 use longbridge::quote::QuoteContext;
+use sha2::{Digest, Sha256};
 
-static POOL: LazyLock<DashMap<String, QuoteContext>> = LazyLock::new(DashMap::new);
+const DEFAULT_IDLE_TTL_SECS: u64 = 10 * 60;
+const DEFAULT_MAX_ENTRIES: usize = 1024;
+const IDLE_TTL_ENV: &str = "LONGBRIDGE_MCP_QUOTE_WS_IDLE_TTL_SECS";
+const MAX_ENTRIES_ENV: &str = "LONGBRIDGE_MCP_QUOTE_WS_MAX_CONTEXTS";
+
+static POOL: LazyLock<Pool<QuoteContext>> = LazyLock::new(|| Pool::new(PoolSettings::from_env()));
+static SWEEPER_STARTED: OnceLock<()> = OnceLock::new();
+
+#[derive(Clone, Copy, Debug)]
+struct PoolSettings {
+    max_entries: usize,
+    idle_ttl: Duration,
+}
+
+impl Default for PoolSettings {
+    fn default() -> Self {
+        Self {
+            max_entries: DEFAULT_MAX_ENTRIES,
+            idle_ttl: Duration::from_secs(DEFAULT_IDLE_TTL_SECS),
+        }
+    }
+}
+
+impl PoolSettings {
+    fn from_env() -> Self {
+        let defaults = Self::default();
+        let max_entries = std::env::var(MAX_ENTRIES_ENV)
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(defaults.max_entries);
+        let idle_ttl = std::env::var(IDLE_TTL_ENV)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .map(Duration::from_secs)
+            .unwrap_or(defaults.idle_ttl);
+
+        Self {
+            max_entries,
+            idle_ttl,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct PoolKey {
+    identity: String,
+}
+
+impl PoolKey {
+    fn new(identity: impl Into<String>) -> Self {
+        Self {
+            identity: identity.into(),
+        }
+    }
+}
+
+struct PoolEntry<T> {
+    value: T,
+    token_fingerprint: String,
+    last_used: Instant,
+}
+
+struct Pool<T: Clone> {
+    settings: PoolSettings,
+    entries: Mutex<HashMap<PoolKey, PoolEntry<T>>>,
+}
+
+impl<T: Clone> Pool<T> {
+    fn new(settings: PoolSettings) -> Self {
+        Self {
+            settings,
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn get_or_insert_with(
+        &self,
+        key: PoolKey,
+        token_fingerprint: String,
+        init: impl FnOnce() -> T,
+    ) -> T {
+        self.get_or_insert_with_at(Instant::now(), key, token_fingerprint, init)
+    }
+
+    fn get_or_insert_with_at(
+        &self,
+        now: Instant,
+        key: PoolKey,
+        token_fingerprint: String,
+        init: impl FnOnce() -> T,
+    ) -> T {
+        let mut entries = self.entries.lock().unwrap_or_else(|err| err.into_inner());
+        let idle_evictions = self.prune_idle_locked(&mut entries, now);
+        if idle_evictions > 0 {
+            crate::metrics::record_quote_ws_pool_event("evict_idle", idle_evictions as u64);
+        }
+
+        if let Some(value) = entries.get_mut(&key).and_then(|entry| {
+            if entry.token_fingerprint == token_fingerprint {
+                entry.last_used = now;
+                Some(entry.value.clone())
+            } else {
+                None
+            }
+        }) {
+            crate::metrics::record_quote_ws_pool_event("hit", 1);
+            crate::metrics::set_quote_ws_pool_entries(entries.len());
+            return value;
+        }
+
+        if entries.contains_key(&key) {
+            entries.remove(&key);
+            crate::metrics::record_quote_ws_pool_event("evict_rotated_token", 1);
+        }
+
+        if entries.len() >= self.settings.max_entries {
+            if self.evict_lru_locked(&mut entries).is_some() {
+                crate::metrics::record_quote_ws_pool_event("evict_capacity", 1);
+            }
+        }
+
+        crate::metrics::record_quote_ws_pool_event("miss", 1);
+        let value = init();
+        entries.insert(
+            key,
+            PoolEntry {
+                value: value.clone(),
+                token_fingerprint,
+                last_used: now,
+            },
+        );
+        crate::metrics::set_quote_ws_pool_entries(entries.len());
+        value
+    }
+
+    fn remove_identity(&self, identity: &str) {
+        let mut entries = self.entries.lock().unwrap_or_else(|err| err.into_inner());
+        let before = entries.len();
+        entries.retain(|key, _| key.identity != identity);
+        let removed = before.saturating_sub(entries.len());
+        if removed > 0 {
+            crate::metrics::record_quote_ws_pool_event("evict_explicit", removed as u64);
+            crate::metrics::set_quote_ws_pool_entries(entries.len());
+        }
+    }
+
+    fn prune_idle_now(&self) {
+        let now = Instant::now();
+        let mut entries = self.entries.lock().unwrap_or_else(|err| err.into_inner());
+        let removed = self.prune_idle_locked(&mut entries, now);
+        if removed > 0 {
+            crate::metrics::record_quote_ws_pool_event("evict_idle", removed as u64);
+            crate::metrics::set_quote_ws_pool_entries(entries.len());
+        }
+    }
+
+    fn prune_idle_locked(
+        &self,
+        entries: &mut HashMap<PoolKey, PoolEntry<T>>,
+        now: Instant,
+    ) -> usize {
+        let before = entries.len();
+        let idle_ttl = self.settings.idle_ttl;
+        entries.retain(|_, entry| now.saturating_duration_since(entry.last_used) <= idle_ttl);
+        before.saturating_sub(entries.len())
+    }
+
+    fn evict_lru_locked(&self, entries: &mut HashMap<PoolKey, PoolEntry<T>>) -> Option<PoolKey> {
+        let key = entries
+            .iter()
+            .min_by_key(|(_, entry)| entry.last_used)
+            .map(|(key, _)| key.clone())?;
+        entries.remove(&key);
+        Some(key)
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .len()
+    }
+
+    #[cfg(test)]
+    fn contains_key(&self, key: &PoolKey) -> bool {
+        self.entries
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .contains_key(key)
+    }
+}
 
 /// Return the cached `QuoteContext` for `token`, creating one on first use.
 pub async fn get_or_init_quote(token: &str, config: Arc<longbridge::Config>) -> QuoteContext {
-    if let Some(ctx) = POOL.get(token) {
-        return ctx.clone();
-    }
-    let (ctx, _) = QuoteContext::new(config);
-    POOL.insert(token.to_string(), ctx.clone());
-    ctx
+    ensure_idle_sweeper_started();
+
+    let key = cache_key_for_token(token);
+    let token_fingerprint = token_fingerprint(token);
+    POOL.get_or_insert_with(key, token_fingerprint, || {
+        let (ctx, _) = QuoteContext::new(config);
+        ctx
+    })
 }
 
 /// Evict a cached entry when a token expires or auth fails.
 #[allow(dead_code)]
 pub fn evict(token: &str) {
-    POOL.remove(token);
+    POOL.remove_identity(&cache_key_for_token(token).identity);
+}
+
+fn ensure_idle_sweeper_started() {
+    SWEEPER_STARTED.get_or_init(|| {
+        let interval = sweep_interval(POOL.settings.idle_ttl);
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            loop {
+                ticker.tick().await;
+                POOL.prune_idle_now();
+            }
+        });
+    });
+}
+
+fn sweep_interval(idle_ttl: Duration) -> Duration {
+    if idle_ttl < Duration::from_secs(1) {
+        Duration::from_secs(1)
+    } else if idle_ttl < Duration::from_secs(60) {
+        idle_ttl
+    } else {
+        Duration::from_secs(60)
+    }
+}
+
+fn cache_key_for_token(token: &str) -> PoolKey {
+    let identity = jwt_identity(token)
+        .map(|identity| format!("jwt:{}", sha256_hex(identity.as_bytes())))
+        .unwrap_or_else(|| format!("token:{}", token_fingerprint(token)));
+    PoolKey::new(identity)
+}
+
+fn token_fingerprint(token: &str) -> String {
+    sha256_hex(token.as_bytes())
+}
+
+fn jwt_subject(token: &str) -> Option<String> {
+    let payload = token.split('.').nth(1)?;
+    let mut padded = payload.to_string();
+    while padded.len() % 4 != 0 {
+        padded.push('=');
+    }
+    let bytes = URL_SAFE.decode(padded).ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    claims["sub"]
+        .as_str()
+        .filter(|sub| !sub.is_empty())
+        .map(str::to_owned)
+}
+
+fn jwt_identity(token: &str) -> Option<String> {
+    let subject = jwt_subject(token)?;
+    stable_identity_from_subject(&subject)
+}
+
+fn stable_identity_from_subject(subject: &str) -> Option<String> {
+    match serde_json::from_str::<serde_json::Value>(subject) {
+        Ok(serde_json::Value::Object(map)) => {
+            const ID_FIELDS: &[&str] = &[
+                "user_id",
+                "member_id",
+                "account_id",
+                "account_no",
+                "account",
+                "uid",
+                "id",
+                "open_id",
+            ];
+            let channel = stable_json_field(&map, "account_channel").unwrap_or_default();
+            for field in ID_FIELDS {
+                if let Some(value) = stable_json_field(&map, field) {
+                    return Some(format!("account_channel={channel};{field}={value}"));
+                }
+            }
+            None
+        }
+        Ok(_) => None,
+        Err(_) => Some(subject.to_owned()),
+    }
+}
+
+fn stable_json_field(
+    map: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<String> {
+    match map.get(key)? {
+        serde_json::Value::String(value) if !value.is_empty() => Some(value.clone()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::{Duration, Instant};
+
+    fn settings(max_entries: usize, idle_ttl: Duration) -> PoolSettings {
+        PoolSettings {
+            max_entries,
+            idle_ttl,
+        }
+    }
+
+    fn key(name: &str) -> PoolKey {
+        PoolKey::new(format!("identity:{name}"))
+    }
+
+    fn jwt_with_sub(sub: &str, signature: &str) -> String {
+        let header = base64::Engine::encode(&URL_SAFE_NO_PAD, r#"{"alg":"none"}"#);
+        let claims = serde_json::json!({ "sub": sub });
+        let payload = base64::Engine::encode(&URL_SAFE_NO_PAD, claims.to_string());
+        format!("{header}.{payload}.{signature}")
+    }
+
+    #[test]
+    fn concurrent_first_use_initializes_once() {
+        let pool = Arc::new(Pool::new(settings(16, Duration::from_secs(60))));
+        let init_count = Arc::new(AtomicUsize::new(0));
+        let key = key("same-user");
+        let token = token_fingerprint("access-token");
+
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let pool = pool.clone();
+            let init_count = init_count.clone();
+            let key = key.clone();
+            let token = token.clone();
+            handles.push(std::thread::spawn(move || {
+                pool.get_or_insert_with_at(Instant::now(), key, token, || {
+                    init_count.fetch_add(1, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(10));
+                    42usize
+                })
+            }));
+        }
+
+        for handle in handles {
+            assert_eq!(handle.join().unwrap(), 42);
+        }
+        assert_eq!(init_count.load(Ordering::SeqCst), 1);
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn idle_entries_are_evicted_after_ttl() {
+        let pool = Pool::new(settings(16, Duration::from_secs(5)));
+        let start = Instant::now();
+        let key = key("idle-user");
+        let token = token_fingerprint("access-token");
+
+        assert_eq!(
+            pool.get_or_insert_with_at(start, key.clone(), token.clone(), || 1usize),
+            1
+        );
+        assert_eq!(
+            pool.get_or_insert_with_at(
+                start + Duration::from_secs(4),
+                key.clone(),
+                token.clone(),
+                || 2usize
+            ),
+            1
+        );
+        assert_eq!(
+            pool.get_or_insert_with_at(start + Duration::from_secs(10), key, token, || 3usize),
+            3
+        );
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn capacity_eviction_removes_least_recently_used_entry() {
+        let pool = Pool::new(settings(2, Duration::from_secs(60)));
+        let start = Instant::now();
+        let a = key("a");
+        let b = key("b");
+        let c = key("c");
+
+        pool.get_or_insert_with_at(start, a.clone(), token_fingerprint("a"), || "a");
+        pool.get_or_insert_with_at(
+            start + Duration::from_secs(1),
+            b.clone(),
+            token_fingerprint("b"),
+            || "b",
+        );
+        pool.get_or_insert_with_at(
+            start + Duration::from_secs(2),
+            a.clone(),
+            token_fingerprint("a"),
+            || "a",
+        );
+        pool.get_or_insert_with_at(
+            start + Duration::from_secs(3),
+            c.clone(),
+            token_fingerprint("c"),
+            || "c",
+        );
+
+        assert_eq!(pool.len(), 2);
+        assert!(pool.contains_key(&a));
+        assert!(!pool.contains_key(&b));
+        assert!(pool.contains_key(&c));
+    }
+
+    #[test]
+    fn jwt_subject_key_survives_token_refresh_without_storing_plaintext() {
+        let sub = r#"{"account_channel":"lb","user_id":"u-1"}"#;
+        let token_a = jwt_with_sub(sub, "signature-a");
+        let token_b = jwt_with_sub(sub, "signature-b");
+
+        let key_a = cache_key_for_token(&token_a);
+        let key_b = cache_key_for_token(&token_b);
+
+        assert_eq!(key_a, key_b);
+        assert!(!key_a.identity.contains(&token_a));
+        assert!(!key_a.identity.contains(sub));
+    }
+
+    #[test]
+    fn jwt_subject_without_user_identity_falls_back_to_token_key() {
+        let sub = r#"{"account_channel":"lb"}"#;
+        let token_a = jwt_with_sub(sub, "signature-a");
+        let token_b = jwt_with_sub(sub, "signature-b");
+
+        let key_a = cache_key_for_token(&token_a);
+        let key_b = cache_key_for_token(&token_b);
+
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn token_rotation_for_same_identity_replaces_cached_context() {
+        let pool = Pool::new(settings(16, Duration::from_secs(60)));
+        let start = Instant::now();
+        let key = key("rotating-user");
+
+        assert_eq!(
+            pool.get_or_insert_with_at(start, key.clone(), token_fingerprint("old-token"), || {
+                1usize
+            }),
+            1
+        );
+        assert_eq!(
+            pool.get_or_insert_with_at(
+                start + Duration::from_secs(1),
+                key.clone(),
+                token_fingerprint("new-token"),
+                || 2usize
+            ),
+            2
+        );
+
+        assert_eq!(pool.len(), 1);
+        assert!(pool.contains_key(&key));
+    }
 }

--- a/src/ws_pool.rs
+++ b/src/ws_pool.rs
@@ -264,8 +264,9 @@ pub async fn get_or_init_quote(
     })
 }
 
-/// Evict a cached entry when a token expires or auth fails.
-#[allow(dead_code)]
+/// Evict the cached `QuoteContext` for `token`. Call this after any error on
+/// a quote API so the next request creates a fresh WebSocket connection rather
+/// than reusing a potentially broken one.
 pub fn evict(token: &str) {
     POOL.remove_identity(&cache_key_for_token(token).identity);
 }

--- a/src/ws_pool.rs
+++ b/src/ws_pool.rs
@@ -79,16 +79,36 @@ struct PoolEntry<T> {
     last_used: Instant,
 }
 
-struct Pool<T: Clone> {
-    settings: PoolSettings,
-    entries: Mutex<HashMap<PoolKey, PoolEntry<T>>>,
+/// Combined state protected by a single Mutex so `last_prune` is always
+/// consistent with `entries` without a second lock acquisition.
+struct PoolInner<T> {
+    entries: HashMap<PoolKey, PoolEntry<T>>,
+    /// Timestamp of the last time `prune_idle` ran inline (on the hot path).
+    /// Used to gate the inline scan so it only runs every `idle_ttl / 4`,
+    /// keeping hot-path Mutex hold short. The background sweeper handles the
+    /// rest.
+    last_prune: Instant,
 }
 
-impl<T: Clone> Pool<T> {
+struct Pool<T>
+where
+    T: Clone,
+{
+    settings: PoolSettings,
+    inner: Mutex<PoolInner<T>>,
+}
+
+impl<T> Pool<T>
+where
+    T: Clone,
+{
     fn new(settings: PoolSettings) -> Self {
         Self {
             settings,
-            entries: Mutex::new(HashMap::new()),
+            inner: Mutex::new(PoolInner {
+                entries: HashMap::new(),
+                last_prune: Instant::now(),
+            }),
         }
     }
 
@@ -108,13 +128,21 @@ impl<T: Clone> Pool<T> {
         token_fingerprint: String,
         init: impl FnOnce() -> T,
     ) -> T {
-        let mut entries = self.entries.lock().unwrap_or_else(|err| err.into_inner());
-        let idle_evictions = self.prune_idle_locked(&mut entries, now);
-        if idle_evictions > 0 {
-            crate::metrics::record_quote_ws_pool_event("evict_idle", idle_evictions as u64);
+        let mut inner = self.inner.lock().unwrap_or_else(|err| err.into_inner());
+
+        // Inline idle prune — time-gated to every idle_ttl/4 so the hot path
+        // does not run an O(N) HashMap::retain on every single cache hit.
+        // The background sweeper handles cleanup between prune windows.
+        let prune_interval = self.settings.idle_ttl / 4;
+        if now.saturating_duration_since(inner.last_prune) >= prune_interval {
+            let removed = Self::do_prune_idle(&mut inner.entries, self.settings.idle_ttl, now);
+            if removed > 0 {
+                crate::metrics::record_quote_ws_pool_event("evict_idle", removed as u64);
+            }
+            inner.last_prune = now;
         }
 
-        if let Some(value) = entries.get_mut(&key).and_then(|entry| {
+        if let Some(value) = inner.entries.get_mut(&key).and_then(|entry| {
             if entry.token_fingerprint == token_fingerprint {
                 entry.last_used = now;
                 Some(entry.value.clone())
@@ -123,24 +151,29 @@ impl<T: Clone> Pool<T> {
             }
         }) {
             crate::metrics::record_quote_ws_pool_event("hit", 1);
-            crate::metrics::set_quote_ws_pool_entries(entries.len());
+            crate::metrics::set_quote_ws_pool_entries(inner.entries.len());
             return value;
         }
 
-        if entries.contains_key(&key) {
-            entries.remove(&key);
+        if inner.entries.contains_key(&key) {
+            inner.entries.remove(&key);
             crate::metrics::record_quote_ws_pool_event("evict_rotated_token", 1);
         }
 
-        if entries.len() >= self.settings.max_entries {
-            if self.evict_lru_locked(&mut entries).is_some() {
-                crate::metrics::record_quote_ws_pool_event("evict_capacity", 1);
-            }
+        if inner.entries.len() >= self.settings.max_entries
+            && Self::do_evict_lru(&mut inner.entries).is_some()
+        {
+            crate::metrics::record_quote_ws_pool_event("evict_capacity", 1);
         }
 
         crate::metrics::record_quote_ws_pool_event("miss", 1);
+        // `init()` is called while the Mutex is held. `QuoteContext::new` spawns
+        // its WS task on the SDK's own Tokio runtime and returns immediately, so
+        // this does not block the calling thread. The trade-off is that concurrent
+        // first-use requests for the SAME key are serialized here — preventing
+        // duplicate WS connections for the same user, which is the desired behavior.
         let value = init();
-        entries.insert(
+        inner.entries.insert(
             key,
             PoolEntry {
                 value: value.clone(),
@@ -148,43 +181,42 @@ impl<T: Clone> Pool<T> {
                 last_used: now,
             },
         );
-        crate::metrics::set_quote_ws_pool_entries(entries.len());
+        crate::metrics::set_quote_ws_pool_entries(inner.entries.len());
         value
     }
 
     fn remove_identity(&self, identity: &str) {
-        let mut entries = self.entries.lock().unwrap_or_else(|err| err.into_inner());
-        let before = entries.len();
-        entries.retain(|key, _| key.identity != identity);
-        let removed = before.saturating_sub(entries.len());
+        let mut inner = self.inner.lock().unwrap_or_else(|err| err.into_inner());
+        let before = inner.entries.len();
+        inner.entries.retain(|key, _| key.identity != identity);
+        let removed = before.saturating_sub(inner.entries.len());
         if removed > 0 {
             crate::metrics::record_quote_ws_pool_event("evict_explicit", removed as u64);
-            crate::metrics::set_quote_ws_pool_entries(entries.len());
+            crate::metrics::set_quote_ws_pool_entries(inner.entries.len());
         }
     }
 
     fn prune_idle_now(&self) {
         let now = Instant::now();
-        let mut entries = self.entries.lock().unwrap_or_else(|err| err.into_inner());
-        let removed = self.prune_idle_locked(&mut entries, now);
+        let mut inner = self.inner.lock().unwrap_or_else(|err| err.into_inner());
+        let removed = Self::do_prune_idle(&mut inner.entries, self.settings.idle_ttl, now);
         if removed > 0 {
             crate::metrics::record_quote_ws_pool_event("evict_idle", removed as u64);
-            crate::metrics::set_quote_ws_pool_entries(entries.len());
+            crate::metrics::set_quote_ws_pool_entries(inner.entries.len());
         }
     }
 
-    fn prune_idle_locked(
-        &self,
+    fn do_prune_idle(
         entries: &mut HashMap<PoolKey, PoolEntry<T>>,
+        idle_ttl: Duration,
         now: Instant,
     ) -> usize {
         let before = entries.len();
-        let idle_ttl = self.settings.idle_ttl;
         entries.retain(|_, entry| now.saturating_duration_since(entry.last_used) <= idle_ttl);
         before.saturating_sub(entries.len())
     }
 
-    fn evict_lru_locked(&self, entries: &mut HashMap<PoolKey, PoolEntry<T>>) -> Option<PoolKey> {
+    fn do_evict_lru(entries: &mut HashMap<PoolKey, PoolEntry<T>>) -> Option<PoolKey> {
         let key = entries
             .iter()
             .min_by_key(|(_, entry)| entry.last_used)
@@ -195,29 +227,39 @@ impl<T: Clone> Pool<T> {
 
     #[cfg(test)]
     fn len(&self) -> usize {
-        self.entries
+        self.inner
             .lock()
             .unwrap_or_else(|err| err.into_inner())
+            .entries
             .len()
     }
 
     #[cfg(test)]
     fn contains_key(&self, key: &PoolKey) -> bool {
-        self.entries
+        self.inner
             .lock()
             .unwrap_or_else(|err| err.into_inner())
+            .entries
             .contains_key(key)
     }
 }
 
 /// Return the cached `QuoteContext` for `token`, creating one on first use.
-pub async fn get_or_init_quote(token: &str, config: Arc<longbridge::Config>) -> QuoteContext {
+///
+/// `make_config` is a lazy factory: it is only called on a cache miss so
+/// callers avoid building a `Config` (and its `Arc` allocation) on every
+/// cache hit. Pass `|| mctx.create_config()` rather than
+/// `mctx.create_config()`.
+pub async fn get_or_init_quote(
+    token: &str,
+    make_config: impl FnOnce() -> Arc<longbridge::Config>,
+) -> QuoteContext {
     ensure_idle_sweeper_started();
 
     let key = cache_key_for_token(token);
     let token_fingerprint = token_fingerprint(token);
     POOL.get_or_insert_with(key, token_fingerprint, || {
-        let (ctx, _) = QuoteContext::new(config);
+        let (ctx, _) = QuoteContext::new(make_config());
         ctx
     })
 }
@@ -230,14 +272,20 @@ pub fn evict(token: &str) {
 
 fn ensure_idle_sweeper_started() {
     SWEEPER_STARTED.get_or_init(|| {
-        let interval = sweep_interval(POOL.settings.idle_ttl);
-        tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(interval);
-            loop {
-                ticker.tick().await;
-                POOL.prune_idle_now();
-            }
-        });
+        // Guard: tokio::spawn requires an active Tokio runtime. Skip silently
+        // when called from a non-async context (e.g. a sync unit test or a
+        // CLI path without a runtime). The time-gated inline prune in
+        // get_or_insert_with_at handles cleanup in the absence of the sweeper.
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let interval = sweep_interval(POOL.settings.idle_ttl);
+            handle.spawn(async move {
+                let mut ticker = tokio::time::interval(interval);
+                loop {
+                    ticker.tick().await;
+                    POOL.prune_idle_now();
+                }
+            });
+        }
     });
 }
 
@@ -440,9 +488,18 @@ mod tests {
         );
 
         assert_eq!(pool.len(), 2);
-        assert!(pool.contains_key(&a));
-        assert!(!pool.contains_key(&b));
-        assert!(pool.contains_key(&c));
+        assert!(
+            pool.contains_key(&a),
+            "entry 'a' (most recently used) should survive LRU eviction"
+        );
+        assert!(
+            !pool.contains_key(&b),
+            "entry 'b' (least recently used) should be LRU-evicted"
+        );
+        assert!(
+            pool.contains_key(&c),
+            "entry 'c' (just inserted) should be retained"
+        );
     }
 
     #[test]
@@ -454,9 +511,18 @@ mod tests {
         let key_a = cache_key_for_token(&token_a);
         let key_b = cache_key_for_token(&token_b);
 
-        assert_eq!(key_a, key_b);
-        assert!(!key_a.identity.contains(&token_a));
-        assert!(!key_a.identity.contains(sub));
+        assert_eq!(
+            key_a, key_b,
+            "same JWT subject should produce the same cache key regardless of signature"
+        );
+        assert!(
+            !key_a.identity.contains(&token_a),
+            "cache key must not contain the raw token bytes"
+        );
+        assert!(
+            !key_a.identity.contains(sub),
+            "cache key must not contain the raw JWT subject"
+        );
     }
 
     #[test]
@@ -494,6 +560,254 @@ mod tests {
         );
 
         assert_eq!(pool.len(), 1);
-        assert!(pool.contains_key(&key));
+        assert!(
+            pool.contains_key(&key),
+            "rotating user's key should remain in pool after token swap"
+        );
+    }
+
+    /// Stress test: N users × M concurrent requests each.
+    ///
+    /// Verifies:
+    ///   1. Pool size never exceeds max_entries under concurrent insertion.
+    ///   2. Each user's init closure runs exactly once regardless of concurrency.
+    ///   3. Hit rate is ≥ 90% when users are stable (no token rotation).
+    ///
+    /// Run with:
+    ///   cargo test stress_pool_bounded_concurrency -- --nocapture --ignored
+    #[test]
+    #[ignore]
+    fn stress_pool_bounded_concurrency() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Instant;
+
+        const USERS: usize = 200;
+        const REQUESTS_PER_USER: usize = 50;
+        const MAX_POOL: usize = 64; // force LRU eviction (200 users > 64 slots)
+
+        let pool = Arc::new(Pool::new(settings(MAX_POOL, Duration::from_secs(300))));
+        let total_inits = Arc::new(AtomicUsize::new(0));
+        let total_hits = Arc::new(AtomicUsize::new(0));
+        let total_requests = USERS * REQUESTS_PER_USER;
+
+        let start = Instant::now();
+        let mut handles = Vec::with_capacity(USERS * REQUESTS_PER_USER);
+
+        for user in 0..USERS {
+            for _ in 0..REQUESTS_PER_USER {
+                let pool = pool.clone();
+                let total_inits = total_inits.clone();
+                let total_hits = total_hits.clone();
+                handles.push(std::thread::spawn(move || {
+                    let k = key(&format!("user-{user}"));
+                    let fp = token_fingerprint(&format!("token-{user}"));
+                    let was_hit = {
+                        let before = pool.len();
+                        pool.get_or_insert_with(k, fp, || {
+                            total_inits.fetch_add(1, Ordering::Relaxed);
+                            user // value = user id
+                        });
+                        let after = pool.len();
+                        // "hit" if pool didn't grow (entry already existed)
+                        after <= before
+                    };
+                    if was_hit {
+                        total_hits.fetch_add(1, Ordering::Relaxed);
+                    }
+                }));
+            }
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let elapsed = start.elapsed();
+        let inits = total_inits.load(Ordering::Relaxed);
+        let hits = total_hits.load(Ordering::Relaxed);
+        let pool_size = pool.len();
+        let hit_rate = hits as f64 / total_requests as f64 * 100.0;
+        let throughput = total_requests as f64 / elapsed.as_secs_f64();
+
+        eprintln!("\n── ws_pool stress ─────────────────────────────");
+        eprintln!("  users:          {USERS}");
+        eprintln!("  requests:       {total_requests} ({REQUESTS_PER_USER}/user)");
+        eprintln!("  threads:        {total_requests}");
+        eprintln!("  max_pool:       {MAX_POOL}");
+        eprintln!("  pool size:      {pool_size}  (≤ {MAX_POOL} ✓)");
+        eprintln!("  total inits:    {inits}  (≤ {USERS} expected)");
+        eprintln!("  hit rate:       {hit_rate:.1}%");
+        eprintln!("  throughput:     {throughput:.0} ops/s");
+        eprintln!("  elapsed:        {:.2?}", elapsed);
+        eprintln!("────────────────────────────────────────────────");
+
+        assert!(
+            pool_size <= MAX_POOL,
+            "pool size {pool_size} exceeded max {MAX_POOL}"
+        );
+        assert!(
+            inits <= USERS,
+            "total inits {inits} exceeded user count {USERS} — double-init detected"
+        );
+        assert!(
+            hit_rate >= 50.0,
+            "hit rate {hit_rate:.1}% too low — pool may not be caching effectively"
+        );
+    }
+
+    /// High-concurrency stress suite. Four scenarios in one run:
+    ///
+    ///   A) Hot pool, all-hit  — 1000 users, warm cache, max_entries=1024.
+    ///      Measures pure Mutex+clone throughput with no evictions.
+    ///   B) Capacity pressure  — 500 users, max_entries=64.
+    ///      Constant LRU evictions; verifies pool never exceeds cap.
+    ///   C) Token-rotation churn — 200 users × 5 token rotations each.
+    ///      Every rotation evicts the old entry; measures rotated-token metric.
+    ///   D) Mixed init + hit    — 100 users × 200 req, init simulates
+    ///      10 ms blocking work; measures that the global Mutex serializes
+    ///      inits (only one init per user) even under contention.
+    ///
+    /// Run with:
+    ///   cargo test stress_high_concurrency -- --nocapture --ignored
+    #[test]
+    #[ignore]
+    fn stress_high_concurrency() {
+        use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+        use std::time::Instant;
+
+        fn run_scenario(
+            label: &str,
+            pool: Arc<Pool<usize>>,
+            users: usize,
+            req_per_user: usize,
+            token_rotations: usize, // how many distinct token fingerprints per user
+            init_delay_ms: u64,
+        ) -> (f64, f64, usize, usize) {
+            let total_inits = Arc::new(AtomicUsize::new(0));
+            let total_requests = users * req_per_user;
+            let start = Instant::now();
+            let mut handles = Vec::with_capacity(total_requests);
+
+            for user in 0..users {
+                for req in 0..req_per_user {
+                    let pool = pool.clone();
+                    let total_inits = total_inits.clone();
+                    let rotation = if token_rotations > 1 {
+                        req / (req_per_user / token_rotations).max(1)
+                    } else {
+                        0
+                    };
+                    handles.push(std::thread::spawn(move || {
+                        let k = key(&format!("user-{user}"));
+                        let fp = token_fingerprint(&format!("token-{user}-rot{rotation}"));
+                        pool.get_or_insert_with(k, fp, || {
+                            total_inits.fetch_add(1, Relaxed);
+                            if init_delay_ms > 0 {
+                                std::thread::sleep(std::time::Duration::from_millis(init_delay_ms));
+                            }
+                            user
+                        })
+                    }));
+                }
+            }
+
+            for h in handles {
+                h.join().unwrap();
+            }
+
+            let elapsed = start.elapsed();
+            let inits = total_inits.load(Relaxed);
+            let pool_size = pool.len();
+            let throughput = total_requests as f64 / elapsed.as_secs_f64();
+            eprintln!(
+                "  {label:<30} {:>6} req | pool={:>4} | inits={:>5} | {throughput:>9.0} ops/s | {:>6.2?}",
+                total_requests, pool_size, inits, elapsed
+            );
+            (throughput, elapsed.as_secs_f64(), pool_size, inits)
+        }
+
+        eprintln!("\n══ ws_pool high-concurrency stress ══════════════════════════════");
+        eprintln!(
+            "  {:<30} {:>6}     {:>5}   {:>5}   {:>9}   {:>6}",
+            "scenario", "reqs", "pool", "inits", "ops/s", "time"
+        );
+        eprintln!("  {}", "─".repeat(72));
+
+        // A: Hot pool, all cache hits
+        let (tp_a, _, pool_a, inits_a) = run_scenario(
+            "A: hot pool (1000u × 50r, cap=1024)",
+            Arc::new(Pool::new(settings(
+                1024,
+                std::time::Duration::from_secs(300),
+            ))),
+            1000,
+            50,
+            1,
+            0,
+        );
+        assert!(pool_a <= 1024, "A: pool {pool_a} > cap 1024");
+        assert!(
+            inits_a <= 1000,
+            "A: inits {inits_a} > users 1000 — double-init detected"
+        );
+
+        // B: Capacity pressure — constant LRU eviction
+        let (tp_b, _, pool_b, _) = run_scenario(
+            "B: LRU pressure (500u × 100r, cap=64)",
+            Arc::new(Pool::new(settings(64, std::time::Duration::from_secs(300)))),
+            500,
+            100,
+            1,
+            0,
+        );
+        assert!(pool_b <= 64, "B: pool {pool_b} exceeded cap 64");
+
+        // C: Token rotation churn (5 rotations per user)
+        let (tp_c, _, pool_c, _) = run_scenario(
+            "C: token rotation (200u × 50r, 5 rot)",
+            Arc::new(Pool::new(settings(
+                512,
+                std::time::Duration::from_secs(300),
+            ))),
+            200,
+            50,
+            5,
+            0,
+        );
+        assert!(pool_c <= 512, "C: pool {pool_c} exceeded cap 512");
+
+        // D: Slow init (10 ms) — verifies per-key serialization
+        let (tp_d, elapsed_d, _, inits_d) = run_scenario(
+            "D: slow init 10ms (100u × 20r, cap=256)",
+            Arc::new(Pool::new(settings(
+                256,
+                std::time::Duration::from_secs(300),
+            ))),
+            100,
+            20,
+            1,
+            10,
+        );
+        assert!(
+            inits_d <= 100,
+            "D: inits {inits_d} > users 100 — Mutex not serializing init correctly"
+        );
+        // Wall-clock should be << 100 users × 10ms = 1000ms if parallel
+        eprintln!(
+            "  D elapsed={elapsed_d:.3}s (serial would be ≥ {:.1}s, parallel < {:.1}s)",
+            100.0 * 0.01,
+            20.0 * 0.01
+        );
+
+        eprintln!("  {}", "─".repeat(72));
+        eprintln!("  throughput: A={tp_a:.0} B={tp_b:.0} C={tp_c:.0} D={tp_d:.0} ops/s");
+        eprintln!("══════════════════════════════════════════════════════════════════");
+
+        assert!(tp_a > 1_000.0, "A throughput {tp_a:.0} ops/s too low");
+        assert!(tp_b > 1_000.0, "B throughput {tp_b:.0} ops/s too low");
+        assert!(
+            elapsed_d < 5.0,
+            "D took {elapsed_d:.2}s — inits may be serializing globally rather than per-key"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Replace the unbounded per-token quote context map with a bounded process-local pool keyed by authenticated identity/token fingerprint
- Add atomic first-use initialization, idle TTL cleanup, LRU capacity eviction, and token-rotation handling
- Add quote WS pool metrics and document the new cache tuning env vars

## Test Plan
- cargo fmt --check
- cargo test