### PR TITLE
fix: improve response diagnostics and landing metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 [[package]]
 name = "longbridge"
 version = "4.3.3"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#cf151b5cf5c7fd87af766657eaa03f9a689f80db"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#546212301251d4e559ab20605e847b020893edf9"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.3.3"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#cf151b5cf5c7fd87af766657eaa03f9a689f80db"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#546212301251d4e559ab20605e847b020893edf9"
 dependencies = [
  "bitflags 2.13.0",
  "num-traits",
@@ -1526,7 +1526,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.3.3"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#cf151b5cf5c7fd87af766657eaa03f9a689f80db"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#546212301251d4e559ab20605e847b020893edf9"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -1534,7 +1534,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.3.3"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#cf151b5cf5c7fd87af766657eaa03f9a689f80db"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#546212301251d4e559ab20605e847b020893edf9"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -1587,7 +1587,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.3.3"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#cf151b5cf5c7fd87af766657eaa03f9a689f80db"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#546212301251d4e559ab20605e847b020893edf9"
 dependencies = [
  "dirs",
  "futures-util",
@@ -1604,7 +1604,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.3.3"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#cf151b5cf5c7fd87af766657eaa03f9a689f80db"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#546212301251d4e559ab20605e847b020893edf9"
 dependencies = [
  "prost",
  "serde",
@@ -1613,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.3.3"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#cf151b5cf5c7fd87af766657eaa03f9a689f80db"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#546212301251d4e559ab20605e847b020893edf9"
 dependencies = [
  "byteorder",
  "flate2",

--- a/src/auth/landing.html
+++ b/src/auth/landing.html
@@ -138,6 +138,10 @@
             }
 
             footer {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 16px;
                 margin-top: 28px;
                 color: var(--muted);
                 font-size: 0.82rem;
@@ -194,7 +198,10 @@
                 — full setup, tool reference &amp; examples.
             </p>
 
-            <footer>© <a href="https://longbridge.com">Longbridge</a></footer>
+            <footer>
+                <span>© <a href="https://longbridge.com">Longbridge</a></span>
+                <span class="mono">v{{VERSION}}</span>
+            </footer>
         </div>
     </body>
 </html>

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -137,6 +137,9 @@ const LANDING_PAGE_HTML: &str = include_str!("landing.html");
 /// Must match the literal URL baked into `landing.html`'s onboarding snippets.
 const LANDING_PAGE_URL_PLACEHOLDER: &str = "https://mcp.longbridge.com";
 
+/// Replaced with the crate version embedded by Cargo at compile time.
+const LANDING_PAGE_VERSION_PLACEHOLDER: &str = "{{VERSION}}";
+
 /// Serve [`LANDING_PAGE_HTML`] only for a browser navigation to `/`
 /// (a `GET` whose `Accept` header asks for `text/html`). Every other request —
 /// JSON-RPC `POST`, the SSE `GET` with `Accept: text/event-stream`, `Accept:
@@ -167,7 +170,9 @@ async fn landing_or_mcp(
 
     if is_browser_root {
         let public = metadata::public_url_from_headers(req.headers(), &state.base_url);
-        let html = LANDING_PAGE_HTML.replace(LANDING_PAGE_URL_PLACEHOLDER, &public.url);
+        let html = LANDING_PAGE_HTML
+            .replace(LANDING_PAGE_URL_PLACEHOLDER, &public.url)
+            .replace(LANDING_PAGE_VERSION_PLACEHOLDER, env!("CARGO_PKG_VERSION"));
         return (
             [(axum::http::header::CONTENT_TYPE, "text/html; charset=utf-8")],
             html,
@@ -438,5 +443,19 @@ mod tests {
             .matches(super::LANDING_PAGE_URL_PLACEHOLDER)
             .count();
         assert_eq!(html.matches(dynamic_url).count(), expected_count);
+    }
+
+    #[test]
+    fn landing_page_version_matches_the_crate_version() {
+        assert!(
+            super::LANDING_PAGE_HTML.contains(super::LANDING_PAGE_VERSION_PLACEHOLDER),
+            "landing.html must contain the version placeholder"
+        );
+        let html = super::LANDING_PAGE_HTML.replace(
+            super::LANDING_PAGE_VERSION_PLACEHOLDER,
+            env!("CARGO_PKG_VERSION"),
+        );
+        assert!(!html.contains(super::LANDING_PAGE_VERSION_PLACEHOLDER));
+        assert!(html.contains(&format!("v{}", env!("CARGO_PKG_VERSION"))));
     }
 }


### PR DESCRIPTION
## Summary

- update all OpenAPI SDK crates to commit `54621230`, which preserves status, trace ID, response headers, and raw body for unexpected HTTP responses
- surface the MCP crate version in the browser landing-page footer
- replace the landing-page version placeholder at runtime and add regression coverage

With the updated SDK, intermediary failures such as HTTP 463 no longer collapse to a status-only error, making the original upstream response available for diagnosis.

## Test Plan

- `cargo fmt --check`
- `cargo test` — 133 passed, 3 ignored
- `git diff --check`