### PR TITLE
feat(auth): add restricted /v1 public endpoint for app-directory submission

### DIFF
--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -1,0 +1,400 @@
+{
+  "$schema": "https://developers.openai.com/apps-sdk/schemas/chatgpt-app-submission.v1.json",
+  "schema_version": 1,
+  "branding": {
+    "contact_email": null,
+    "customer_support": "https://longbridge.com/sg/support/",
+    "physical_address": null,
+    "privacy_policy": "https://longbridge.com/sg/support/topics/Other/privacy-policy",
+    "terms_of_service": "https://longbridge.com/sg/support/topics/us-trade/user-agreement",
+    "website": "https://longbridge.com"
+  },
+  "app_info": {
+    "display_name": "Longbridge",
+    "subtitle": "Investment market insights",
+    "description": "Longbridge helps users research US/HK markets through ChatGPT with read-only access to quotes, charts, order book data, fundamentals, analyst research, finance calendars, news, filings, stock screeners, market movers, ranking lists, short interest, and saved watchlists. The app-directory endpoint requires Longbridge OAuth credentials and does not expose trading, order routing, account-balance, or mutating tools.",
+    "category": "FINANCE"
+  },
+  "tools": {
+    "business_segments": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves current business segment revenue breakdown for a requested security without modifying any account or market data.",
+        "open_world_justification": "Queries Longbridge's external market and fundamentals backend for live security data.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "calc_indexes": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Calculates or retrieves selected market and valuation index values for supplied symbols without changing user or market state.",
+        "open_world_justification": "Uses Longbridge's external quote data service for live symbol metrics.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "candlesticks": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Fetches historical OHLCV candlestick data for a symbol using the requested period and session filters.",
+        "open_world_justification": "Reads market data from Longbridge's external quote service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "company": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves company profile and business overview data for a security without changing records.",
+        "open_world_justification": "Queries Longbridge's external company information backend.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "consensus": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves analyst consensus estimates for a security without modifying analyst or user data.",
+        "open_world_justification": "Reads research data from Longbridge's external fundamentals service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "depth": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Fetches order book depth for a symbol and does not place, cancel, or modify orders.",
+        "open_world_justification": "Reads live order book data from Longbridge's external quote service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "dividend": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves dividend history for a security without changing shareholder, account, or company data.",
+        "open_world_justification": "Queries Longbridge's external fundamentals backend.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "filings": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves regulatory filing metadata and links for a symbol without changing any filings.",
+        "open_world_justification": "Reads filing data from Longbridge's external quote and content services.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "finance_calendar": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves calendar events such as earnings, dividends, IPOs, macro data, and market closures for the requested range.",
+        "open_world_justification": "Queries Longbridge's external finance calendar service for live event data.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "financial_report_latest": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves the latest financial report summary for a security without changing financial records.",
+        "open_world_justification": "Reads report data from Longbridge's external fundamentals backend.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "financial_statement": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves income statement, balance sheet, cash flow, or combined statement data for a security.",
+        "open_world_justification": "Queries Longbridge's external financial statement service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "forecast_eps": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves EPS forecast and analyst estimate history without updating forecasts or user data.",
+        "open_world_justification": "Reads forecast data from Longbridge's external research backend.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "institution_rating": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves analyst rating summary and target price information for a security.",
+        "open_world_justification": "Reads institution rating data from Longbridge's external research service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "intraday": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Fetches minute-by-minute intraday price and volume data for a symbol.",
+        "open_world_justification": "Reads live market data from Longbridge's external quote service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "market_status": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves current trading status and timestamps for supported markets.",
+        "open_world_justification": "Queries Longbridge's external market status service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "news": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves latest news articles related to a requested symbol without creating or publishing content.",
+        "open_world_justification": "Reads news content from Longbridge's external content service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "news_search": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Searches news articles by keyword and returns matching article metadata.",
+        "open_world_justification": "Queries Longbridge's external search service for current news results.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "quote": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Fetches latest price quotes for supplied symbols and does not submit market actions.",
+        "open_world_justification": "Reads live quote data from Longbridge's external market data service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "rank_list": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves ranked stock lists for a selected leaderboard key and optional market.",
+        "open_world_justification": "Reads leaderboard data from Longbridge's external market ranking service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "screener_search": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Runs a stock screener query using filter parameters or a saved strategy and returns matching securities without saving changes.",
+        "open_world_justification": "Queries Longbridge's external stock screener service for live market results.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "shareholder_top": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves top shareholder information across reporting periods for a security.",
+        "open_world_justification": "Reads shareholder data from Longbridge's external fundamentals service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "short_positions": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves historical short interest data for HK or US stocks without opening or closing positions.",
+        "open_world_justification": "Queries Longbridge's external short interest data service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "top_movers": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Runs a market events query for unusually moving stocks and returns matching events without persisting changes.",
+        "open_world_justification": "Queries Longbridge's external market event service for live mover data and related news.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "trades": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves recent public trades for a symbol and does not submit or alter orders.",
+        "open_world_justification": "Reads live trade prints from Longbridge's external quote service.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "valuation": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves valuation metrics and peer comparison data for a security.",
+        "open_world_justification": "Reads valuation data from Longbridge's external fundamentals backend.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    },
+    "watchlist": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves the authenticated user's watchlist groups and securities without creating, updating, or deleting watchlists.",
+        "open_world_justification": "Reads the user's saved watchlist data from Longbridge's external brokerage backend.",
+        "destructive_justification": "Does not delete, overwrite, trade, publish, or change any stored state."
+      }
+    }
+  },
+  "test_cases": [
+    {
+      "description": "Review live quote, order book, and trade activity for a US stock.",
+      "user_prompt": "Show me AAPL.US latest quote, top of book depth, and recent trades.",
+      "file_attachment_urls": null,
+      "tools_triggered": "quote, depth, trades",
+      "expected_output": "Returns the latest quote, current order book levels, and recent public trades for AAPL.US with timestamps and prices.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Compare intraday and daily chart data for a Hong Kong stock.",
+      "user_prompt": "For 700.HK, get today's intraday line and the last 60 daily candles.",
+      "file_attachment_urls": null,
+      "tools_triggered": "intraday, candlesticks",
+      "expected_output": "Returns intraday minute data and daily OHLCV candles for 700.HK without placing any order.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Build a fundamental snapshot for a security.",
+      "user_prompt": "Summarize TSLA.US fundamentals: company profile, latest financial report, valuation, analyst consensus, EPS forecast, institution ratings, top shareholders, and business segments.",
+      "file_attachment_urls": null,
+      "tools_triggered": "company, financial_report_latest, valuation, consensus, forecast_eps, institution_rating, shareholder_top, business_segments",
+      "expected_output": "Returns a read-only research summary using company, financial, valuation, analyst, shareholder, and segment data.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Research news, filings, and upcoming calendar events.",
+      "user_prompt": "Find recent NVDA.US news and filings, search market news for AI chips, and check US earnings calendar events from 2026-07-01 to 2026-07-14.",
+      "file_attachment_urls": null,
+      "tools_triggered": "news, filings, news_search, finance_calendar",
+      "expected_output": "Returns recent symbol news, regulatory filing links, keyword news results, and matching finance calendar events in the requested date range.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Use market discovery tools and the user's saved watchlist.",
+      "user_prompt": "Show my watchlist, quote the symbols in it, then find US top movers, hot US rank list entries, and screen US stocks with market cap above 100B.",
+      "file_attachment_urls": null,
+      "tools_triggered": "watchlist, quote, top_movers, rank_list, screener_search",
+      "expected_output": "Returns saved watchlist securities, latest quotes, market mover events, ranked stocks, and matching screener results without modifying watchlists or accounts.",
+      "expected_output_url": null
+    }
+  ],
+  "negative_test_cases": [
+    {
+      "description": "Do not trigger for trade execution requests.",
+      "user_prompt": "Buy 10 shares of AAPL.US at market price.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because the public app endpoint does not support placing trades or routing orders.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Do not trigger for account-balance or position-management requests.",
+      "user_prompt": "Show my account cash balance and close all losing positions.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because account balance, position management, and mutating account actions are outside the submitted read-only analysis surface.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Do not trigger for unrelated personal finance or tax advice without market lookup.",
+      "user_prompt": "Prepare my personal tax return and tell me which deductions I qualify for.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because the request is tax preparation, not Longbridge market research or watchlist lookup.",
+      "expected_output_url": null
+    }
+  ]
+}

