### PR TITLE
feat(auth): add restricted /v2 public MCP endpoint with per-tool version annotations

### DIFF
--- a/src/auth/metadata.rs
+++ b/src/auth/metadata.rs
@@ -61,6 +61,15 @@ pub(crate) struct ProtectedResourceMetadata {
 /// granted permissions is done server-side off this marker.
 const V1_SCOPES_SUPPORTED: &[&str] = &["mcp-endpoint=v1"];
 
+/// Scope value advertised for the restricted public `/v2` endpoint.
+///
+/// Mirrors [`V1_SCOPES_SUPPORTED`]: a client discovering auth from a `/v2` 401
+/// copies this `mcp-endpoint=v2` marker into the authorization request's `scope`
+/// parameter, so the Longbridge authorization server can present the broader
+/// read-only consent set for `/v2` (account/portfolio + order history, but no
+/// trade execution, DCA, IPO orders, or money movement).
+const V2_SCOPES_SUPPORTED: &[&str] = &["mcp-endpoint=v2"];
+
 fn build_resource_metadata(resource: String, scopes: Vec<String>) -> ProtectedResourceMetadata {
     ProtectedResourceMetadata {
         resource,
@@ -95,6 +104,24 @@ pub async fn protected_resource_metadata_v1(
         resource_url_from_headers(&headers, &state.base_url)
     );
     let scopes = V1_SCOPES_SUPPORTED.iter().map(|s| s.to_string()).collect();
+    Json(build_resource_metadata(resource, scopes))
+}
+
+/// Protected-resource metadata for the restricted `/v2` endpoint (RFC 9728
+/// resource-specific document at `/.well-known/oauth-protected-resource/v2`).
+///
+/// Mirrors [`protected_resource_metadata_v1`]: the `resource` identifier is the
+/// `/v2` URL and `scopes_supported` is the `/v2` read-only marker, so a client
+/// that discovers auth from a `/v2` 401 requests the v2 consent set.
+pub async fn protected_resource_metadata_v2(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Json<ProtectedResourceMetadata> {
+    let resource = format!(
+        "{}/v2",
+        resource_url_from_headers(&headers, &state.base_url)
+    );
+    let scopes = V2_SCOPES_SUPPORTED.iter().map(|s| s.to_string()).collect();
     Json(build_resource_metadata(resource, scopes))
 }
 

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -19,18 +19,44 @@ pub struct BearerToken(pub String);
 #[derive(Clone, Debug)]
 pub struct AgentEndpoint;
 
-/// Marker inserted into request extensions for requests that arrived on the
-/// restricted public endpoint (`/v1`). Its presence tells downstream handlers
+/// Which restricted public endpoint a request arrived on. Each maps to a
+/// distinct tool allowlist and its own RFC 9728 resource-specific metadata.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RestrictedVersion {
+    /// `/v1` — read-only market-analysis surface.
+    V1,
+    /// `/v2` — broader read surface (adds read-only account/portfolio,
+    /// order/execution history, IPO market data, watchlist, alerts, sharelist,
+    /// community) but still no trade execution, DCA, IPO orders, or money
+    /// movement.
+    V2,
+}
+
+impl RestrictedVersion {
+    /// RFC 9728 protected-resource-metadata path advertised to clients that hit
+    /// a `401` on this endpoint, so the authorize URL requests the matching
+    /// read-only consent set.
+    pub fn metadata_path(self) -> &'static str {
+        match self {
+            RestrictedVersion::V1 => "/.well-known/oauth-protected-resource/v1",
+            RestrictedVersion::V2 => "/.well-known/oauth-protected-resource/v2",
+        }
+    }
+}
+
+/// Marker inserted into request extensions for requests that arrived on a
+/// restricted public endpoint (`/v1` or `/v2`). Its presence — and the
+/// [`RestrictedVersion`] it carries — tells downstream handlers
 /// (`ServerHandler::list_tools`, `ServerHandler::call_tool`) to expose and
-/// accept only the curated read-only analysis allowlist, never trading,
-/// DCA, or account tools.
+/// accept only that version's allowlist, never trade execution, DCA, IPO
+/// orders, or money-movement tools.
 ///
 /// Unlike [`AgentEndpoint`], this is inserted regardless of token presence: the
-/// `/v1` endpoint uses [`AuthMode::Required`], so a valid Bearer token is always
-/// present by the time the request reaches a handler, yet the exposed tool set
-/// must still be restricted.
-#[derive(Clone, Debug)]
-pub struct RestrictedEndpoint;
+/// restricted endpoints use [`AuthMode::Required`], so a valid Bearer token is
+/// always present by the time the request reaches a handler, yet the exposed
+/// tool set must still be restricted.
+#[derive(Clone, Copy, Debug)]
+pub struct RestrictedEndpoint(pub RestrictedVersion);
 
 /// Which endpoint a request arrived on, which decides how token-less requests
 /// are handled.
@@ -66,24 +92,24 @@ pub enum AuthMode {
 ///   through with no `BearerToken` but tagged with [`AgentEndpoint`], letting
 ///   the handshake succeed and the `authenticate` tool be listed/called.
 ///
-/// When `restricted` is set (the `/v1` public endpoint) a [`RestrictedEndpoint`]
-/// marker is attached to every request that proceeds, so handlers expose and
-/// accept only the public analysis allowlist.
+/// When `restricted` is `Some` (a `/v1` or `/v2` public endpoint) a
+/// [`RestrictedEndpoint`] marker carrying that [`RestrictedVersion`] is attached
+/// to every request that proceeds, so handlers expose and accept only that
+/// version's allowlist.
 pub async fn mcp_auth_layer(
     mut req: Request,
     next: Next,
     base_url: &str,
     mode: AuthMode,
-    restricted: bool,
+    restricted: Option<RestrictedVersion>,
 ) -> Response {
     let resource = crate::auth::metadata::resource_url_from_headers(req.headers(), base_url);
-    // The restricted `/v1` endpoint points at its own RFC 9728 resource-specific
+    // A restricted endpoint points at its own RFC 9728 resource-specific
     // metadata, which advertises read-only scopes only — so the authorize URL the
     // client builds never requests trading scopes.
-    let metadata_path = if restricted {
-        "/.well-known/oauth-protected-resource/v1"
-    } else {
-        "/.well-known/oauth-protected-resource"
+    let metadata_path = match restricted {
+        Some(version) => version.metadata_path(),
+        None => "/.well-known/oauth-protected-resource",
     };
     let www_authenticate = format!("Bearer resource_metadata=\"{resource}{metadata_path}\"");
 
@@ -119,10 +145,11 @@ pub async fn mcp_auth_layer(
     }
 
     // Tag the request so list_tools/call_tool restrict to the public allowlist.
-    // Inserted regardless of token presence: `/v1` is `AuthMode::Required`, so a
-    // token-less request has already been rejected with 401 above.
-    if restricted {
-        req.extensions_mut().insert(RestrictedEndpoint);
+    // Inserted regardless of token presence: restricted endpoints are
+    // `AuthMode::Required`, so a token-less request has already been rejected
+    // with 401 above.
+    if let Some(version) = restricted {
+        req.extensions_mut().insert(RestrictedEndpoint(version));
     }
 
     next.run(req).await

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -46,18 +46,21 @@ fn build_locales_node(sources: &[&[(&str, &str)]]) -> serde_json::Value {
     serde_json::Value::Object(locales)
 }
 
-/// Build the `/mcp/tools.json` (and `/v1/tools.json`) body.
+/// Build the `/mcp/tools.json` (and `/v1/tools.json`, `/v2/tools.json`) body.
 ///
 /// Order: tools → scopes → locales (relies on serde_json's `preserve_order`).
 /// When `allow` is `Some`, the tool list and every scope's `tools` array are
-/// pruned to that allowlist and scopes left with no tools are dropped — so the
-/// restricted `/v1` document never advertises trading or account capabilities.
+/// pruned to that allowlist and scopes left with no tools are dropped — so a
+/// restricted document never advertises a capability the endpoint blocks.
 /// Locales (a translation dictionary keyed by tool name) are carried verbatim.
 fn build_tools_json(allow: Option<&std::collections::HashSet<&'static str>>) -> serde_json::Value {
     let mut out = serde_json::Map::new();
 
     let tool_list = match allow {
-        Some(_) => tools::v1_list_tools(),
+        Some(allow) => tools::list_tools()
+            .into_iter()
+            .filter(|t| allow.contains(t.name.as_ref()))
+            .collect(),
         None => tools::list_tools(),
     };
     let tools: serde_json::Value =
@@ -100,10 +103,22 @@ async fn tools_json() -> axum::Json<&'static serde_json::Value> {
 async fn v1_tools_json() -> axum::Json<&'static serde_json::Value> {
     static V1_TOOLS_JSON: std::sync::LazyLock<serde_json::Value> = std::sync::LazyLock::new(|| {
         let allow: std::collections::HashSet<&'static str> =
-            tools::V1_PUBLIC_TOOLS.iter().copied().collect();
+            tools::v1_tool_names().into_iter().collect();
         build_tools_json(Some(&allow))
     });
     axum::Json(&*V1_TOOLS_JSON)
+}
+
+/// Restricted tool manifest for the public `/v2` endpoint: the broader
+/// allowlist (read-only account/portfolio + order history, but no trade
+/// execution, DCA, IPO orders, or money movement), with scopes pruned to match.
+async fn v2_tools_json() -> axum::Json<&'static serde_json::Value> {
+    static V2_TOOLS_JSON: std::sync::LazyLock<serde_json::Value> = std::sync::LazyLock::new(|| {
+        let allow: std::collections::HashSet<&'static str> =
+            tools::v2_tool_names().into_iter().collect();
+        build_tools_json(Some(&allow))
+    });
+    axum::Json(&*V2_TOOLS_JSON)
 }
 
 async fn scopes_json() -> axum::Json<&'static serde_json::Value> {
@@ -181,6 +196,11 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/.well-known/oauth-protected-resource/v1",
             axum::routing::get(metadata::protected_resource_metadata_v1),
         )
+        // RFC 9728 resource-specific metadata for the restricted `/v2` endpoint.
+        .route(
+            "/.well-known/oauth-protected-resource/v2",
+            axum::routing::get(metadata::protected_resource_metadata_v2),
+        )
         .with_state(state.clone());
 
     // Serve the static server card at both the host-root path Smithery's docs
@@ -211,8 +231,10 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     let tools_route: Router = Router::new()
         .route("/mcp/tools.json", axum::routing::get(tools_json))
         .route("/mcp/scopes.json", axum::routing::get(scopes_json))
-        // Restricted public manifest for the `/v1` endpoint (allowlist only).
-        .route("/v1/tools.json", axum::routing::get(v1_tools_json));
+        // Restricted public manifests for the `/v1` and `/v2` endpoints
+        // (allowlist only).
+        .route("/v1/tools.json", axum::routing::get(v1_tools_json))
+        .route("/v2/tools.json", axum::routing::get(v2_tools_json));
 
     // Build an auth-wrapped MCP service for one mounting point. The same
     // `Longbridge` MCP server is mounted several times; the only thing that
@@ -221,38 +243,35 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     //     missing token yields 401, exactly as before this feature.
     //   - `AuthMode::Optional` for the `/agent` endpoint: token-less requests
     //     are allowed through into the `authenticate` reverse-auth flow.
-    let make_mcp_with_auth = |base_url: String, mode: middleware::AuthMode, restricted: bool| {
-        let svc = StreamableHttpService::new(
-            move || Ok(Longbridge),
-            Arc::new(NeverSessionManager::default()),
-            StreamableHttpServerConfig::default()
-                .with_stateful_mode(false)
-                .disable_allowed_hosts(),
-        );
-        tower::ServiceBuilder::new()
-            .layer(axum::middleware::from_fn(
-                move |req: axum::extract::Request, next: axum::middleware::Next| {
-                    let base_url = base_url.clone();
-                    async move {
-                        middleware::mcp_auth_layer(req, next, &base_url, mode, restricted).await
-                    }
-                },
-            ))
-            .service(svc)
-    };
+    let make_mcp_with_auth =
+        |base_url: String,
+         mode: middleware::AuthMode,
+         restricted: Option<middleware::RestrictedVersion>| {
+            let svc = StreamableHttpService::new(
+                move || Ok(Longbridge),
+                Arc::new(NeverSessionManager::default()),
+                StreamableHttpServerConfig::default()
+                    .with_stateful_mode(false)
+                    .disable_allowed_hosts(),
+            );
+            tower::ServiceBuilder::new()
+                .layer(axum::middleware::from_fn(
+                    move |req: axum::extract::Request, next: axum::middleware::Next| {
+                        let base_url = base_url.clone();
+                        async move {
+                            middleware::mcp_auth_layer(req, next, &base_url, mode, restricted).await
+                        }
+                    },
+                ))
+                .service(svc)
+        };
 
     // Main endpoints — Bearer required (token-less -> 401). Mounted at both
     // `/mcp` and root so deployments that strip or omit the `/mcp` prefix work.
-    let mcp_with_auth = make_mcp_with_auth(
-        state.base_url.clone(),
-        middleware::AuthMode::Required,
-        false,
-    );
-    let mcp_with_auth_root = make_mcp_with_auth(
-        state.base_url.clone(),
-        middleware::AuthMode::Required,
-        false,
-    );
+    let mcp_with_auth =
+        make_mcp_with_auth(state.base_url.clone(), middleware::AuthMode::Required, None);
+    let mcp_with_auth_root =
+        make_mcp_with_auth(state.base_url.clone(), middleware::AuthMode::Required, None);
     // Root mount, plus a thin front layer that serves the human landing page for
     // browser GETs to `/`. All programmatic MCP traffic passes straight through.
     let root_service = tower::ServiceBuilder::new()
@@ -260,15 +279,23 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .service(mcp_with_auth_root);
     // Optional-auth endpoint — same MCP server, but token-less requests are let
     // through so an OAuth-incapable client can call the `authenticate` tool.
-    let mcp_agent = make_mcp_with_auth(
+    let mcp_agent =
+        make_mcp_with_auth(state.base_url.clone(), middleware::AuthMode::Optional, None);
+    // Restricted public endpoints — Bearer required, but only the version's
+    // curated allowlist is listed and callable. `/v1` is the read-only
+    // analysis surface submitted to third-party app directories
+    // (OpenAI/Claude/Grok); `/v2` is the broader read surface (adds read-only
+    // account/portfolio + order history) with the same no-execution guarantee.
+    let mcp_v1 = make_mcp_with_auth(
         state.base_url.clone(),
-        middleware::AuthMode::Optional,
-        false,
+        middleware::AuthMode::Required,
+        Some(middleware::RestrictedVersion::V1),
     );
-    // Restricted public endpoint — Bearer required, but only the curated
-    // read-only analysis allowlist is listed and callable. This is the URL
-    // submitted to third-party app directories (OpenAI/Claude/Grok).
-    let mcp_v1 = make_mcp_with_auth(state.base_url.clone(), middleware::AuthMode::Required, true);
+    let mcp_v2 = make_mcp_with_auth(
+        state.base_url.clone(),
+        middleware::AuthMode::Required,
+        Some(middleware::RestrictedVersion::V2),
+    );
 
     Router::new()
         .merge(metadata_routes)
@@ -279,6 +306,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .merge(tools_route)
         .nest_service("/agent", mcp_agent)
         .nest_service("/v1", mcp_v1)
+        .nest_service("/v2", mcp_v2)
         .nest_service("/mcp", mcp_with_auth)
         // Also serve at root so deployments that omit the /mcp path prefix work.
         .fallback_service(root_service)

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,8 +190,9 @@ async fn main() -> anyhow::Result<()> {
         "tools registered"
     );
 
-    // The two client-facing endpoints differ only in which tools they expose.
-    let public_tools = crate::tools::v1_list_tools();
+    // The client-facing endpoints differ only in which tools they expose.
+    let v1_tools = crate::tools::v1_list_tools();
+    let v2_tools = crate::tools::v2_list_tools();
     tracing::info!(
         url = %format!("{}/mcp", config.base_url),
         tools = tools.len(),
@@ -199,8 +200,13 @@ async fn main() -> anyhow::Result<()> {
     );
     tracing::info!(
         url = %format!("{}/v1", config.base_url),
-        tools = public_tools.len(),
+        tools = v1_tools.len(),
         "restricted public endpoint — app directories (read-only analysis only)"
+    );
+    tracing::info!(
+        url = %format!("{}/v2", config.base_url),
+        tools = v2_tools.len(),
+        "restricted public endpoint — broader read surface (no trade execution / DCA / IPO orders / money movement)"
     );
 
     if let (Some(cert), Some(key)) = (&config.tls_cert, &config.tls_key) {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -13,7 +13,7 @@ use rmcp::tool;
 use rmcp::tool_handler;
 use rmcp::tool_router;
 
-use crate::auth::middleware::{AgentEndpoint, BearerToken, RestrictedEndpoint};
+use crate::auth::middleware::{AgentEndpoint, BearerToken, RestrictedEndpoint, RestrictedVersion};
 use crate::error::Error;
 use crate::serialize::to_tool_json;
 
@@ -365,16 +365,25 @@ fn is_agent_endpoint(ctx: &RequestContext<RoleServer>) -> bool {
         .unwrap_or(false)
 }
 
-/// Whether the request arrived on the restricted public `/v1` endpoint.
+/// The restricted public endpoint version this request arrived on, if any.
 ///
-/// The auth middleware inserts [`RestrictedEndpoint`] for every request that
-/// proceeds on `/v1`. When true, `list_tools` exposes and `call_tool` accepts
-/// only the [`V1_PUBLIC_TOOLS`] allowlist.
-fn is_restricted_endpoint(ctx: &RequestContext<RoleServer>) -> bool {
+/// The auth middleware inserts [`RestrictedEndpoint`] (carrying a
+/// [`RestrictedVersion`]) for every request that proceeds on `/v1` or `/v2`.
+/// When `Some`, `list_tools` exposes and `call_tool` accepts only that
+/// version's allowlist.
+fn restricted_version(ctx: &RequestContext<RoleServer>) -> Option<RestrictedVersion> {
     ctx.extensions
         .get::<axum::http::request::Parts>()
-        .map(|parts| parts.extensions.get::<RestrictedEndpoint>().is_some())
-        .unwrap_or(false)
+        .and_then(|parts| parts.extensions.get::<RestrictedEndpoint>())
+        .map(|marker| marker.0)
+}
+
+/// Whether `name` is on the active restricted endpoint's allowlist.
+fn is_restricted_tool_allowed(version: RestrictedVersion, name: &str) -> bool {
+    match version {
+        RestrictedVersion::V1 => is_v1_public_tool(name),
+        RestrictedVersion::V2 => is_v2_public_tool(name),
+    }
 }
 
 fn extract_context(ctx: &RequestContext<RoleServer>) -> Result<McpContext, McpError> {
@@ -491,59 +500,234 @@ fn tools_agent_endpoint() -> &'static [rmcp::model::Tool] {
     })
 }
 
-/// Curated read-only allowlist exposed on the restricted public `/v1` endpoint.
+/// Endpoint version bit flags used by [`TOOL_ENDPOINTS`].
+const V1: u8 = 1 << 0;
+const V2: u8 = 1 << 1;
+
+/// Single source of truth for restricted-endpoint membership of every
+/// registered tool — the per-tool version annotation.
 ///
-/// Investment-analysis tools only. NEVER add trading, DCA, account, watchlist,
-/// alert, or any other personal/mutating tool here: `/v1` is the surface
-/// submitted to third-party app directories (OpenAI/Claude/Grok), which forbid
-/// investment-trade execution. A unit test asserts this list stays disjoint
-/// from the `trade.write`, `trade.read`, and `account.read` scopes and that
-/// every entry exists in the live tool registry.
-pub const V1_PUBLIC_TOOLS: &[&str] = &[
-    // Quotes / charts
-    "quote",
-    "candlesticks",
-    "depth",
-    "intraday",
-    "trades",
-    "calc_indexes",
-    "market_status",
-    // Fundamentals
-    "financial_statement",
-    "financial_report_latest",
-    "company",
-    "dividend",
-    "valuation",
-    "business_segments",
-    // Research
-    "institution_rating",
-    "consensus",
-    "forecast_eps",
-    "shareholder_top",
-    "short_positions",
-    // News / content
-    "news",
-    "news_search",
-    "filings",
-    // Market intelligence
-    "screener_search",
-    "top_movers",
-    "rank_list",
-    "finance_calendar",
-    // Watchlist (read-only query; group create/update/delete are excluded)
-    "watchlist",
+/// `/v1` and `/v2` are **whitelists**: a tool is exposed only when its flags
+/// include the matching bit. This is deliberately **default-out** — a tool
+/// absent from this table (or marked `0`) appears on neither restricted
+/// endpoint, so a newly added tool can never silently leak onto a
+/// directory-submitted surface.
+///
+/// - `/v1` — read-only market-analysis surface (OpenAI/Claude/Grok submission).
+/// - `/v2` — broader surface that additionally exposes read-only
+///   account/portfolio, read-only order/execution history, IPO market data,
+///   watchlist, alerts, sharelist, and community tools. `/v2` still **never**
+///   exposes trade execution (`submit_order`/`cancel_order`/`replace_order`),
+///   DCA automation, IPO order management (`ipo_orders`/`ipo_order_detail`/
+///   `ipo_profit_loss`), or money movement (`deposits`/`withdrawals`/
+///   `bank_cards`).
+///
+/// Every `/v1` tool is also valid on `/v2`, so v1 entries carry `V1 | V2`.
+///
+/// Invariants enforced by unit tests: every name is live, every live tool is
+/// listed exactly once, `V1 ⊆ V2`, and the v2 set is disjoint from the
+/// trade-write / DCA / IPO-order / money-movement tools.
+const TOOL_ENDPOINTS: &[(&str, u8)] = &[
+    // v1 + v2 — read-only market / fundamental / research analysis.
+    ("business_segments", V1 | V2),
+    ("calc_indexes", V1 | V2),
+    ("candlesticks", V1 | V2),
+    ("company", V1 | V2),
+    ("consensus", V1 | V2),
+    ("depth", V1 | V2),
+    ("dividend", V1 | V2),
+    ("filings", V1 | V2),
+    ("finance_calendar", V1 | V2),
+    ("financial_report_latest", V1 | V2),
+    ("financial_statement", V1 | V2),
+    ("forecast_eps", V1 | V2),
+    ("institution_rating", V1 | V2),
+    ("intraday", V1 | V2),
+    ("market_status", V1 | V2),
+    ("news", V1 | V2),
+    ("news_search", V1 | V2),
+    ("quote", V1 | V2),
+    ("rank_list", V1 | V2),
+    ("screener_search", V1 | V2),
+    ("shareholder_top", V1 | V2),
+    ("short_positions", V1 | V2),
+    ("top_movers", V1 | V2),
+    ("trades", V1 | V2),
+    ("valuation", V1 | V2),
+    ("watchlist", V1 | V2),
+    // v2 only — broader read surface plus non-trade write tools (watchlist,
+    // alert, sharelist, community).
+    ("account_balance", V2),
+    ("ah_premium", V2),
+    ("ah_premium_intraday", V2),
+    ("alert_add", V2),
+    ("alert_delete", V2),
+    ("alert_disable", V2),
+    ("alert_enable", V2),
+    ("alert_list", V2),
+    ("anomaly", V2),
+    ("broker_holding", V2),
+    ("broker_holding_daily", V2),
+    ("broker_holding_detail", V2),
+    ("brokers", V2),
+    ("business_segments_history", V2),
+    ("capital_distribution", V2),
+    ("capital_flow", V2),
+    ("cash_flow", V2),
+    ("constituent", V2),
+    ("corp_action", V2),
+    ("create_watchlist_group", V2),
+    ("delete_watchlist_group", V2),
+    ("dividend_detail", V2),
+    ("estimate_max_purchase_quantity", V2),
+    ("exchange_rate", V2),
+    ("executive", V2),
+    ("financial_report", V2),
+    ("financial_report_snapshot", V2),
+    ("fund_holder", V2),
+    ("fund_positions", V2),
+    ("history_candlesticks_by_date", V2),
+    ("history_candlesticks_by_offset", V2),
+    ("history_executions", V2),
+    ("history_market_temperature", V2),
+    ("history_orders", V2),
+    ("industry_peers", V2),
+    ("industry_rank", V2),
+    ("industry_valuation", V2),
+    ("industry_valuation_dist", V2),
+    ("institution_rating_detail", V2),
+    ("institution_rating_history", V2),
+    ("institution_rating_industry_rank", V2),
+    ("institutional_views", V2),
+    ("invest_relation", V2),
+    ("ipo_calendar", V2),
+    ("ipo_detail", V2),
+    ("ipo_listed", V2),
+    ("ipo_subscriptions", V2),
+    ("margin_ratio", V2),
+    ("market_temperature", V2),
+    ("now", V2),
+    ("operating", V2),
+    ("option_chain_expiry_date_list", V2),
+    ("option_chain_info_by_date", V2),
+    ("option_quote", V2),
+    ("option_volume", V2),
+    ("option_volume_daily", V2),
+    ("order_detail", V2),
+    ("participants", V2),
+    ("profit_analysis", V2),
+    ("profit_analysis_detail", V2),
+    ("quant_run", V2),
+    ("rank_categories", V2),
+    ("screener_indicators", V2),
+    ("screener_recommend_strategies", V2),
+    ("screener_strategy", V2),
+    ("screener_user_strategies", V2),
+    ("security_list", V2),
+    ("shareholder", V2),
+    ("shareholder_detail", V2),
+    ("sharelist_add", V2),
+    ("sharelist_create", V2),
+    ("sharelist_delete", V2),
+    ("sharelist_detail", V2),
+    ("sharelist_list", V2),
+    ("sharelist_popular", V2),
+    ("sharelist_remove", V2),
+    ("sharelist_sort", V2),
+    ("short_margin", V2),
+    ("short_trades", V2),
+    ("statement_export", V2),
+    ("statement_list", V2),
+    ("static_info", V2),
+    ("stock_positions", V2),
+    ("today_executions", V2),
+    ("today_orders", V2),
+    ("topic", V2),
+    ("topic_create", V2),
+    ("topic_create_reply", V2),
+    ("topic_detail", V2),
+    ("topic_replies", V2),
+    ("topic_search", V2),
+    ("trade_stats", V2),
+    ("trading_days", V2),
+    ("trading_session", V2),
+    ("update_watchlist_group", V2),
+    ("valuation_comparison", V2),
+    ("valuation_history", V2),
+    ("valuation_rank", V2),
+    ("warrant_issuers", V2),
+    ("warrant_list", V2),
+    ("warrant_quote", V2),
+    // Excluded from every restricted endpoint — DCA automation, order-write,
+    // IPO order management, money movement / PCI.
+    ("bank_cards", 0),
+    ("cancel_order", 0),
+    ("dca_check", 0),
+    ("dca_create", 0),
+    ("dca_history", 0),
+    ("dca_list", 0),
+    ("dca_pause", 0),
+    ("dca_resume", 0),
+    ("dca_stats", 0),
+    ("dca_stop", 0),
+    ("dca_update", 0),
+    ("deposits", 0),
+    ("ipo_order_detail", 0),
+    ("ipo_orders", 0),
+    ("ipo_profit_loss", 0),
+    ("replace_order", 0),
+    ("submit_order", 0),
+    ("withdrawals", 0),
+    // Reverse-auth tool — only surfaced on the unauthenticated `/agent`
+    // endpoint, never on a restricted endpoint.
+    ("authenticate", 0),
 ];
 
-/// Whether `name` is on the public `/v1` allowlist.
-fn is_v1_public_tool(name: &str) -> bool {
-    V1_PUBLIC_TOOLS.contains(&name)
+/// Endpoint membership flags for `name`, or `0` when the tool is on no
+/// restricted endpoint (or is unknown).
+fn endpoint_flags(name: &str) -> u8 {
+    TOOL_ENDPOINTS
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, f)| *f)
+        .unwrap_or(0)
 }
 
-/// Tools for the restricted public `/v1` endpoint: only [`V1_PUBLIC_TOOLS`].
-/// Computed once; every `tools/list` response clones from this slice.
+/// Whether `name` is exposed on the restricted public `/v1` endpoint.
+fn is_v1_public_tool(name: &str) -> bool {
+    endpoint_flags(name) & V1 != 0
+}
+
+/// Whether `name` is exposed on the restricted public `/v2` endpoint.
+fn is_v2_public_tool(name: &str) -> bool {
+    endpoint_flags(name) & V2 != 0
+}
+
+/// Tool names exposed on the `/v1` endpoint. Used by the `/v1/tools.json`
+/// manifest handler to prune the manifest to the allowlist.
+pub fn v1_tool_names() -> Vec<&'static str> {
+    TOOL_ENDPOINTS
+        .iter()
+        .filter(|(_, f)| f & V1 != 0)
+        .map(|(n, _)| *n)
+        .collect()
+}
+
+/// Tool names exposed on the `/v2` endpoint. Used by the `/v2/tools.json`
+/// manifest handler to prune the manifest to the allowlist.
+pub fn v2_tool_names() -> Vec<&'static str> {
+    TOOL_ENDPOINTS
+        .iter()
+        .filter(|(_, f)| f & V2 != 0)
+        .map(|(n, _)| *n)
+        .collect()
+}
+
+/// Tools for the restricted public `/v1` endpoint. Computed once; every
+/// `tools/list` response clones from this slice.
 fn tools_v1_endpoint() -> &'static [rmcp::model::Tool] {
-    static V1: std::sync::OnceLock<Vec<rmcp::model::Tool>> = std::sync::OnceLock::new();
-    V1.get_or_init(|| {
+    static V1_TOOLS: std::sync::OnceLock<Vec<rmcp::model::Tool>> = std::sync::OnceLock::new();
+    V1_TOOLS.get_or_init(|| {
         all_tools_cached()
             .iter()
             .filter(|t| is_v1_public_tool(t.name.as_ref()))
@@ -552,10 +736,29 @@ fn tools_v1_endpoint() -> &'static [rmcp::model::Tool] {
     })
 }
 
-/// Tool descriptors exposed on the restricted public `/v1` endpoint
-/// (allowlist only). Used by the `/v1/tools.json` manifest handler.
+/// Tools for the restricted public `/v2` endpoint. Computed once; every
+/// `tools/list` response clones from this slice.
+fn tools_v2_endpoint() -> &'static [rmcp::model::Tool] {
+    static V2_TOOLS: std::sync::OnceLock<Vec<rmcp::model::Tool>> = std::sync::OnceLock::new();
+    V2_TOOLS.get_or_init(|| {
+        all_tools_cached()
+            .iter()
+            .filter(|t| is_v2_public_tool(t.name.as_ref()))
+            .cloned()
+            .collect()
+    })
+}
+
+/// Tool descriptors exposed on the restricted public `/v1` endpoint.
+/// Used by the `/v1/tools.json` manifest handler.
 pub fn v1_list_tools() -> Vec<rmcp::model::Tool> {
     tools_v1_endpoint().to_vec()
+}
+
+/// Tool descriptors exposed on the restricted public `/v2` endpoint.
+/// Used by the `/v2/tools.json` manifest handler.
+pub fn v2_list_tools() -> Vec<rmcp::model::Tool> {
+    tools_v2_endpoint().to_vec()
 }
 
 /// Returns the tool router, built once and cached for the lifetime of the process.
@@ -3897,17 +4100,27 @@ impl ServerHandler for Longbridge {
                  returned `Authorization: Bearer` token.",
                 crate::tools::authenticate::connect_page_url()
             ));
-        } else if is_restricted_endpoint(&context) {
-            // The public `/v1` endpoint describes only its analysis capabilities
-            // and does not mention trading. Keep the first sentence
+        } else if let Some(version) = restricted_version(&context) {
+            // Restricted public endpoints describe only their (non-execution)
+            // capabilities and do not mention trading. Keep the first sentence
             // self-contained (clients surface the first ~512 chars).
-            info.instructions = Some(
-                "Longbridge MCP — market and investment analysis for US, HK, A-share, and SG \
-                 markets. Provides live quotes, candlestick charts, order-book depth, \
-                 fundamentals, valuations, analyst ratings and estimates, news, filings, and \
-                 screeners."
-                    .to_string(),
-            );
+            info.instructions = Some(match version {
+                RestrictedVersion::V1 => {
+                    "Longbridge MCP — market and investment analysis for US, HK, A-share, and SG \
+                     markets. Provides live quotes, candlestick charts, order-book depth, \
+                     fundamentals, valuations, analyst ratings and estimates, news, filings, and \
+                     screeners."
+                        .to_string()
+                }
+                RestrictedVersion::V2 => {
+                    "Longbridge MCP — market analysis and portfolio insight for US, HK, A-share, \
+                     and SG markets. Provides live quotes, charts, order-book depth, fundamentals, \
+                     valuations, analyst research, news, filings, screeners, watchlists, and \
+                     read-only account, portfolio, and order history. Does not place, modify, or \
+                     cancel orders."
+                        .to_string()
+                }
+            });
         }
         Ok(info)
     }
