### PR TITLE
feat(auth): honor allowlisted X-Host when deriving OAuth metadata URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ These are **advanced settings** — most users do not need to change them. They 
 |----------|---------|-------------|
 | `LONGBRIDGE_MCP_CONFIG_DIR` | `~/.longbridge/mcp` | Config file directory |
 | `LONGBRIDGE_HTTP_URL` | `https://openapi.longbridge.com` | Longbridge API base URL (also used for OAuth metadata) |
+| `LONGBRIDGE_PUBLIC_HOSTS` | *(none)* | Comma-separated hostnames accepted from the edge-injected `X-Host` header; matching requests echo that host in the 401 challenge / RFC 9728 metadata. Unset = `X-Host` ignored |
+| `LONGBRIDGE_GLOBAL_OAUTH_URL` | *(none)* | Authorization-server URL advertised to requests arriving via an allowlisted `X-Host` (global single-domain entry). Unset = fall back to `LONGBRIDGE_HTTP_URL` |
 | `LONGBRIDGE_QUOTE_WS_URL` | `wss://openapi-quote.longbridge.com/v2` | Quote WebSocket endpoint |
 | `LONGBRIDGE_TRADE_WS_URL` | `wss://openapi-trade.longbridge.com/v2` | Trade WebSocket endpoint |
 | `LONGBRIDGE_MCP_QUOTE_WS_IDLE_TTL_SECS` | `600` | Idle seconds before a cached quote WebSocket context is evicted |

--- a/src/auth/metadata.rs
+++ b/src/auth/metadata.rs
@@ -12,24 +12,75 @@ fn longbridge_oauth_url() -> String {
         .unwrap_or_else(|_| "https://openapi.longbridge.com".to_string())
 }
 