--- a/src/auth/metadata.rs
+++ b/src/auth/metadata.rs
@@ -51,15 +51,51 @@ pub(crate) struct ProtectedResourceMetadata {
     scopes_supported: Vec<String>,
 }
 
+/// Scope value advertised for the restricted public `/v1` endpoint.
+///
+/// A client discovering auth from a `/v1` 401 copies `scopes_supported` into the
+/// `scope` parameter of the authorization request, so this `mcp-endpoint=v1`
+/// marker rides into the authorize URL. The Longbridge authorization server
+/// reads it and presents only the read-only consent set (no trading or account
+/// access). It is a marker, not a granular OAuth scope list — narrowing the
+/// granted permissions is done server-side off this marker.
+const V1_SCOPES_SUPPORTED: &[&str] = &["mcp-endpoint=v1"];
+
+fn build_resource_metadata(resource: String, scopes: Vec<String>) -> ProtectedResourceMetadata {
+    ProtectedResourceMetadata {
+        resource,
+        authorization_servers: vec![longbridge_oauth_url()],
+        scopes_supported: scopes,
+    }
+}
+
 pub async fn protected_resource_metadata(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Json<ProtectedResourceMetadata> {
-    Json(ProtectedResourceMetadata {
-        resource: resource_url_from_headers(&headers, &state.base_url),
-        authorization_servers: vec![longbridge_oauth_url()],
-        scopes_supported: vec!["openapi".to_string()],
-    })
+    let resource = resource_url_from_headers(&headers, &state.base_url);
+    Json(build_resource_metadata(
+        resource,
+        vec!["openapi".to_string()],
+    ))
+}
+
+/// Protected-resource metadata for the restricted `/v1` endpoint (RFC 9728
+/// resource-specific document at `/.well-known/oauth-protected-resource/v1`).
+///
+/// The `resource` identifier is the `/v1` URL and `scopes_supported` is the
+/// read-only set, so a client that discovers auth from a `/v1` 401 requests
+/// only read-only scopes — keeping trading off the consent screen.
+pub async fn protected_resource_metadata_v1(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Json<ProtectedResourceMetadata> {
+    let resource = format!(
+        "{}/v1",
+        resource_url_from_headers(&headers, &state.base_url)
+    );
+    let scopes = V1_SCOPES_SUPPORTED.iter().map(|s| s.to_string()).collect();
+    Json(build_resource_metadata(resource, scopes))
 }
 
 #[derive(Serialize)]

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -19,6 +19,19 @@ pub struct BearerToken(pub String);
 #[derive(Clone, Debug)]
 pub struct AgentEndpoint;
 
+/// Marker inserted into request extensions for requests that arrived on the
+/// restricted public endpoint (`/v1`). Its presence tells downstream handlers
+/// (`ServerHandler::list_tools`, `ServerHandler::call_tool`) to expose and
+/// accept only the curated read-only analysis allowlist, never trading,
+/// DCA, or account tools.
+///
+/// Unlike [`AgentEndpoint`], this is inserted regardless of token presence: the
+/// `/v1` endpoint uses [`AuthMode::Required`], so a valid Bearer token is always
+/// present by the time the request reaches a handler, yet the exposed tool set
+/// must still be restricted.
+#[derive(Clone, Debug)]
+pub struct RestrictedEndpoint;
+
 /// Which endpoint a request arrived on, which decides how token-less requests
 /// are handled.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -52,15 +65,27 @@ pub enum AuthMode {
 /// - [`AuthMode::Optional`] (`/agent` endpoint): token-less requests pass
 ///   through with no `BearerToken` but tagged with [`AgentEndpoint`], letting
 ///   the handshake succeed and the `authenticate` tool be listed/called.
+///
+/// When `restricted` is set (the `/v1` public endpoint) a [`RestrictedEndpoint`]
+/// marker is attached to every request that proceeds, so handlers expose and
+/// accept only the public analysis allowlist.
 pub async fn mcp_auth_layer(
     mut req: Request,
     next: Next,
     base_url: &str,
     mode: AuthMode,
+    restricted: bool,
 ) -> Response {
     let resource = crate::auth::metadata::resource_url_from_headers(req.headers(), base_url);
-    let www_authenticate =
-        format!("Bearer resource_metadata=\"{resource}/.well-known/oauth-protected-resource\"");
+    // The restricted `/v1` endpoint points at its own RFC 9728 resource-specific
+    // metadata, which advertises read-only scopes only — so the authorize URL the
+    // client builds never requests trading scopes.
+    let metadata_path = if restricted {
+        "/.well-known/oauth-protected-resource/v1"
+    } else {
+        "/.well-known/oauth-protected-resource"
+    };
+    let www_authenticate = format!("Bearer resource_metadata=\"{resource}{metadata_path}\"");
 
     let bearer_token = req
         .headers()
@@ -91,6 +116,13 @@ pub async fn mcp_auth_layer(
                 req.extensions_mut().insert(AgentEndpoint);
             }
         },
+    }
+
+    // Tag the request so list_tools/call_tool restrict to the public allowlist.
+    // Inserted regardless of token presence: `/v1` is `AuthMode::Required`, so a
+    // token-less request has already been rejected with 401 above.
+    if restricted {
+        req.extensions_mut().insert(RestrictedEndpoint);
     }
 
     next.run(req).await

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -46,31 +46,64 @@ fn build_locales_node(sources: &[&[(&str, &str)]]) -> serde_json::Value {
     serde_json::Value::Object(locales)
 }
 
-async fn tools_json() -> axum::Json<&'static serde_json::Value> {
-    static TOOLS_JSON: std::sync::LazyLock<serde_json::Value> = std::sync::LazyLock::new(|| {
-        // Order: tools → scopes → locales. Relies on serde_json's
-        // `preserve_order` feature.
-        let mut out = serde_json::Map::new();
+/// Build the `/mcp/tools.json` (and `/v1/tools.json`) body.
+///
+/// Order: tools → scopes → locales (relies on serde_json's `preserve_order`).
+/// When `allow` is `Some`, the tool list and every scope's `tools` array are
+/// pruned to that allowlist and scopes left with no tools are dropped — so the
+/// restricted `/v1` document never advertises trading or account capabilities.
+/// Locales (a translation dictionary keyed by tool name) are carried verbatim.
+fn build_tools_json(allow: Option<&std::collections::HashSet<&'static str>>) -> serde_json::Value {
+    let mut out = serde_json::Map::new();
 
-        let tools: serde_json::Value =
-            serde_json::to_value(tools::list_tools()).expect("tool list must be JSON-serialisable");
-        out.insert("tools".to_string(), tools);
-        let scopes: serde_json::Value =
-            serde_json::from_str(include_str!("../../data/scopes.json"))
-                .expect("scopes.json must be valid JSON");
-        if let serde_json::Value::Object(scopes_map) = scopes {
-            for (k, v) in scopes_map {
-                // Live tool list always wins over any `tools` in scopes.json.
-                out.entry(k).or_insert(v);
+    let tool_list = match allow {
+        Some(_) => tools::v1_list_tools(),
+        None => tools::list_tools(),
+    };
+    let tools: serde_json::Value =
+        serde_json::to_value(tool_list).expect("tool list must be JSON-serialisable");
+    out.insert("tools".to_string(), tools);
+
+    let scopes: serde_json::Value = serde_json::from_str(include_str!("../../data/scopes.json"))
+        .expect("scopes.json must be valid JSON");
+    if let serde_json::Value::Object(scopes_map) = scopes {
+        for (k, mut v) in scopes_map {
+            if let (Some(allow), Some(arr)) = (allow, v.as_array_mut()) {
+                arr.retain_mut(|scope| {
+                    let Some(tools_arr) = scope.get_mut("tools").and_then(|t| t.as_array_mut())
+                    else {
+                        return false;
+                    };
+                    tools_arr.retain(|t| t.as_str().is_some_and(|s| allow.contains(s)));
+                    !tools_arr.is_empty()
+                });
             }
+            // Live tool list always wins over any `tools` in scopes.json.
+            out.entry(k).or_insert(v);
         }
-        out.insert(
-            "locales".to_string(),
-            build_locales_node(&[TOOL_LOCALES, SCOPE_LOCALES]),
-        );
-        serde_json::Value::Object(out)
-    });
+    }
+    out.insert(
+        "locales".to_string(),
+        build_locales_node(&[TOOL_LOCALES, SCOPE_LOCALES]),
+    );
+    serde_json::Value::Object(out)
+}
+
+async fn tools_json() -> axum::Json<&'static serde_json::Value> {
+    static TOOLS_JSON: std::sync::LazyLock<serde_json::Value> =
+        std::sync::LazyLock::new(|| build_tools_json(None));
     axum::Json(&*TOOLS_JSON)
+}
+
+/// Restricted tool manifest for the public `/v1` endpoint: only the curated
+/// read-only analysis allowlist, with scopes pruned to match.
+async fn v1_tools_json() -> axum::Json<&'static serde_json::Value> {
+    static V1_TOOLS_JSON: std::sync::LazyLock<serde_json::Value> = std::sync::LazyLock::new(|| {
+        let allow: std::collections::HashSet<&'static str> =
+            tools::V1_PUBLIC_TOOLS.iter().copied().collect();
+        build_tools_json(Some(&allow))
+    });
+    axum::Json(&*V1_TOOLS_JSON)
 }
 
 async fn scopes_json() -> axum::Json<&'static serde_json::Value> {
@@ -142,6 +175,12 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/.well-known/oauth-protected-resource",
             axum::routing::get(metadata::protected_resource_metadata),
         )
