### PR TITLE
chore: bump version 0.7.1 → 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-mcp"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longbridge-mcp"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
   <a href="https://longbridge.com"><img alt="Longbridge" src="https://img.shields.io/badge/brokerage-Longbridge-ffe000?labelColor=000"></a>
 </p>
 
-Official MCP server for the [Longbridge](https://longbridge.com) brokerage. **145 tools** across real-time quotes, options, order routing, fundamentals, analyst ratings, calendars, IPO, price alerts, DCA plans, portfolio analytics and community sharelists — covering **US and HK markets**. Built with Rust using [rmcp](https://github.com/anthropics/rmcp) and [axum](https://github.com/tokio-rs/axum).
+Official MCP server for the [Longbridge](https://longbridge.com) brokerage. **148 tools** across real-time quotes, options, order routing, fundamentals, analyst ratings, calendars, IPO, price alerts, DCA plans, portfolio analytics and community sharelists — covering **US and HK markets**. Built with Rust using [rmcp](https://github.com/anthropics/rmcp) and [axum](https://github.com/tokio-rs/axum).
 
 ## Features
 
-- **145 MCP tools** across 13 categories: quotes, trading, fundamentals, screener, market data, calendars, IPO, portfolio, alerts, content, account statements, DCA, and community sharelists
+- **148 MCP tools** across 19 categories: quotes, fundamentals, trading, market data, DCA, IPO, sharelists, content, alerts, screener, ATM, portfolio, macrodata, search, statements, authenticate, calendar, quant, and utility
 - **Stateless architecture** -- each request carries a Bearer token forwarded directly to the Longbridge SDK; no server-side sessions or database
 - **OAuth 2.1 resource metadata** compliant with RFC 9728, pointing clients to Longbridge OAuth for authorization
 - **JSON response transformation** -- field names normalized to snake_case, timestamps converted to RFC 3339, internal counter_id values mapped to human-readable symbols
@@ -179,19 +179,23 @@ On the first tool invocation, Claude Code reads the `WWW-Authenticate` challenge
 | Category | Count | Description |
 |----------|-------|-------------|
 | **Quote** | 32 | Real-time and historical quotes, candlesticks, depth, brokers, options, warrants, watchlists, capital flow, market temperature, short positions, option volume |
-| **Trade** | 14 | Order submission/cancellation/replacement, positions, balance, executions, cash flow, margin |
-| **Fundamental** | 19 | Financial statements, business segments, institutional views, industry peers, earnings snapshot, dividends, EPS forecasts, valuations, company info, shareholders, corporate actions |
-| **Market** | 10 | Market status, industry rank, broker holdings, A/H premium, trade statistics, anomalies, index constituents |
-| **IPO** | 8 | IPO subscriptions, calendar, listed stocks, order detail, profit/loss analysis |
-| **Content** | 8 | News, discussion topics, filing details |
+| **Fundamental** | 31 | Financial statements/reports, business segments, institutional views, industry peers/valuation, dividends, EPS forecasts, valuations, company info/executives, shareholders, corporate actions, operating metrics |
+| **Trade** | 15 | Order submission/cancellation/replacement, positions, balance, executions, cash flow, margin |
+| **Market** | 14 | Market status, industry/top-mover rank, broker holdings, A/H premium, trade statistics, anomalies, short trades, index constituents |
 | **DCA** | 9 | Dollar-cost averaging plan create/update/pause/resume/stop, execution history, statistics, and support check |
+| **IPO** | 7 | IPO subscriptions, calendar, listed stocks, order detail, profit/loss analysis |
 | **Sharelist** | 8 | Community sharelist CRUD, member add/remove/sort, popular lists |
+| **Content** | 6 | News, discussion topic CRUD and replies |
 | **Alert** | 5 | Price alert CRUD (add, delete, enable, disable, list) |
+| **Screener** | 5 | Stock screener search, indicators, and strategy recommendation/management |
 | **ATM** | 3 | Bank cards, withdrawal records, deposit records |
 | **Portfolio** | 3 | Exchange rates, profit/loss analysis with optional date range |
+| **Macrodata** | 2 | Macroeconomic indicator list and detail data |
 | **Search** | 2 | News search, community topic search |
 | **Statement** | 2 | Account statement listing and export |
+| **Authenticate** | 1 | OAuth authorization-code exchange for MCP-native clients that can't complete a browser redirect |
 | **Calendar** | 1 | Finance calendar events (earnings, dividends, IPOs, macro data, market closures) |
+| **Quant** | 1 | Run a quant indicator script against historical K-line data server-side |
 | **Utility** | 1 | Current UTC time |
 
 ## Prometheus Metrics

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,11 +58,13 @@ src/
 ├── error.rs                Unified error type (thiserror)
 ├── counter.rs              Symbol ↔ counter_id bidirectional conversion
 ├── metrics.rs              Prometheus metrics and /metrics handler
+├── ws_pool.rs              Cached QuoteContext pool (idle TTL, capacity eviction)
 │
 ├── auth/
 │   ├── mod.rs              Router composition, AppState, MCP service wiring
 │   ├── metadata.rs         /.well-known/oauth-protected-resource (RFC 9728)
-│   └── middleware.rs       Bearer token extraction middleware
+│   ├── middleware.rs       Bearer token extraction middleware
+│   └── landing.html        Landing page served at `/` for browser visitors
 │
 ├── serialize/
 │   ├── mod.rs              Public API: to_tool_json(), transform_json()
@@ -71,18 +73,40 @@ src/
 │   └── counter_id.rs       CounterIdSerializer (counter_id → symbol)
 │
 └── tools/
-    ├── mod.rs              McpContext, #[tool_router], forwarding layer
-    ├── parse.rs            Parameter parsing helpers
-    ├── http_client.rs      Shared HTTP request helpers
-    ├── quote.rs            SDK QuoteContext tools (29)
-    ├── trade.rs            SDK TradeContext tools (14)
-    ├── fundamental.rs      HTTP fundamental data tools (18)
-    ├── market.rs           HTTP market data tools (9)
-    ├── content.rs          SDK ContentContext + HTTP content tools (8)
-    ├── alert.rs            HTTP price alert tools (5)
-    ├── portfolio.rs        HTTP portfolio tools (3)
-    ├── statement.rs        HTTP account statement tools (2)
-    └── calendar.rs         HTTP finance calendar tool (1)
+    ├── mod.rs              McpContext, #[tool_router], forwarding layer, TOOL_ENDPOINTS
+    ├── quote.rs            Quote tools (32)
+    ├── fundamental.rs      Fundamental data tools (31)
+    ├── trade.rs            Trade tools (15)
+    ├── market.rs           Market data tools (14)
+    ├── dca.rs              Dollar-cost averaging tools (9)
+    ├── sharelist.rs        Community sharelist tools (8)
+    ├── ipo.rs              IPO tools (7)
+    ├── content.rs          News/discussion tools (6)
+    ├── alert.rs            Price alert tools (5)
+    ├── screener.rs         Stock screener tools (5)
+    ├── portfolio.rs        Portfolio tools (3)
+    ├── atm.rs              ATM/bank card tools (3)
+    ├── macrodata.rs        Macroeconomic indicator tools (2)
+    ├── search.rs           Search tools (2)
+    ├── statement.rs        Account statement tools (2)
+    ├── authenticate.rs     Self-service OAuth code exchange tool (1)
+    ├── calendar.rs         Finance calendar tool (1)
+    ├── quant.rs            Quant indicator script tool (1)
+    │
+    ├── output/             Typed output schemas for tools with a known post-transform shape
+    │   ├── mod.rs
+    │   ├── account.rs
+    │   ├── discovery.rs
+    │   ├── fundamental.rs
+    │   ├── market.rs
+    │   ├── quote.rs
+    │   └── social.rs
+    │
+    └── support/            Shared plumbing, not MCP tools themselves
+        ├── mod.rs
+        ├── http_client.rs  Shared HTTP request helpers
+        ├── parse.rs        Parameter parsing helpers
+        └── tolerant.rs     Lenient deserializers for loosely-typed client input
 ```
 
 ## Authentication
@@ -170,17 +194,27 @@ for the `depth` tool, including field descriptions.
 
 | Module | Count | Data Source | Description |
 |--------|-------|-------------|-------------|
-| `quote` | 29 | SDK `QuoteContext` | Quotes, candlesticks, depth, options, warrants, watchlists, capital flow |
-| `trade` | 14 | SDK `TradeContext` | Orders, positions, balance, executions, margin |
-| `fundamental` | 18 | HTTP `/v1/quote/*` | Financial reports, ratings, valuations, company info |
-| `market` | 9 | HTTP `/v1/quote/*` | Broker holdings, A/H premium, anomalies, index constituents |
-| `content` | 8 | SDK + HTTP | News, topics, filings, community posts |
+| `quote` | 32 | SDK `QuoteContext` + HTTP `/v1/quote/*` | Quotes, candlesticks, depth, brokers, options, warrants, watchlists, capital flow |
+| `fundamental` | 31 | HTTP `/v1/quote/*` | Financial reports/statements, ratings, valuations, company info, shareholders, corporate actions |
+| `trade` | 15 | SDK `TradeContext` | Orders, positions, balance, executions, margin |
+| `market` | 14 | HTTP `/v1/quote/*` | Broker holdings, A/H premium, anomalies, top movers, short trades, index constituents |
+| `dca` | 9 | HTTP `/v1/dailycoins/*` | Dollar-cost averaging plan CRUD, execution history, statistics |
+| `sharelist` | 8 | HTTP `/v1/sharelists/*` | Community sharelist CRUD, member management, popular lists |
+| `ipo` | 7 | HTTP `/v1/ipo/*` | IPO subscriptions, calendar, listed stocks, profit/loss analysis |
+| `content` | 6 | SDK `ContentContext` | News, discussion topic CRUD and replies |
 | `alert` | 5 | HTTP `/v1/notify/*` | Price alert CRUD |
-| `portfolio` | 3 | HTTP `/v1/portfolio/*` | Exchange rates, P&L analysis |
-| `statement` | 2 | HTTP `/v1/asset/*` | Account statement listing and export |
+| `screener` | 5 | HTTP `/v1/quote/*` | Stock screener search, indicators, strategy recommendation/management |
+| `portfolio` | 3 | HTTP `/v1/portfolio/*` + `/v1/asset/*` | Exchange rates, P&L analysis |
+| `atm` | 3 | HTTP `/v1/account/*` | Bank cards, withdrawal/deposit records |
+| `macrodata` | 2 | SDK `FundamentalContext` | Macroeconomic indicator list and detail data |
+| `search` | 2 | HTTP `/v1/search/*` | News search, community topic search |
+| `statement` | 2 | SDK `AssetContext` | Account statement listing and export |
+| `authenticate` | 1 | OAuth authorization-code exchange | Self-service auth for MCP-native clients that can't complete a browser redirect |
 | `calendar` | 1 | HTTP `/v1/quote/*` | Finance calendar events |
+| `quant` | 1 | HTTP `/v1/quant/*` | Run a quant indicator script against historical K-line data server-side |
+| `utility` | 1 | none | Current UTC time |
 
-SDK tools create `QuoteContext`/`TradeContext`/`ContentContext` per request (WebSocket-based). HTTP tools use the authenticated `HttpClient` for REST calls. Both paths produce JSON that flows through the same `TransformSerializer`.
+SDK tools create `QuoteContext`/`TradeContext`/`ContentContext`/`AssetContext`/`FundamentalContext` per request (`QuoteContext` is WebSocket-based and cached; the rest are per-request). HTTP tools use the authenticated `HttpClient` for REST calls. Both paths produce JSON that flows through the same `TransformSerializer`.
 
 ## Symbol Mapping
 

--- a/server.json
+++ b/server.json
@@ -92,9 +92,9 @@
         }
       },
       "localizedDescriptions": {
-        "en": "Longbridge — official MCP server for the Longbridge brokerage. 145 tools across real-time quotes, options, order routing, fundamentals, stock screener, shareholders, short selling, IPO, calendars, alerts, DCA and portfolio analytics for US / HK markets.",
-        "zh-CN": "长桥证券官方 MCP 服务：145 个工具覆盖美股 / 港股的实时行情、期权、下单路由、基本面、选股器、股东持仓、卖空数据、IPO 打新、财报日历、价格预警、定投计划与组合分析。",
-        "zh-HK": "長橋證券官方 MCP 伺服器：145 個工具覆蓋美股 / 港股的即時行情、期權、下單路由、基本面、選股器、股東持倉、賣空數據、IPO 打新、財報日曆、價格警示、定投計劃與組合分析。"
+        "en": "Longbridge — official MCP server for the Longbridge brokerage. 148 tools across real-time quotes, options, order routing, fundamentals, stock screener, shareholders, short selling, IPO, calendars, alerts, DCA and portfolio analytics for US / HK markets.",
+        "zh-CN": "长桥证券官方 MCP 服务：148 个工具覆盖美股 / 港股的实时行情、期权、下单路由、基本面、选股器、股东持仓、卖空数据、IPO 打新、财报日历、价格预警、定投计划与组合分析。",
+        "zh-HK": "長橋證券官方 MCP 伺服器：148 個工具覆蓋美股 / 港股的即時行情、期權、下單路由、基本面、選股器、股東持倉、賣空數據、IPO 打新、財報日曆、價格警示、定投計劃與組合分析。"
       },
       "icons": [
         {
@@ -138,7 +138,7 @@
           "name": "Hong Kong"
         }
       ],
-      "toolCount": 145,
+      "toolCount": 148,
       "toolCategories": {
         "quote": 32,
         "fundamental": 22,

--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.longbridge/mcp",
-  "description": "US/HK markets — 145 tools: quotes, options, orders, fundamentals, screener, IPO, alerts & DCA",
-  "version": "0.7.1",
+  "description": "US/HK markets — 148 tools: quotes, options, orders, fundamentals, screener, IPO, alerts & DCA",
+  "version": "0.7.2",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"


### PR DESCRIPTION
## Summary
- Bumps `Cargo.toml`/`Cargo.lock` version 0.7.1 → 0.7.2
- Refreshes `server.json`'s stale tool-count description (145 → 148, matching the live `/mcp` endpoint)

Since v0.7.1, main picked up:
- #99 X-Host OAuth metadata routing for global entry hosts
- #100 / #101 independent canary Docker build workflow
- #102 landing page URL fix for global entry hosts

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-features --all-targets`
- [x] `cargo test` (106 passed)
- [x] Verified live tool count via `/mcp/tools.json` (148)