@@ -3935,14 +4148,17 @@ impl ServerHandler for Longbridge {
         request: rmcp::model::CallToolRequestParams,
         context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-        // Execution-layer gate for the restricted `/v1` endpoint: a tool hidden
-        // from `tools/list` must also be un-callable by name, or the listing
-        // filter is merely cosmetic. Trading/account tools are rejected here.
-        if is_restricted_endpoint(&context) && !is_v1_public_tool(request.name.as_ref()) {
+        // Execution-layer gate for a restricted endpoint: a tool hidden from
+        // `tools/list` must also be un-callable by name, or the listing filter
+        // is merely cosmetic. Off-allowlist tools are rejected here.
+        if let Some(version) = restricted_version(&context)
+            && !is_restricted_tool_allowed(version, request.name.as_ref())
+        {
             return Err(McpError::invalid_request(
                 format!(
                     "Tool `{}` is not available on this endpoint. \
-                     This endpoint exposes read-only market-analysis tools only.",
+                     This endpoint does not expose trade execution, recurring-investment, \
+                     IPO order, or money-movement tools.",
                     request.name
                 ),
                 None,
@@ -3961,8 +4177,11 @@ impl ServerHandler for Longbridge {
         // the clone cost (Arc ref-bumps + String title copies), not filter work.
         let tools = if is_agent_endpoint(&context) && !is_authenticated(&context) {
             tools_agent_endpoint().to_vec()
-        } else if is_restricted_endpoint(&context) {
-            tools_v1_endpoint().to_vec()
+        } else if let Some(version) = restricted_version(&context) {
+            match version {
+                RestrictedVersion::V1 => tools_v1_endpoint().to_vec(),
+                RestrictedVersion::V2 => tools_v2_endpoint().to_vec(),
+            }
         } else {
             tools_main_endpoint().to_vec()
         };
@@ -4155,51 +4374,149 @@ mod tests {
         assert!(collect_headers(&HeaderMap::new()).is_empty());
     }
 
-    /// The public `/v1` allowlist must reference only live tools and must never
-    /// overlap the trading/account scopes. Guards against (a) a tool being
-    /// renamed/removed without updating the allowlist, and (b) a trading or
-    /// account tool being added to the allowlist by mistake — which would put a
-    /// forbidden capability on the endpoint submitted to OpenAI/Claude/Grok.
+    /// Read the `tools` array of one scope from `data/scopes.json`.
+    fn scope_tools(key: &str) -> Vec<String> {
+        let scopes: serde_json::Value =
+            serde_json::from_str(include_str!("../../data/scopes.json"))
+                .expect("scopes.json must be valid JSON");
+        scopes["scopes"]
+            .as_array()
+            .expect("scopes array")
+            .iter()
+            .find(|s| s["key"].as_str() == Some(key))
+            .and_then(|s| s["tools"].as_array())
+            .unwrap_or_else(|| panic!("scope `{key}` must exist with a tools array"))
+            .iter()
+            .map(|t| t.as_str().expect("tool name must be a string").to_string())
+            .collect()
+    }
+
+    /// The version table is the single source of truth for `/v1` and `/v2`
+    /// membership. It must classify every live tool exactly once and reference
+    /// only live tools, so adding or renaming a tool forces an explicit
+    /// classification (and can never silently leak onto a restricted endpoint).
     #[test]
-    fn v1_allowlist_is_live_and_disjoint_from_trading_scopes() {
+    fn endpoint_table_is_complete_and_live() {
+        use std::collections::HashSet;
+
+        let live: HashSet<String> = crate::tools::list_tools()
+            .iter()
+            .map(|t| t.name.to_string())
+            .collect();
+
+        let mut seen = HashSet::new();
+        for (name, _) in super::TOOL_ENDPOINTS {
+            assert!(
+                seen.insert(*name),
+                "TOOL_ENDPOINTS lists `{name}` more than once"
+            );
+            assert!(
+                live.contains(*name),
+                "TOOL_ENDPOINTS references unknown tool `{name}` (renamed or removed?)"
+            );
+        }
+
+        for name in &live {
+            assert!(
+                seen.contains(name.as_str()),
+                "live tool `{name}` is not classified in TOOL_ENDPOINTS \
+                 (add it with V1|V2, V2, or 0)"
+            );
+        }
+    }
+
+    /// Every `/v1` tool must also be on `/v2`: the v2 surface is a superset of
+    /// the read-only analysis surface.
+    #[test]
+    fn v1_is_subset_of_v2() {
+        for name in super::v1_tool_names() {
+            assert!(
+                super::is_v2_public_tool(name),
+                "`{name}` is on /v1 but not /v2 — v1 must be a subset of v2"
+            );
+        }
+    }
+
+    /// The public `/v1` allowlist must be read-only and disjoint from the
+    /// trading/account scopes. Guards against a write/trading/account tool
+    /// landing on the endpoint submitted to OpenAI/Claude/Grok.
+    #[test]
+    fn v1_allowlist_is_read_only_and_disjoint_from_trading_scopes() {
         use std::collections::HashSet;
 
         let live = crate::tools::list_tools();
         let by_name: std::collections::HashMap<&str, &rmcp::model::Tool> =
             live.iter().map(|t| (t.name.as_ref(), t)).collect();
-        for name in super::V1_PUBLIC_TOOLS {
-            let tool = by_name.get(name).unwrap_or_else(|| {
-                panic!("V1 allowlist references unknown tool `{name}` (renamed or removed?)")
-            });
-            // Hard guard: every exposed `/v1` tool must be read-only. Catches any
-            // write tool (trading, watchlist/alert mutation, …) added by mistake,
-            // regardless of which OAuth scope it belongs to.
+        for name in super::v1_tool_names() {
+            let tool = by_name
+                .get(name)
+                .unwrap_or_else(|| panic!("/v1 allowlist references unknown tool `{name}`"));
             let read_only = tool.annotations.as_ref().and_then(|a| a.read_only_hint);
             assert_eq!(
                 read_only,
                 Some(true),
-                "V1 allowlist tool `{name}` is not marked read_only_hint = true"
+                "/v1 allowlist tool `{name}` is not marked read_only_hint = true"
             );
         }
 
-        let allow: HashSet<&str> = super::V1_PUBLIC_TOOLS.iter().copied().collect();
-        let scopes: serde_json::Value =
-            serde_json::from_str(include_str!("../../data/scopes.json"))
-                .expect("scopes.json must be valid JSON");
-        let scope_array = scopes["scopes"].as_array().expect("scopes array");
+        let allow: HashSet<&str> = super::v1_tool_names().into_iter().collect();
         for forbidden in ["trade.write", "trade.read", "account.read"] {
-            let tools = scope_array
-                .iter()
-                .find(|s| s["key"].as_str() == Some(forbidden))
-                .and_then(|s| s["tools"].as_array())
-                .unwrap_or_else(|| panic!("scope `{forbidden}` must exist with a tools array"));
-            for tool in tools {
-                let tool = tool.as_str().expect("tool name must be a string");
+            for tool in scope_tools(forbidden) {
                 assert!(
-                    !allow.contains(tool),
-                    "V1 allowlist must not contain `{tool}` from forbidden scope `{forbidden}`"
+                    !allow.contains(tool.as_str()),
+                    "/v1 allowlist must not contain `{tool}` from forbidden scope `{forbidden}`"
                 );
             }
+        }
+    }
+
+    /// The public `/v2` allowlist must never expose trade execution, DCA
+    /// automation, IPO order management, or money movement / PCI tools — the
+    /// hard-exclusion set, even though `/v2` is otherwise a near-full surface.
+    #[test]
+    fn v2_allowlist_excludes_execution_dca_ipo_orders_and_money_movement() {
+        use std::collections::HashSet;
+
+        let allow: HashSet<&str> = super::v2_tool_names().into_iter().collect();
+
+        // trade.write (submit/cancel/replace + DCA writes) must be fully absent.
+        for tool in scope_tools("trade.write") {
+            assert!(
+                !allow.contains(tool.as_str()),
+                "/v2 allowlist must not contain `{tool}` from scope `trade.write`"
+            );
+        }
+
+        // Explicit hard-exclusion set, independent of scope grouping.
+        let hard_excluded = [
+            // All DCA automation.
+            "dca_check",
+            "dca_history",
+            "dca_list",
+            "dca_stats",
+            "dca_create",
+            "dca_pause",
+            "dca_resume",
+            "dca_stop",
+            "dca_update",
+            // Order write operations.
+            "submit_order",
+            "cancel_order",
+            "replace_order",
+            // IPO order management.
+            "ipo_orders",
+            "ipo_order_detail",
+            "ipo_profit_loss",
+            // Money movement / PCI.
+            "deposits",
+            "withdrawals",
+            "bank_cards",
+        ];
+        for tool in hard_excluded {
+            assert!(
+                !allow.contains(tool),
+                "/v2 allowlist must not contain hard-excluded tool `{tool}`"
+            );
         }
     }
 }


### PR DESCRIPTION
## What

Adds a second restricted MCP endpoint, **`/v2`** — a broader read surface than `/v1`. `/v2` exposes every registered tool as a **whitelist** except:

- all DCA automation (9),
- order writes — `submit_order` / `cancel_order` / `replace_order` (3),
- IPO order management — `ipo_orders` / `ipo_order_detail` / `ipo_profit_loss` (3),
- money movement / PCI — `deposits` / `withdrawals` / `bank_cards` (3).

So `/v2` keeps read-only account/portfolio, read-only order/execution history, IPO market data, watchlist, alerts, sharelist, and community tools — but never trade execution, DCA, IPO orders, or money movement. Direct users keep the full set on `/mcp`.

**Counts:** v1 = 26 · v2 = 127 · hard-excluded = 18 (+ `authenticate`).

## Why

The user asked for a `/v2` declared as a whitelist with a per-tool version annotation, instead of the flat `V1_PUBLIC_TOOLS` array. A whitelist is default-out: a newly added tool can't silently leak onto a directory-submitted surface. Money-movement tools are explicitly excluded — an "everything except orders" framing would have let them through, touching Directory Policy 4.A.

## How

- **Per-tool version annotation** — single centralized table `TOOL_ENDPOINTS: &[(&str, u8)]` (`V1`/`V2` bit flags) in `src/tools/mod.rs` classifies all 146 tools exactly once; replaces `V1_PUBLIC_TOOLS`. `V1 ⊆ V2`.
- **Wiring mirrors `/v1`** — `RestrictedEndpoint(RestrictedVersion{V1,V2})`; `mcp_auth_layer` takes `Option<RestrictedVersion>`; `restricted_version(ctx)` drives endpoint-aware `list_tools`, the two-layer `call_tool` gate, and `initialize` instructions.
- **Manifest & metadata** — `/v2/tools.json` + RFC 9728 metadata at `/.well-known/oauth-protected-resource/v2` (`scopes_supported = ["mcp-endpoint=v2"]`). `build_tools_json` generalized to prune by any allow-set.
- **Anti-drift tests** — table completeness/liveness, `V1 ⊆ V2`, v1 read-only + disjoint from trade/account scopes, v2 disjoint from trade-write / DCA / IPO-order / money-movement.

## Verification

`cargo build` / `cargo +nightly fmt` / `cargo clippy --all-features --all-targets` clean; anti-drift tests pass.

Live MCP-protocol probe of `/v2`:
- no token → `401` with `WWW-Authenticate` pointing at the v2 metadata
- `initialize` → protocol `2025-06-18`, v2-specific instructions
- `tools/list` → **127 tools**, zero excluded
- `tools/call` excluded tools (`submit_order`, `dca_list`, `deposits`, …) → `-32600` execution-layer rejection; allowed tools (`quote`, `account_balance`) pass the gate and reach upstream

## Follow-ups (external, not code)

- Expand the privacy policy to disclose the account/portfolio/order/cash-flow/statement reads `/v2` exposes before directory submission.
- Confirm the Longbridge AS maps `scope=mcp-endpoint=v2` to the v2 consent set end-to-end (same open item as `/v1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
