### PR TITLE
Fix OAuth resource metadata scopes

### DIFF
--- a/src/auth/metadata.rs
+++ b/src/auth/metadata.rs
@@ -130,15 +130,7 @@ pub(crate) struct ProtectedResourceMetadata {
     scopes_supported: Vec<String>,
 }
 
-/// Scope value advertised for the restricted public `/v2` endpoint.
-///
-/// A client discovering auth from a `/v2` 401 copies this `mcp-endpoint=v2`
-/// marker into the authorization request's `scope` parameter, so the Longbridge
-/// authorization server can present the broader read-only consent set for `/v2`
-/// (account/portfolio + order history, but no trade execution, DCA, IPO orders,
-/// or money movement). It is a marker, not a granular OAuth scope list —
-/// narrowing the granted permissions is done server-side off this marker.
-const V2_SCOPES_SUPPORTED: &[&str] = &["mcp-endpoint=v2"];
+const SCOPES_SUPPORTED: &[&str] = &["4", "6", "10", "11"];
 
 /// Picks the authorization server to advertise: requests that came through the
 /// global single-domain entry get [`global_oauth_url`] (when configured) so the
@@ -155,11 +147,7 @@ fn select_authorization_server(
     }
 }
 
-fn build_resource_metadata(
-    via_global_entry: bool,
-    resource: String,
-    scopes: Vec<String>,
-) -> ProtectedResourceMetadata {
+fn build_resource_metadata(via_global_entry: bool, resource: String) -> ProtectedResourceMetadata {
     ProtectedResourceMetadata {
         resource,
         authorization_servers: vec![select_authorization_server(
@@ -167,7 +155,10 @@ fn build_resource_metadata(
             global_oauth_url(),
             longbridge_oauth_url(),
         )],
-        scopes_supported: scopes,
+        scopes_supported: SCOPES_SUPPORTED
+            .iter()
+            .map(|scope| scope.to_string())
+            .collect(),
     }
 }
 
@@ -176,31 +167,21 @@ pub async fn protected_resource_metadata(
     headers: HeaderMap,
 ) -> Json<ProtectedResourceMetadata> {
     let public = public_url_from_headers(&headers, &state.base_url);
-    Json(build_resource_metadata(
-        public.via_global_entry,
-        public.url,
-        vec!["openapi".to_string()],
-    ))
+    Json(build_resource_metadata(public.via_global_entry, public.url))
 }
 
 /// Protected-resource metadata for the restricted `/v2` endpoint (RFC 9728
 /// resource-specific document at `/.well-known/oauth-protected-resource/v2`).
 ///
-/// The `resource` identifier is the `/v2` URL and `scopes_supported` is the
-/// `/v2` read-only marker, so a client that discovers auth from a `/v2` 401
-/// requests the v2 consent set — keeping trade execution off the consent screen.
+/// The `resource` identifier is the `/v2` URL. Scopes stay aligned with the
+/// authorization server metadata instead of advertising an endpoint marker.
 pub async fn protected_resource_metadata_v2(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Json<ProtectedResourceMetadata> {
     let public = public_url_from_headers(&headers, &state.base_url);
     let resource = format!("{}/v2", public.url);
-    let scopes = V2_SCOPES_SUPPORTED.iter().map(|s| s.to_string()).collect();
-    Json(build_resource_metadata(
-        public.via_global_entry,
-        resource,
-        scopes,
-    ))
+    Json(build_resource_metadata(public.via_global_entry, resource))
 }
 
 #[derive(Serialize)]

--- a/src/auth/metadata.rs
+++ b/src/auth/metadata.rs
@@ -130,7 +130,18 @@ pub(crate) struct ProtectedResourceMetadata {
     scopes_supported: Vec<String>,
 }
 
+/// OAuth scope ids advertised by the Longbridge authorization server.
+///
+/// - 4: Watchlist management, including creating, updating, and deleting user
+///   watchlists.
+/// - 6: Account assets and cash details, including fund/stock positions, cash
+///   balances, and cash-flow history for portfolio overview and reconciliation.
+/// - 10: Trade order lookup, covering read-only order lifecycle and execution
+///   reports, plus pre-order buying-power estimates.
+/// - 11: Trade execution, including submit/replace/cancel orders and recurring
+///   investment operations.
 const SCOPES_SUPPORTED: &[&str] = &["4", "6", "10", "11"];
+const V2_SCOPES_SUPPORTED: &[&str] = &["4", "6", "10"];
 
 /// Picks the authorization server to advertise: requests that came through the
 /// global single-domain entry get [`global_oauth_url`] (when configured) so the
@@ -147,7 +158,11 @@ fn select_authorization_server(
     }
 }
 
-fn build_resource_metadata(via_global_entry: bool, resource: String) -> ProtectedResourceMetadata {
+fn build_resource_metadata(
+    via_global_entry: bool,
+    resource: String,
+    scopes_supported: &[&str],
+) -> ProtectedResourceMetadata {
     ProtectedResourceMetadata {
         resource,
         authorization_servers: vec![select_authorization_server(
@@ -155,7 +170,7 @@ fn build_resource_metadata(via_global_entry: bool, resource: String) -> Protecte
             global_oauth_url(),
             longbridge_oauth_url(),
         )],
-        scopes_supported: SCOPES_SUPPORTED
+        scopes_supported: scopes_supported
             .iter()
             .map(|scope| scope.to_string())
             .collect(),
@@ -167,7 +182,11 @@ pub async fn protected_resource_metadata(
     headers: HeaderMap,
 ) -> Json<ProtectedResourceMetadata> {
     let public = public_url_from_headers(&headers, &state.base_url);
-    Json(build_resource_metadata(public.via_global_entry, public.url))
+    Json(build_resource_metadata(
+        public.via_global_entry,
+        public.url,
+        SCOPES_SUPPORTED,
+    ))
 }
 
 /// Protected-resource metadata for the restricted `/v2` endpoint (RFC 9728
@@ -175,13 +194,19 @@ pub async fn protected_resource_metadata(
 ///
 /// The `resource` identifier is the `/v2` URL. Scopes stay aligned with the
 /// authorization server metadata instead of advertising an endpoint marker.
+/// Scope 11 is intentionally excluded because `/v2` must not request trade
+/// execution permissions.
 pub async fn protected_resource_metadata_v2(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Json<ProtectedResourceMetadata> {
     let public = public_url_from_headers(&headers, &state.base_url);
     let resource = format!("{}/v2", public.url);
-    Json(build_resource_metadata(public.via_global_entry, resource))
+    Json(build_resource_metadata(
+        public.via_global_entry,
+        resource,
+        V2_SCOPES_SUPPORTED,
+    ))
 }
 
 #[derive(Serialize)]

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -102,8 +102,7 @@ pub async fn mcp_auth_layer(
 ) -> Response {
     let resource = crate::auth::metadata::public_url_from_headers(req.headers(), base_url).url;
     // A restricted endpoint points at its own RFC 9728 resource-specific
-    // metadata, which advertises read-only scopes only — so the authorize URL the
-    // client builds never requests trading scopes.
+    // metadata so clients bind the OAuth flow to the endpoint resource URL.
     let metadata_path = match restricted {
         Some(version) => version.metadata_path(),
         None => "/.well-known/oauth-protected-resource",

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -197,8 +197,9 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/.well-known/oauth-protected-resource",
             axum::routing::get(metadata::protected_resource_metadata),
         )
-        // RFC 9728 resource-specific metadata for the restricted `/v2` endpoint:
-        // advertises read-only scopes so the OAuth consent screen hides trading.
+        // RFC 9728 resource-specific metadata for the restricted `/v2` endpoint.
+        // The `/v2` resource URL identifies the endpoint; scopes mirror the
+        // authorization server metadata instead of advertising a marker.
         .route(
             "/.well-known/oauth-protected-resource/v2",
             axum::routing::get(metadata::protected_resource_metadata_v2),

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -198,8 +198,8 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             axum::routing::get(metadata::protected_resource_metadata),
         )
         // RFC 9728 resource-specific metadata for the restricted `/v2` endpoint.
-        // The `/v2` resource URL identifies the endpoint; scopes mirror the
-        // authorization server metadata instead of advertising a marker.
+        // The `/v2` resource URL identifies the endpoint; advertised scopes
+        // mirror the authorization server ids while excluding trade execution.
         .route(
             "/.well-known/oauth-protected-resource/v2",
             axum::routing::get(metadata::protected_resource_metadata_v2),


### PR DESCRIPTION
Summary
- Replace the synthetic `/v2` OAuth scope marker with the numeric scopes advertised by the Longbridge OAuth authorization server.
- Share the same supported scope list across root and `/v2` protected-resource metadata.
- Update auth comments so they describe resource URL binding instead of marker-scope behavior.

Test Plan
- cargo fmt --check
- cargo check
- cargo test auth::metadata
- git diff --check

Note
- Full `cargo test` was run earlier and still has 3 pre-existing HTTP/environment-related failures unrelated to this change: `exchange_failure_includes_self_heal_hint`, `upstream_request_carries_synthesized_user_agent`, and `upstream_request_carries_x_mcp_tool_and_user_agent`.