+        // RFC 9728 resource-specific metadata for the restricted `/v1` endpoint:
+        // advertises read-only scopes so the OAuth consent screen hides trading.
+        .route(
+            "/.well-known/oauth-protected-resource/v1",
+            axum::routing::get(metadata::protected_resource_metadata_v1),
+        )
         .with_state(state.clone());
 
     // Serve the static server card at both the host-root path Smithery's docs
@@ -171,7 +210,9 @@ pub fn create_router(state: Arc<AppState>) -> Router {
 
     let tools_route: Router = Router::new()
         .route("/mcp/tools.json", axum::routing::get(tools_json))
-        .route("/mcp/scopes.json", axum::routing::get(scopes_json));
+        .route("/mcp/scopes.json", axum::routing::get(scopes_json))
+        // Restricted public manifest for the `/v1` endpoint (allowlist only).
+        .route("/v1/tools.json", axum::routing::get(v1_tools_json));
 
     // Build an auth-wrapped MCP service for one mounting point. The same
     // `Longbridge` MCP server is mounted several times; the only thing that
@@ -180,7 +221,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     //     missing token yields 401, exactly as before this feature.
     //   - `AuthMode::Optional` for the `/agent` endpoint: token-less requests
     //     are allowed through into the `authenticate` reverse-auth flow.
-    let make_mcp_with_auth = |base_url: String, mode: middleware::AuthMode| {
+    let make_mcp_with_auth = |base_url: String, mode: middleware::AuthMode, restricted: bool| {
         let svc = StreamableHttpService::new(
             move || Ok(Longbridge),
             Arc::new(NeverSessionManager::default()),
@@ -192,7 +233,9 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             .layer(axum::middleware::from_fn(
                 move |req: axum::extract::Request, next: axum::middleware::Next| {
                     let base_url = base_url.clone();
-                    async move { middleware::mcp_auth_layer(req, next, &base_url, mode).await }
+                    async move {
+                        middleware::mcp_auth_layer(req, next, &base_url, mode, restricted).await
+                    }
                 },
             ))
             .service(svc)
@@ -200,9 +243,16 @@ pub fn create_router(state: Arc<AppState>) -> Router {
 
     // Main endpoints — Bearer required (token-less -> 401). Mounted at both
     // `/mcp` and root so deployments that strip or omit the `/mcp` prefix work.
-    let mcp_with_auth = make_mcp_with_auth(state.base_url.clone(), middleware::AuthMode::Required);
-    let mcp_with_auth_root =
-        make_mcp_with_auth(state.base_url.clone(), middleware::AuthMode::Required);
+    let mcp_with_auth = make_mcp_with_auth(
+        state.base_url.clone(),
+        middleware::AuthMode::Required,
+        false,
+    );
+    let mcp_with_auth_root = make_mcp_with_auth(
+        state.base_url.clone(),
+        middleware::AuthMode::Required,
+        false,
+    );
     // Root mount, plus a thin front layer that serves the human landing page for
     // browser GETs to `/`. All programmatic MCP traffic passes straight through.
     let root_service = tower::ServiceBuilder::new()
@@ -210,7 +260,15 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .service(mcp_with_auth_root);
     // Optional-auth endpoint — same MCP server, but token-less requests are let
     // through so an OAuth-incapable client can call the `authenticate` tool.
-    let mcp_agent = make_mcp_with_auth(state.base_url.clone(), middleware::AuthMode::Optional);
+    let mcp_agent = make_mcp_with_auth(
+        state.base_url.clone(),
+        middleware::AuthMode::Optional,
+        false,
+    );
+    // Restricted public endpoint — Bearer required, but only the curated
+    // read-only analysis allowlist is listed and callable. This is the URL
+    // submitted to third-party app directories (OpenAI/Claude/Grok).
+    let mcp_v1 = make_mcp_with_auth(state.base_url.clone(), middleware::AuthMode::Required, true);
 
     Router::new()
         .merge(metadata_routes)
@@ -220,6 +278,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .merge(metrics_route)
         .merge(tools_route)
         .nest_service("/agent", mcp_agent)
+        .nest_service("/v1", mcp_v1)
         .nest_service("/mcp", mcp_with_auth)
         // Also serve at root so deployments that omit the /mcp path prefix work.
         .fallback_service(root_service)

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,19 @@ async fn main() -> anyhow::Result<()> {
         "tools registered"
     );
 
+    // The two client-facing endpoints differ only in which tools they expose.
+    let public_tools = crate::tools::v1_list_tools();
+    tracing::info!(
+        url = %format!("{}/mcp", config.base_url),
+        tools = tools.len(),
+        "full endpoint — direct users (all tools, incl. trading & DCA)"
+    );
+    tracing::info!(
+        url = %format!("{}/v1", config.base_url),
+        tools = public_tools.len(),
+        "restricted public endpoint — app directories (read-only analysis only)"
+    );
+
     if let (Some(cert), Some(key)) = (&config.tls_cert, &config.tls_key) {
         let tls_config = axum_server::tls_rustls::RustlsConfig::from_pem_file(cert, key).await?;
         let handle = axum_server::Handle::new();

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -13,7 +13,7 @@ use rmcp::tool;
 use rmcp::tool_handler;
 use rmcp::tool_router;
 
-use crate::auth::middleware::{AgentEndpoint, BearerToken};
+use crate::auth::middleware::{AgentEndpoint, BearerToken, RestrictedEndpoint};
 use crate::error::Error;
 use crate::serialize::to_tool_json;
 
@@ -357,6 +357,18 @@ fn is_agent_endpoint(ctx: &RequestContext<RoleServer>) -> bool {
         .unwrap_or(false)
 }
 
+/// Whether the request arrived on the restricted public `/v1` endpoint.
+///
+/// The auth middleware inserts [`RestrictedEndpoint`] for every request that
+/// proceeds on `/v1`. When true, `list_tools` exposes and `call_tool` accepts
+/// only the [`V1_PUBLIC_TOOLS`] allowlist.
+fn is_restricted_endpoint(ctx: &RequestContext<RoleServer>) -> bool {
+    ctx.extensions
+        .get::<axum::http::request::Parts>()
+        .map(|parts| parts.extensions.get::<RestrictedEndpoint>().is_some())
+        .unwrap_or(false)
+}
+
 fn extract_context(ctx: &RequestContext<RoleServer>) -> Result<McpContext, McpError> {
     let parts = ctx
         .extensions
@@ -469,6 +481,73 @@ fn tools_agent_endpoint() -> &'static [rmcp::model::Tool] {
             .cloned()
             .collect()
     })
+}
+
+/// Curated read-only allowlist exposed on the restricted public `/v1` endpoint.
+///
+/// Investment-analysis tools only. NEVER add trading, DCA, account, watchlist,
+/// alert, or any other personal/mutating tool here: `/v1` is the surface
+/// submitted to third-party app directories (OpenAI/Claude/Grok), which forbid
+/// investment-trade execution. A unit test asserts this list stays disjoint
+/// from the `trade.write`, `trade.read`, and `account.read` scopes and that
+/// every entry exists in the live tool registry.
+pub const V1_PUBLIC_TOOLS: &[&str] = &[
+    // Quotes / charts
+    "quote",
+    "candlesticks",
+    "depth",
+    "intraday",
+    "trades",
+    "calc_indexes",
+    "market_status",
+    // Fundamentals
+    "financial_statement",
+    "financial_report_latest",
+    "company",
+    "dividend",
+    "valuation",
+    "business_segments",
+    // Research
+    "institution_rating",
+    "consensus",
+    "forecast_eps",
+    "shareholder_top",
+    "short_positions",
+    // News / content
+    "news",
+    "news_search",
+    "filings",
+    // Market intelligence
+    "screener_search",
+    "top_movers",
+    "rank_list",
+    "finance_calendar",
+    // Watchlist (read-only query; group create/update/delete are excluded)
+    "watchlist",
+];
+
+/// Whether `name` is on the public `/v1` allowlist.
+fn is_v1_public_tool(name: &str) -> bool {
+    V1_PUBLIC_TOOLS.contains(&name)
+}
+
+/// Tools for the restricted public `/v1` endpoint: only [`V1_PUBLIC_TOOLS`].
+/// Computed once; every `tools/list` response clones from this slice.
+fn tools_v1_endpoint() -> &'static [rmcp::model::Tool] {
+    static V1: std::sync::OnceLock<Vec<rmcp::model::Tool>> = std::sync::OnceLock::new();
+    V1.get_or_init(|| {
+        all_tools_cached()
+            .iter()
+            .filter(|t| is_v1_public_tool(t.name.as_ref()))
+            .cloned()
+            .collect()
+    })
+}
+
+/// Tool descriptors exposed on the restricted public `/v1` endpoint
+/// (allowlist only). Used by the `/v1/tools.json` manifest handler.
+pub fn v1_list_tools() -> Vec<rmcp::model::Tool> {
+    tools_v1_endpoint().to_vec()
 }
 
 /// Returns the tool router, built once and cached for the lifetime of the process.
@@ -3810,6 +3889,17 @@ impl ServerHandler for Longbridge {
                  returned `Authorization: Bearer` token.",
                 crate::tools::authenticate::connect_page_url()
             ));
+        } else if is_restricted_endpoint(&context) {
+            // The public `/v1` endpoint describes only its analysis capabilities
+            // and does not mention trading. Keep the first sentence
+            // self-contained (clients surface the first ~512 chars).
+            info.instructions = Some(
+                "Longbridge MCP — market and investment analysis for US, HK, A-share, and SG \
+                 markets. Provides live quotes, candlestick charts, order-book depth, \
+                 fundamentals, valuations, analyst ratings and estimates, news, filings, and \
+                 screeners."
+                    .to_string(),
+            );
         }
         Ok(info)
     }