-/// Derives `scheme://host` from the incoming request headers.
+/// Authorization-server URL advertised to clients that reached us through the
+/// global single-domain entry (allowlisted `X-Host`, see [`public_hosts`]).
+/// Unset/empty = such requests keep advertising [`longbridge_oauth_url`].
+///
+/// Deliberately separate from `LONGBRIDGE_HTTP_URL`: that variable is also the
+/// longbridge SDK upstream base and the `/agent` reverse-auth base, so pointing
+/// it at the global edge domain would reroute this server's own upstream calls
+/// through the public edge.
+fn global_oauth_url() -> Option<String> {
+    std::env::var("LONGBRIDGE_GLOBAL_OAUTH_URL")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Hostnames that may be asserted via the edge-injected `X-Host` header
+/// (comma-separated env `LONGBRIDGE_PUBLIC_HOSTS`). Unset/empty = the `X-Host`
+/// path is disabled entirely and behavior is unchanged.
+///
+/// The allowlist is what makes `X-Host` trustworthy: the DC ingress rewrites
+/// `Host`/`X-Forwarded-Host` to the origin hostname but passes custom headers
+/// through — from the edge *and* from anyone hitting the origin directly.
+/// Without the gate, a direct caller could make the 401 challenge / RFC 9728
+/// metadata advertise an attacker-controlled domain.
+fn public_hosts() -> Vec<String> {
+    std::env::var("LONGBRIDGE_PUBLIC_HOSTS")
+        .map(|v| {
+            v.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Public URL resolved for a request, plus whether the host was asserted
+/// through the global single-domain entry (allowlisted `X-Host`).
+pub(crate) struct PublicUrl {
+    /// `scheme://host` to echo in the 401 challenge and RFC 9728 metadata.
+    pub url: String,
+    /// True when the host came from an allowlisted `X-Host`; switches the
+    /// advertised authorization server to [`global_oauth_url`].
+    pub via_global_entry: bool,
+}
+
+/// Derives the public `scheme://host` a request should be answered with.
 ///
 /// Header priority for the host:
-///   1. `X-Forwarded-Host` — set by the reverse proxy to the external hostname
+///   1. `X-Host` — injected by the global edge (Lambda@Edge) with the single
+///      public domain (e.g. `mcp-global.longbridge.xyz`); only honoured when it
+///      matches the `LONGBRIDGE_PUBLIC_HOSTS` allowlist. Needed because the DC
+///      ingress rewrites `Host`/`X-Forwarded-Host` back to the origin hostname,
+///      while custom headers pass through untouched.
+///   2. `X-Forwarded-Host` — set by the reverse proxy to the external hostname
 ///      (e.g. `openapi.longbridge.xyz` when the proxy rewrites the Host).
-///   2. `Host` — the hostname the client actually connected to (correct for
+///   3. `Host` — the hostname the client actually connected to (correct for
 ///      direct connections; may be the internal backend host behind a proxy).
-///   3. Falls back to `fallback` (`--base-url`) when both are absent.
+///   4. Falls back to `fallback` (`--base-url`) when all are absent.
 ///
 /// Scheme priority: `X-Forwarded-Proto` → scheme of `--base-url`.
-pub(crate) fn resource_url_from_headers(headers: &HeaderMap, fallback: &str) -> String {
-    let Some(host) = headers
-        .get("x-forwarded-host")
-        .or_else(|| headers.get(axum::http::header::HOST))
-        .and_then(|v| v.to_str().ok())
-    else {
-        return fallback.to_string();
-    };
+pub(crate) fn public_url_from_headers(headers: &HeaderMap, fallback: &str) -> PublicUrl {
+    resolve_public_url(headers, fallback, &public_hosts())
+}
+
+fn resolve_public_url(
+    headers: &HeaderMap,
+    fallback: &str,
+    allowed_x_hosts: &[String],
+) -> PublicUrl {
     // Prefer the proxy-set header; fall back to the scheme in --base-url so
     // that local HTTP deployments without a reverse proxy still return "http".
     let fallback_scheme = if fallback.starts_with("https://") {
@@ -41,7 +92,35 @@ pub(crate) fn resource_url_from_headers(headers: &HeaderMap, fallback: &str) -> 
         .get("x-forwarded-proto")
         .and_then(|v| v.to_str().ok())
         .unwrap_or(fallback_scheme);
-    format!("{scheme}://{host}")
+
+    let x_host = headers
+        .get("x-host")
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|h| !h.is_empty());
+    if let Some(host) = x_host
+        && allowed_x_hosts.iter().any(|a| a.eq_ignore_ascii_case(host))
+    {
+        return PublicUrl {
+            url: format!("{scheme}://{host}"),
+            via_global_entry: true,
+        };
+    }
+
+    let Some(host) = headers
+        .get("x-forwarded-host")
+        .or_else(|| headers.get(axum::http::header::HOST))
+        .and_then(|v| v.to_str().ok())
+    else {
+        return PublicUrl {
+            url: fallback.to_string(),
+            via_global_entry: false,
+        };
+    };
+    PublicUrl {
+        url: format!("{scheme}://{host}"),
+        via_global_entry: false,
+    }
 }
 
 #[derive(Serialize)]
@@ -61,10 +140,33 @@ pub(crate) struct ProtectedResourceMetadata {
 /// narrowing the granted permissions is done server-side off this marker.
 const V2_SCOPES_SUPPORTED: &[&str] = &["mcp-endpoint=v2"];
 
-fn build_resource_metadata(resource: String, scopes: Vec<String>) -> ProtectedResourceMetadata {
+/// Picks the authorization server to advertise: requests that came through the
+/// global single-domain entry get [`global_oauth_url`] (when configured) so the
+/// whole OAuth bootstrap stays on the global domains; everything else keeps the
+/// per-DC [`longbridge_oauth_url`].
+fn select_authorization_server(
+    via_global_entry: bool,
+    global: Option<String>,
+    fallback: String,
+) -> String {
+    match (via_global_entry, global) {
+        (true, Some(url)) => url,
+        _ => fallback,
+    }
+}
+
+fn build_resource_metadata(
+    via_global_entry: bool,
+    resource: String,
+    scopes: Vec<String>,
+) -> ProtectedResourceMetadata {
     ProtectedResourceMetadata {
         resource,
-        authorization_servers: vec![longbridge_oauth_url()],
+        authorization_servers: vec![select_authorization_server(
+            via_global_entry,
+            global_oauth_url(),
+            longbridge_oauth_url(),
+        )],
         scopes_supported: scopes,
     }
 }
@@ -73,9 +175,10 @@ pub async fn protected_resource_metadata(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Json<ProtectedResourceMetadata> {
-    let resource = resource_url_from_headers(&headers, &state.base_url);
+    let public = public_url_from_headers(&headers, &state.base_url);
     Json(build_resource_metadata(
-        resource,
+        public.via_global_entry,
+        public.url,
         vec!["openapi".to_string()],
     ))
 }
@@ -90,12 +193,14 @@ pub async fn protected_resource_metadata_v2(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Json<ProtectedResourceMetadata> {
-    let resource = format!(
-        "{}/v2",
-        resource_url_from_headers(&headers, &state.base_url)
-    );
+    let public = public_url_from_headers(&headers, &state.base_url);
+    let resource = format!("{}/v2", public.url);
     let scopes = V2_SCOPES_SUPPORTED.iter().map(|s| s.to_string()).collect();
-    Json(build_resource_metadata(resource, scopes))
+    Json(build_resource_metadata(
+        public.via_global_entry,
+        resource,
+        scopes,
+    ))
 }
 
 #[derive(Serialize)]
@@ -139,4 +244,146 @@ static SERVER_CARD: LazyLock<ServerCard> = LazyLock::new(|| ServerCard {
 /// attempting Dynamic Client Registration directly.
 pub async fn server_card() -> Json<&'static ServerCard> {
     Json(&*SERVER_CARD)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: &str = "https://localhost:8000";
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                axum::http::HeaderName::try_from(*k).expect("valid header name"),
+                v.parse().expect("valid header value"),
+            );
+        }
+        h
+    }
+
+    fn allow(hosts: &[&str]) -> Vec<String> {
+        hosts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn x_host_in_allowlist_wins_over_rewritten_host() {
+        // Mirrors the production chain: the DC ingress has rewritten Host/XFH
+        // back to the origin hostname; only the edge-injected X-Host still
+        // carries the global single domain.
+        let h = headers(&[
+            ("x-host", "mcp-global.longbridge.xyz"),
+            ("x-forwarded-host", "mcp.longbridge.xyz"),
+            ("host", "mcp.longbridge.xyz"),
+            ("x-forwarded-proto", "https"),
+        ]);
+        let got = resolve_public_url(&h, BASE, &allow(&["mcp-global.longbridge.xyz"]));
+        assert_eq!(got.url, "https://mcp-global.longbridge.xyz");
+        assert!(got.via_global_entry);
+    }
+
+    #[test]
+    fn x_host_not_in_allowlist_is_ignored() {
+        // A forged X-Host on a direct-to-origin request must not change the
+        // echoed domain.
+        let h = headers(&[
+            ("x-host", "evil.example.com"),
+            ("host", "mcp.longbridge.xyz"),
+            ("x-forwarded-proto", "https"),
+        ]);
+        let got = resolve_public_url(&h, BASE, &allow(&["mcp-global.longbridge.xyz"]));
+        assert_eq!(got.url, "https://mcp.longbridge.xyz");
+        assert!(!got.via_global_entry);
+    }
+
+    #[test]
+    fn x_host_disabled_when_allowlist_empty() {
+        // LONGBRIDGE_PUBLIC_HOSTS unset = the feature is off entirely and
+        // behavior matches the previous release.
+        let h = headers(&[
+            ("x-host", "mcp-global.longbridge.xyz"),
+            ("host", "mcp.longbridge.xyz"),
+            ("x-forwarded-proto", "https"),
+        ]);
+        let got = resolve_public_url(&h, BASE, &[]);
+        assert_eq!(got.url, "https://mcp.longbridge.xyz");
+        assert!(!got.via_global_entry);
+    }
+
+    #[test]
+    fn x_host_match_is_case_insensitive() {
+        let h = headers(&[
+            ("x-host", "MCP-Global.Longbridge.XYZ"),
+            ("host", "mcp.longbridge.xyz"),
+            ("x-forwarded-proto", "https"),
+        ]);
+        let got = resolve_public_url(&h, BASE, &allow(&["mcp-global.longbridge.xyz"]));
+        assert_eq!(got.url, "https://MCP-Global.Longbridge.XYZ");
+        assert!(got.via_global_entry);
+    }
+
+    #[test]
+    fn falls_back_to_xfh_then_host_then_base_url() {
+        let allowlist = allow(&["mcp-global.longbridge.xyz"]);
+
+        let xfh = headers(&[
+            ("x-forwarded-host", "public.example.com"),
+            ("host", "backend.internal"),
+        ]);
+        let got = resolve_public_url(&xfh, BASE, &allowlist);
+        assert_eq!(got.url, "https://public.example.com");
+        assert!(!got.via_global_entry);
+
+        let host_only = headers(&[("host", "backend.internal")]);
+        assert_eq!(
+            resolve_public_url(&host_only, BASE, &allowlist).url,
+            "https://backend.internal"
+        );
+
+        let empty = headers(&[]);
+        assert_eq!(resolve_public_url(&empty, BASE, &allowlist).url, BASE);
+    }
+
+    #[test]
+    fn scheme_prefers_x_forwarded_proto_then_base_url_scheme() {
+        let allowlist = allow(&["mcp-global.longbridge.xyz"]);
+        let h = headers(&[
+            ("x-host", "mcp-global.longbridge.xyz"),
+            ("x-forwarded-proto", "http"),
+        ]);
+        assert_eq!(
+            resolve_public_url(&h, BASE, &allowlist).url,
+            "http://mcp-global.longbridge.xyz"
+        );
+
+        let no_proto = headers(&[("x-host", "mcp-global.longbridge.xyz")]);
+        assert_eq!(
+            resolve_public_url(&no_proto, "http://localhost:8000", &allowlist).url,
+            "http://mcp-global.longbridge.xyz"
+        );
+    }
+
+    #[test]
+    fn authorization_server_selection_matrix() {
+        let global = || Some("https://openapi-global.longbridge.xyz".to_string());
+        let fallback = || "https://openapi.longbridge.xyz".to_string();
+
+        // Global entry + configured → advertise the global AS.
+        assert_eq!(
+            select_authorization_server(true, global(), fallback()),
+            "https://openapi-global.longbridge.xyz"
+        );
+        // Global entry but LONGBRIDGE_GLOBAL_OAUTH_URL unset → keep the default.
+        assert_eq!(
+            select_authorization_server(true, None, fallback()),
+            fallback()
+        );
+        // Direct-to-origin (not the global entry) → always the default,
+        // existing clients see no change.
+        assert_eq!(
+            select_authorization_server(false, global(), fallback()),
+            fallback()
+        );
+    }
 }

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -100,7 +100,7 @@ pub async fn mcp_auth_layer(
     mode: AuthMode,
     restricted: Option<RestrictedVersion>,
 ) -> Response {
-    let resource = crate::auth::metadata::resource_url_from_headers(req.headers(), base_url);
+    let resource = crate::auth::metadata::public_url_from_headers(req.headers(), base_url).url;
     // A restricted endpoint points at its own RFC 9728 resource-specific
     // metadata, which advertises read-only scopes only — so the authorize URL the
     // client builds never requests trading scopes.


### PR DESCRIPTION
## Problem

Behind a global single-domain edge (CloudFront + Lambda@Edge fronting one public domain, e.g. `mcp-global.longbridge.xyz`, over multiple DCs), the DC ingress rewrites both `Host` and `X-Forwarded-Host` back to the origin hostname before the request reaches this server. As a result the 401 challenge and the RFC 9728 metadata advertise the **origin** domain and the **per-DC** authorization server:

```
POST https://mcp-global.longbridge.xyz/mcp        (no token)
 → 401 WWW-Authenticate: Bearer resource_metadata=
       "https://mcp.longbridge.xyz/.well-known/oauth-protected-resource"   ← origin domain

GET https://mcp-global.longbridge.xyz/.well-known/oauth-protected-resource
 → { "resource": "https://mcp.longbridge.xyz",
     "authorization_servers": ["https://openapi.longbridge.xyz"] }         ← per-DC AS
```

The client's whole OAuth bootstrap (discovery → authorize → token) is pulled off the global domain onto one DC's origin: users homed in another DC cannot authorize at all, and the RFC 8707 `resource` identifier no longer matches the URL the client actually uses.

The data plane is unaffected — this only breaks the 401 → discovery → authorize bootstrap for clients entering via the global domain.

## Change

The edge injects `X-Host: <single public domain>` on every routed request, and custom headers survive the ingress untouched (verified against the staging chain, where forged/injected `X-Forwarded-Host` gets rewritten). So:

- **`resource` / 401 challenge**: resolve the echoed host as `X-Host > X-Forwarded-Host > Host > --base-url`, honoring `X-Host` **only when it matches the new comma-separated `LONGBRIDGE_PUBLIC_HOSTS` allowlist**. The gate is what keeps a forged `X-Host` on a direct-to-origin request from steering the 401 challenge / metadata to an attacker-controlled domain.
- **`authorization_servers`**: when (and only when) the request came through such a global entry, advertise the new `LONGBRIDGE_GLOBAL_OAUTH_URL`. Kept separate from `LONGBRIDGE_HTTP_URL` on purpose — that variable is also the longbridge SDK upstream base and the `/agent` reverse-auth base, so pointing it at the edge domain would reroute this server's own upstream calls through the public edge.

## Rollout / compatibility

- Both new env vars unset ⇒ byte-for-byte the previous behavior (this is also the rollout switch).
- Direct-to-origin clients (no allowlisted `X-Host`) see no change either way.

## Tests

7 new unit tests over the pure resolver (`resolve_public_url` / `select_authorization_server`): allowlist hit, forged X-Host ignored, feature off when allowlist unset, case-insensitive host match, XFH→Host→base-url fallback chain, scheme selection, and the AS mapping matrix. `cargo test` (104 passed), `cargo clippy --all-features --all-targets` clean, `cargo +nightly fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)