### PR TITLE
chore: update server.json to v0.8.4, 151 tools

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.longbridge/mcp",
-  "description": "US/HK markets — 148 tools: quotes, options, orders, fundamentals, screener, IPO, alerts & DCA",
-  "version": "0.7.2",
+  "description": "US/HK markets — 151 tools: quotes, options, orders, fundamentals, screener, IPO, alerts & DCA",
+  "version": "0.8.4",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.5.3",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.8.4",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",
@@ -92,9 +92,9 @@
         }
       },
       "localizedDescriptions": {
-        "en": "Longbridge — official MCP server for the Longbridge brokerage. 148 tools across real-time quotes, options, order routing, fundamentals, stock screener, shareholders, short selling, IPO, calendars, alerts, DCA and portfolio analytics for US / HK markets.",
-        "zh-CN": "长桥证券官方 MCP 服务：148 个工具覆盖美股 / 港股的实时行情、期权、下单路由、基本面、选股器、股东持仓、卖空数据、IPO 打新、财报日历、价格预警、定投计划与组合分析。",
-        "zh-HK": "長橋證券官方 MCP 伺服器：148 個工具覆蓋美股 / 港股的即時行情、期權、下單路由、基本面、選股器、股東持倉、賣空數據、IPO 打新、財報日曆、價格警示、定投計劃與組合分析。"
+        "en": "Longbridge — official MCP server for the Longbridge brokerage. 151 tools across real-time quotes, options, order routing, fundamentals, stock screener, shareholders, short selling, IPO, calendars, alerts, DCA and portfolio analytics for US / HK markets.",
+        "zh-CN": "长桥证券官方 MCP 服务：151 个工具覆盖美股 / 港股的实时行情、期权、下单路由、基本面、选股器、股东持仓、卖空数据、IPO 打新、财报日历、价格预警、定投计划与组合分析。",
+        "zh-HK": "長橋證券官方 MCP 伺服器：151 個工具覆蓋美股 / 港股的即時行情、期權、下單路由、基本面、選股器、股東持倉、賣空數據、IPO 打新、財報日曆、價格警示、定投計劃與組合分析。"
       },
       "icons": [
         {
@@ -138,10 +138,10 @@
           "name": "Hong Kong"
         }
       ],
-      "toolCount": 148,
+      "toolCount": 151,
       "toolCategories": {
         "quote": 32,
-        "fundamental": 22,
+        "fundamental": 24,
         "trade": 14,
         "market": 14,
         "screener": 5,
@@ -151,7 +151,7 @@
         "sharelist": 8,
         "alert": 5,
         "atm": 3,
-        "portfolio": 3,
+        "portfolio": 4,
         "search": 2,
         "statement": 2,
         "calendar": 1,


### PR DESCRIPTION
## Summary
- `server.json` was stale at v0.7.2 / 148 tools since it was last updated.
- Bumps `version` and the OCI package tag to `0.8.4` (just tagged and released — image confirmed built by the `docker` job in the release workflow run).
- Updates `toolCount`/`toolCategories`/description text to 151 tools, reflecting the 3 tools #98 added: `etf_docs`, `financial_report_key_metrics` (fundamental) and `profit_analysis_realized` (portfolio).

## Test plan
- `python3 -m json.tool server.json` (valid JSON)
- Confirmed `v0.8.4` tag + GHCR image were published by the release workflow before this change.