### PR TITLE
fix(auth): proxy OAuth token requests by DC region

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,6 +1573,7 @@ dependencies = [
  "serde",
  "serde-transcode",
  "serde_json",
+ "serde_urlencoded",
  "sha2",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1", features = [
 ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+serde_urlencoded = "0.7"
 schemars = "1"
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Official MCP server for the [Longbridge](https://longbridge.com) brokerage. **14
 
 - **148 MCP tools** across 19 categories: quotes, fundamentals, trading, market data, DCA, IPO, sharelists, content, alerts, screener, ATM, portfolio, macrodata, search, statements, authenticate, calendar, quant, and utility
 - **Stateless architecture** -- each request carries a Bearer token forwarded directly to the Longbridge SDK; no server-side sessions or database
-- **OAuth 2.1 resource metadata** compliant with RFC 9728, pointing clients to Longbridge OAuth for authorization
+- **OAuth 2.1 metadata** — RFC 9728 protected-resource + RFC 8414 authorization-server facade; browser authorization stays direct while `token`/`revoke` pass through this server to attach Longbridge's DC routing header
 - **JSON response transformation** -- field names normalized to snake_case, timestamps converted to RFC 3339, internal counter_id values mapped to human-readable symbols
 - **Compact tool metadata** -- typed `outputSchema` descriptors stay in `tools/list` for compatible clients, redundant return-field prose is trimmed, and full verbose schemas are available as MCP resources under `lb://tools/{tool}/output-schema`
 - **Prometheus metrics** for monitoring tool calls, latency, and errors
@@ -171,6 +171,9 @@ On the first tool invocation, Claude Code reads the `WWW-Authenticate` challenge
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/.well-known/oauth-protected-resource` | Protected Resource Metadata (RFC 9728) |
+| GET | `/.well-known/oauth-authorization-server` | Authorization Server Metadata (RFC 8414); advertises direct Longbridge authorize/register and proxied token/revoke endpoints |
+| POST | `/oauth2/token` | OAuth token proxy; derives `x-dc-region` from the code/refresh token, defaulting to AP |
+| POST | `/oauth2/revoke` | OAuth revocation proxy; derives `x-dc-region` from the token, defaulting to AP |
 | GET | `/metrics` | Prometheus metrics |
 | POST/GET/DELETE | `/mcp` | MCP Streamable HTTP endpoint (requires Bearer token) |
 

--- a/src/auth/metadata.rs
+++ b/src/auth/metadata.rs
@@ -147,7 +147,7 @@ const V2_SCOPES_SUPPORTED: &[&str] = &["4", "6", "10"];
 /// global single-domain entry get [`global_oauth_url`] (when configured) so the
 /// whole OAuth bootstrap stays on the global domains; everything else keeps the
 /// per-DC [`longbridge_oauth_url`].
-fn select_authorization_server(
+pub(crate) fn select_authorization_server(
     via_global_entry: bool,
     global: Option<String>,
     fallback: String,
@@ -159,17 +159,13 @@ fn select_authorization_server(
 }
 
 fn build_resource_metadata(
-    via_global_entry: bool,
+    authorization_server: String,
     resource: String,
     scopes_supported: &[&str],
 ) -> ProtectedResourceMetadata {
     ProtectedResourceMetadata {
         resource,
-        authorization_servers: vec![select_authorization_server(
-            via_global_entry,
-            global_oauth_url(),
-            longbridge_oauth_url(),
-        )],
+        authorization_servers: vec![authorization_server],
         scopes_supported: scopes_supported
             .iter()
             .map(|scope| scope.to_string())
@@ -183,7 +179,7 @@ pub async fn protected_resource_metadata(
 ) -> Json<ProtectedResourceMetadata> {
     let public = public_url_from_headers(&headers, &state.base_url);
     Json(build_resource_metadata(
-        public.via_global_entry,
+        public.url.clone(),
         public.url,
         SCOPES_SUPPORTED,
     ))
@@ -203,10 +199,65 @@ pub async fn protected_resource_metadata_v2(
     let public = public_url_from_headers(&headers, &state.base_url);
     let resource = format!("{}/v2", public.url);
     Json(build_resource_metadata(
-        public.via_global_entry,
+        public.url,
         resource,
         V2_SCOPES_SUPPORTED,
     ))
+}
+
+/// Longbridge OAuth upstream selected for this public entry point.
+pub(crate) fn oauth_upstream_url(via_global_entry: bool) -> String {
+    select_authorization_server(via_global_entry, global_oauth_url(), longbridge_oauth_url())
+}
+
+/// RFC 8414 metadata for the minimal OAuth facade hosted by this MCP server.
+/// Authorization and registration remain direct Longbridge endpoints; only
+/// token exchange and revocation return through this server so it can attach
+/// Longbridge's private DC routing header.
+#[derive(Serialize)]
+pub(crate) struct AuthorizationServerMetadata {
+    issuer: String,
+    authorization_endpoint: String,
+    token_endpoint: String,
+    revocation_endpoint: String,
+    registration_endpoint: String,
+    jwks_uri: String,
+    scopes_supported: Vec<String>,
+    response_types_supported: Vec<&'static str>,
+    grant_types_supported: Vec<&'static str>,
+    token_endpoint_auth_methods_supported: Vec<&'static str>,
+    code_challenge_methods_supported: Vec<&'static str>,
+}
+
+fn build_authorization_server_metadata(
+    issuer: String,
+    upstream: String,
+) -> AuthorizationServerMetadata {
+    let issuer = issuer.trim_end_matches('/');
+    let upstream = upstream.trim_end_matches('/');
+    AuthorizationServerMetadata {
+        issuer: issuer.to_string(),
+        authorization_endpoint: format!("{upstream}/oauth2/authorize"),
+        token_endpoint: format!("{issuer}/oauth2/token"),
+        revocation_endpoint: format!("{issuer}/oauth2/revoke"),
+        registration_endpoint: format!("{upstream}/oauth2/register"),
+        jwks_uri: format!("{upstream}/.well-known/jwks.json"),
+        scopes_supported: SCOPES_SUPPORTED.iter().map(|s| s.to_string()).collect(),
+        response_types_supported: vec!["code"],
+        grant_types_supported: vec!["authorization_code", "refresh_token"],
+        token_endpoint_auth_methods_supported: vec!["none"],
+        code_challenge_methods_supported: vec!["S256", "plain"],
+    }
+}
+
+/// Serve the MCP OAuth facade's RFC 8414 authorization-server metadata.
+pub async fn authorization_server_metadata(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Json<AuthorizationServerMetadata> {
+    let public = public_url_from_headers(&headers, &state.base_url);
+    let upstream = oauth_upstream_url(public.via_global_entry);
+    Json(build_authorization_server_metadata(public.url, upstream))
 }
 
 #[derive(Serialize)]
@@ -390,6 +441,32 @@ mod tests {
         assert_eq!(
             select_authorization_server(false, global(), fallback()),
             fallback()
+        );
+    }
+
+    #[test]
+    fn oauth_facade_only_proxies_credential_bearing_endpoints() {
+        let metadata = build_authorization_server_metadata(
+            "https://mcp.longbridge.com/".to_string(),
+            "https://openapi.longbridge.com/".to_string(),
+        );
+
+        assert_eq!(metadata.issuer, "https://mcp.longbridge.com");
+        assert_eq!(
+            metadata.authorization_endpoint,
+            "https://openapi.longbridge.com/oauth2/authorize"
+        );
+        assert_eq!(
+            metadata.registration_endpoint,
+            "https://openapi.longbridge.com/oauth2/register"
+        );
+        assert_eq!(
+            metadata.token_endpoint,
+            "https://mcp.longbridge.com/oauth2/token"
+        );
+        assert_eq!(
+            metadata.revocation_endpoint,
+            "https://mcp.longbridge.com/oauth2/revoke"
         );
     }
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,5 +1,6 @@
 pub mod metadata;
 pub mod middleware;
+mod oauth_proxy;
 
 use std::sync::Arc;
 
@@ -204,6 +205,10 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/.well-known/oauth-protected-resource/v2",
             axum::routing::get(metadata::protected_resource_metadata_v2),
         )
+        .route(
+            "/.well-known/oauth-authorization-server",
+            axum::routing::get(metadata::authorization_server_metadata),
+        )
         .with_state(state.clone());
 
     // Serve the static server card at both the host-root path Smithery's docs
@@ -236,6 +241,11 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/mcp/scopes.json", axum::routing::get(scopes_json))
         // Restricted public manifest for the `/v2` endpoint (allowlist only).
         .route("/v2/tools.json", axum::routing::get(v2_tools_json));
+
+    let oauth_proxy_routes: Router = Router::new()
+        .route("/oauth2/token", axum::routing::post(oauth_proxy::token))
+        .route("/oauth2/revoke", axum::routing::post(oauth_proxy::revoke))
+        .with_state(state.clone());
 
     // Build an auth-wrapped MCP service for one mounting point. The same
     // `Longbridge` MCP server is mounted several times; the only thing that
@@ -303,6 +313,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .merge(openai_apps_challenge_route)
         .merge(metrics_route)
         .merge(tools_route)
+        .merge(oauth_proxy_routes)
         .nest_service("/agent", mcp_agent)
         .nest_service("/v2", mcp_v2)
         .nest_service("/mcp", mcp_with_auth)

--- a/src/auth/oauth_proxy.rs
+++ b/src/auth/oauth_proxy.rs
@@ -1,0 +1,207 @@
+//! Minimal OAuth token and revocation proxy.
+//!
+//! Authorization, dynamic registration, and browser callbacks stay directly
+//! between the MCP client and Longbridge. Only credential-bearing POSTs pass
+//! through this module so the server can derive and attach `x-dc-region`.
+
+use std::sync::{Arc, LazyLock};
+use std::time::Duration;
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use longbridge::DcRegion;
+
+use crate::auth::AppState;
+use crate::auth::metadata::{oauth_upstream_url, public_url_from_headers};
+
+static OAUTH_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .user_agent(concat!("longbridge-mcp/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .expect("failed to build upstream OAuth HTTP client")
+});
+
+const TOKEN_CREDENTIALS: &[&str] = &["refresh_token", "code"];
+const REVOKE_CREDENTIALS: &[&str] = &["token"];
+
+/// Proxy a token exchange and attach the region derived from its credential.
+pub async fn token(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    forward(&state, &headers, "/oauth2/token", TOKEN_CREDENTIALS, body).await
+}
+
+/// Proxy token revocation and attach the region derived from the token.
+pub async fn revoke(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    forward(&state, &headers, "/oauth2/revoke", REVOKE_CREDENTIALS, body).await
+}
+
+fn derive_region(pairs: &[(String, String)], credential_fields: &[&str]) -> DcRegion {
+    credential_fields
+        .iter()
+        .find_map(|name| {
+            pairs
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| DcRegion::from_credential(value))
+        })
+        .unwrap_or(DcRegion::Ap)
+}
+
+async fn forward(
+    state: &AppState,
+    headers: &HeaderMap,
+    upstream_path: &str,
+    credential_fields: &[&str],
+    body: Bytes,
+) -> Response {
+    let region = serde_urlencoded::from_bytes::<Vec<(String, String)>>(&body)
+        .map(|pairs| derive_region(&pairs, credential_fields))
+        .unwrap_or(DcRegion::Ap);
+    let public = public_url_from_headers(headers, &state.base_url);
+    let upstream = oauth_upstream_url(public.via_global_entry);
+    let url = format!("{}{upstream_path}", upstream.trim_end_matches('/'));
+
+    match upstream_request(&url, region, body).send().await {
+        Ok(response) => relay(response).await,
+        Err(error) => (
+            StatusCode::BAD_GATEWAY,
+            format!("upstream OAuth request failed: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+fn upstream_request(url: &str, region: DcRegion, body: Bytes) -> reqwest::RequestBuilder {
+    OAUTH_HTTP_CLIENT
+        .post(url)
+        .header(
+            header::CONTENT_TYPE.as_str(),
+            "application/x-www-form-urlencoded",
+        )
+        .header(longbridge::DC_REGION_HEADER, region.as_str())
+        .body(body)
+}
+
+async fn relay(upstream: reqwest::Response) -> Response {
+    let status =
+        StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let content_type = upstream
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("application/json")
+        .to_string();
+    let body = upstream.bytes().await.unwrap_or_default();
+    (
+        status,
+        [
+            (header::CONTENT_TYPE, content_type),
+            (header::CACHE_CONTROL, "no-store".to_string()),
+            (header::PRAGMA, "no-cache".to_string()),
+        ],
+        body,
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pairs(values: &[(&str, &str)]) -> Vec<(String, String)> {
+        values
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn token_region_uses_refresh_token_before_code() {
+        let form = pairs(&[("code", "ap_code"), ("refresh_token", "us_refresh")]);
+        assert_eq!(derive_region(&form, TOKEN_CREDENTIALS), DcRegion::Us);
+    }
+
+    #[test]
+    fn token_region_uses_authorization_code() {
+        let form = pairs(&[("code", "us_code")]);
+        assert_eq!(derive_region(&form, TOKEN_CREDENTIALS), DcRegion::Us);
+    }
+
+    #[test]
+    fn revoke_region_uses_token() {
+        let form = pairs(&[("token", "us_access_token")]);
+        assert_eq!(derive_region(&form, REVOKE_CREDENTIALS), DcRegion::Us);
+    }
+
+    #[test]
+    fn unrecognized_or_missing_credential_defaults_to_ap() {
+        assert_eq!(
+            derive_region(&pairs(&[("code", "opaque")]), TOKEN_CREDENTIALS),
+            DcRegion::Ap
+        );
+        assert_eq!(derive_region(&[], TOKEN_CREDENTIALS), DcRegion::Ap);
+    }
+
+    #[test]
+    fn upstream_request_adds_region_without_rewriting_form_body() {
+        let body = Bytes::from_static(
+            b"grant_type=authorization_code&code=us_code&redirect_uri=http%3A%2F%2F127.0.0.1%3A1234%2Fcallback",
+        );
+        let request = upstream_request(
+            "https://openapi.longbridge.com/oauth2/token",
+            DcRegion::Us,
+            body.clone(),
+        )
+        .build()
+        .expect("OAuth proxy request should build");
+
+        assert_eq!(
+            request
+                .headers()
+                .get(longbridge::DC_REGION_HEADER)
+                .expect("DC region header should be present"),
+            "us"
+        );
+        assert_eq!(
+            request.body().and_then(reqwest::Body::as_bytes),
+            Some(body.as_ref())
+        );
+    }
+
+    #[test]
+    fn malformed_form_defaults_to_ap_without_changing_bytes() {
+        let body = Bytes::from_static(b"code=%GG&redirect_uri=http://127.0.0.1/callback");
+        let region = serde_urlencoded::from_bytes::<Vec<(String, String)>>(&body)
+            .map(|pairs| derive_region(&pairs, TOKEN_CREDENTIALS))
+            .unwrap_or(DcRegion::Ap);
+        let request = upstream_request(
+            "https://openapi.longbridge.com/oauth2/token",
+            region,
+            body.clone(),
+        )
+        .build()
+        .expect("OAuth proxy request should build");
+
+        assert_eq!(
+            request
+                .headers()
+                .get(longbridge::DC_REGION_HEADER)
+                .expect("DC region header should be present"),
+            "ap"
+        );
+        assert_eq!(
+            request.body().and_then(reqwest::Body::as_bytes),
+            Some(body.as_ref())
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Make the MCP public URL an RFC 8414 authorization-server facade while keeping browser authorization, dynamic registration, callbacks, and JWKS requests directly on Longbridge OAuth.
- Proxy only credential-bearing `/oauth2/token` and `/oauth2/revoke` requests through MCP so it can attach the private `x-dc-region` routing header that Codex and Claude Code do not send.
- Derive the region from `refresh_token` before `code` for token requests, and from `token` for revocation; missing, malformed, or unrecognized credentials intentionally default to AP.
- Preserve the original form body byte-for-byte and relay the upstream status/body with OAuth cache-prevention headers.
- Document the facade endpoints and add focused metadata, region-selection, header, and body-preservation tests.

## Callback validation and proxy boundary

OAuth dynamic client registration includes the client's loopback callback/`redirect_uri`, and the original OAuth server validates later authorization and token requests against that registered value. AP and US share the OAuth `client_id` registration, so DC-specific client registration is not required.

This facade deliberately keeps callback-sensitive stages on the original OAuth service:

- `registration_endpoint` points directly to Longbridge.
- `authorization_endpoint` points directly to Longbridge.
- The browser callback remains directly between Longbridge and the MCP client.
- MCP proxies only token/revoke; it does not insert an intermediate callback or rewrite `redirect_uri`.
- The token form body is forwarded byte-for-byte, preserving the exact registered `redirect_uri` for upstream validation.

A full authorize/callback proxy would require registering or translating the proxy callback and would fail callback validation without additional state. This PR avoids that design.

## Web routing boundary

Browser confirmation already selects a DC-specific forward host:

- US: `mr.longbridge.com`
- AP: `mr.lbkrs.com`

The destination host determines the Web DC. Developers Web must not send the private `x-dc-region` header; doing so can be rejected by the edge/WAF with HTTP 403. The Web header change was reverted separately.

After browser confirmation issues a code, Codex or Claude Code sends the token request without Longbridge's private routing header. MCP can derive the DC from that code and attach `x-dc-region` only to the server-to-server token request. Refresh and revocation use the same approach with their respective credentials.

## Endpoint layout

- RFC 9728 protected-resource metadata points clients to this MCP server as the authorization-server issuer.
- RFC 8414 metadata advertises Longbridge directly for `authorization_endpoint`, `registration_endpoint`, and `jwks_uri`.
- RFC 8414 metadata advertises this MCP server for `token_endpoint` and `revocation_endpoint`.
- The proxy selects the existing Longbridge OAuth upstream, derives the credential DC, and attaches `x-dc-region` only to token/revoke requests.

## Test Plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets`
- [x] `cargo test` — 136 passed, 0 failed, 3 ignored
- [x] Verify US-prefixed authorization codes, refresh tokens, and access tokens select `x-dc-region: us`
- [x] Verify missing, malformed, and unrecognized credentials select `x-dc-region: ap`
- [x] Verify the URL-encoded token request body, including `redirect_uri`, is forwarded without rewriting
- [ ] Retest dynamic registration, US browser authorization, callback validation, and CLI token exchange end to end
