### PR TITLE
ci: add independent canary Docker build workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,8 +1,6 @@
 name: Canary Docker Build
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,41 @@
+name: Canary Docker Build
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-canary
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,format=short
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- New `.github/workflows/canary.yml`, **manual-only** (`workflow_dispatch`) — does not run automatically on push to `main`.
- Builds and pushes `ghcr.io/longbridge/longbridge-mcp-canary`, tagged with the short commit sha and `latest`.
- `release.yml` is untouched — no GitHub Release is created, no version tag required.

Note: `workflow_dispatch` only becomes available once the workflow definition exists on the default branch, so this PR needs merging once to register it. After that, it only runs when manually triggered (GitHub UI "Run workflow" or `gh workflow run canary.yml`), never automatically.

## Test plan
- [x] YAML validated
- [ ] After merge, manually trigger via `gh workflow run canary.yml` — confirm image appears at `ghcr.io/longbridge/longbridge-mcp-canary:latest`