### PR TITLE
ci: tag canary image with crate version instead of commit sha

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Read crate version
+        id: version
+        run: |
+          version=$(grep -m1 '^version' Cargo.toml | sed -E 's/version *= *"(.*)"/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -28,7 +34,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,format=short
+            type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=latest
 
       - uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
Follow-up to #100. Tags the canary image as `ghcr.io/longbridge/longbridge-mcp-canary:<Cargo.toml version>` (e.g. `:0.7.1`) instead of `:sha-<hash>` — correlates the canary build with the app version rather than an opaque commit hash. Still also tags `:latest`.

## Test plan
- [x] YAML validated
- [ ] After merge, manually trigger via `gh workflow run canary.yml` — confirm image appears at `ghcr.io/longbridge/longbridge-mcp-canary:<version>`