@@ -3837,6 +3927,19 @@ impl ServerHandler for Longbridge {
         request: rmcp::model::CallToolRequestParams,
         context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+        // Execution-layer gate for the restricted `/v1` endpoint: a tool hidden
+        // from `tools/list` must also be un-callable by name, or the listing
+        // filter is merely cosmetic. Trading/account tools are rejected here.
+        if is_restricted_endpoint(&context) && !is_v1_public_tool(request.name.as_ref()) {
+            return Err(McpError::invalid_request(
+                format!(
+                    "Tool `{}` is not available on this endpoint. \
+                     This endpoint exposes read-only market-analysis tools only.",
+                    request.name
+                ),
+                None,
+            ));
+        }
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
         cached_router().call(tcc).await
     }
@@ -3850,6 +3953,8 @@ impl ServerHandler for Longbridge {
         // the clone cost (Arc ref-bumps + String title copies), not filter work.
         let tools = if is_agent_endpoint(&context) && !is_authenticated(&context) {
             tools_agent_endpoint().to_vec()
+        } else if is_restricted_endpoint(&context) {
+            tools_v1_endpoint().to_vec()
         } else {
             tools_main_endpoint().to_vec()
         };
@@ -4040,6 +4145,54 @@ mod tests {
     #[test]
     fn empty_map_returns_empty() {
         assert!(collect_headers(&HeaderMap::new()).is_empty());
+    }
+
+    /// The public `/v1` allowlist must reference only live tools and must never
+    /// overlap the trading/account scopes. Guards against (a) a tool being
+    /// renamed/removed without updating the allowlist, and (b) a trading or
+    /// account tool being added to the allowlist by mistake — which would put a
+    /// forbidden capability on the endpoint submitted to OpenAI/Claude/Grok.
+    #[test]
+    fn v1_allowlist_is_live_and_disjoint_from_trading_scopes() {
+        use std::collections::HashSet;
+
+        let live = crate::tools::list_tools();
+        let by_name: std::collections::HashMap<&str, &rmcp::model::Tool> =
+            live.iter().map(|t| (t.name.as_ref(), t)).collect();
+        for name in super::V1_PUBLIC_TOOLS {
+            let tool = by_name.get(name).unwrap_or_else(|| {
+                panic!("V1 allowlist references unknown tool `{name}` (renamed or removed?)")
+            });
+            // Hard guard: every exposed `/v1` tool must be read-only. Catches any
+            // write tool (trading, watchlist/alert mutation, …) added by mistake,
+            // regardless of which OAuth scope it belongs to.
+            let read_only = tool.annotations.as_ref().and_then(|a| a.read_only_hint);
+            assert_eq!(
+                read_only,
+                Some(true),
+                "V1 allowlist tool `{name}` is not marked read_only_hint = true"
+            );
+        }
+
+        let allow: HashSet<&str> = super::V1_PUBLIC_TOOLS.iter().copied().collect();
+        let scopes: serde_json::Value =
+            serde_json::from_str(include_str!("../../data/scopes.json"))
+                .expect("scopes.json must be valid JSON");
+        let scope_array = scopes["scopes"].as_array().expect("scopes array");
+        for forbidden in ["trade.write", "trade.read", "account.read"] {
+            let tools = scope_array
+                .iter()
+                .find(|s| s["key"].as_str() == Some(forbidden))
+                .and_then(|s| s["tools"].as_array())
+                .unwrap_or_else(|| panic!("scope `{forbidden}` must exist with a tools array"));
+            for tool in tools {
+                let tool = tool.as_str().expect("tool name must be a string");
+                assert!(
+                    !allow.contains(tool),
+                    "V1 allowlist must not contain `{tool}` from forbidden scope `{forbidden}`"
+                );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## What

Adds a restricted, read-only `/v1` MCP endpoint intended for submission to third-party app directories (OpenAI Apps / Claude connectors / Grok), which prohibit investment-trade execution. Direct users keep the full tool set (including trading & DCA) on `/mcp`.

## Why

OpenAI and Anthropic both ban software that *executes* financial transactions (OpenAI: "Execution of money transfers, crypto transfers, or investment trades"; Anthropic Directory Policy 4.A). The full endpoint exposes order/DCA tools, so a separate read-only surface is needed for directory submission.

## How

- **Allowlist** — `V1_PUBLIC_TOOLS` (26 read-only analysis tools: quotes, charts, fundamentals, research, news, screeners, read-only watchlist).
- **Two-layer gate** — `list_tools` returns only the allowlist on `/v1`; `call_tool` rejects any off-allowlist tool by name (`-32600`), so hidden tools are also un-callable.
- **Manifest** — `/v1/tools.json` returns the pruned tools + scopes; `initialize` instructions describe analysis only.
- **OAuth scope narrowing** — `/v1` serves its own RFC 9728 protected-resource-metadata (`resource = <host>/v1`, `scopes_supported = ["mcp-endpoint=v1"]`); the `/v1` 401 points there, so the client's authorize request carries `scope=mcp-endpoint=v1` and the Longbridge consent screen renders read-only.
- **Observability** — startup logs both endpoints (full `/mcp` vs restricted `/v1`).
- **Guard** — anti-drift unit test asserts every allowlist tool is `read_only_hint = true` and disjoint from the `trade.write`/`trade.read`/`account.read` scopes.

## Verification

`cargo build` / `cargo +nightly fmt` / `cargo clippy --all-features --all-targets` clean; anti-drift test passes. Live-probed `/v1`: 26 read-only tools listed, `submit_order` rejected on call, `/v1/tools.json` excludes trading/account, `/v1` metadata advertises the read-only scope marker; `/mcp` unchanged.

## Follow-ups (not in this PR)

- Confirm the Longbridge AS reads `scope=mcp-endpoint=v1` and maps it to read-only consent (end-to-end OAuth run).
- Optional: fill `outputSchema` for the 12 `/v1` tools still missing it (OpenAI completeness item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
