### PR TITLE
fix(logging): stop logging MCP request/response payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,24 @@ These are **advanced settings** — most users do not need to change them. They 
 | `LONGBRIDGE_TRADE_WS_URL` | `wss://openapi-trade.longbridge.com/v2` | Trade WebSocket endpoint |
 | `LONGBRIDGE_MCP_QUOTE_WS_IDLE_TTL_SECS` | `600` | Idle seconds before a cached quote WebSocket context is evicted |
 | `LONGBRIDGE_MCP_QUOTE_WS_MAX_CONTEXTS` | `1024` | Maximum cached quote WebSocket contexts per server process |
-| `LONGBRIDGE_LOG_PATH` | *(none)* | SDK internal log path |
+| `LONGBRIDGE_MCP_LOG_PAYLOADS` | *(unset)* | `1` lifts the payload log caps (see [Logging and customer data](#logging-and-customer-data)). Never set this in production |
+| `LONGBRIDGE_LOG_PATH` | *(none)* | SDK internal log path. **Leave unset in production** — the SDK writes unfiltered request/response bodies there (see [Logging and customer data](#logging-and-customer-data)) |
+
+## Logging and customer data
+
+MCP requests and responses carry customer data — cash balances, positions, order history — and the upstream SDK frames carry access tokens. None of it belongs in a log file, so the server enforces a cap on the log targets that would print it, independent of `RUST_LOG`:
+
+| Target | Cap | What it would otherwise print |
+|--------|-----|-------------------------------|
+| `longbridge_httpcli` | `warn` | OpenAPI request and full response bodies (INFO) |
+| `longbridge_wscli` | `warn` | Every WebSocket frame, auth token included (INFO) |
+| `longbridge::trade` | `warn` | Order push events (INFO) |
+| `rmcp` | `info` | Decoded MCP requests and full tool results (DEBUG), raw JSON-RPC frames (TRACE) |
+
+Raising verbosity is therefore safe: `RUST_LOG=debug` (or even `trace`) gives you this server's own logs without turning customer data into log lines. Two things do defeat it, both off by default:
+
+- `LONGBRIDGE_MCP_LOG_PAYLOADS=1` removes the caps. Use it only against a test account on a local machine.
+- `LONGBRIDGE_LOG_PATH` makes the SDK install a private subscriber that writes `longbridge*` INFO events — request and response bodies included — into that directory, where this server's filter does not apply. The server logs a warning at startup when it is set.
 
 ## Authentication
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,264 @@
+//! Tracing setup, including the hard caps that keep customer data out of the
+//! log files.
+//!
+//! Several dependencies log complete request/response payloads:
+//!
+//! - `longbridge_httpcli` logs the OpenAPI request body and the full response
+//!   body at INFO — cash balances, positions, order history.
+//! - `longbridge_wscli` logs every WebSocket frame at INFO, including the
+//!   session auth frame that carries the customer's token and OTP.
+//! - `longbridge::trade` logs order push events at INFO.
+//! - `rmcp` logs the decoded MCP request and the full tool result at DEBUG, and
+//!   raw JSON-RPC frames at TRACE.
+//!
+//! Those lines write customer account data and credentials to disk. Naming the
+//! quiet levels in a default `RUST_LOG` string is not enough, because setting
+//! `RUST_LOG` replaces that string wholesale: an operator exporting
+//! `RUST_LOG=debug` to chase an unrelated bug silently turns payload logging
+//! back on. The caps therefore live in [`payload_guard`], a filter layer that
+//! runs alongside the `EnvFilter` and drops those events regardless of what
+//! `RUST_LOG` asks for.
+//!
+//! Set `LONGBRIDGE_MCP_LOG_PAYLOADS=1` to lift the caps when debugging locally
+//! against a test account.
+
+use std::path::Path;
+
+use tracing::Metadata;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, filter, fmt};
+
+/// Filter used when `RUST_LOG` is unset.
+///
+/// The payload targets are listed here too so the common case stays quiet at
+/// the source; [`payload_guard`] is what enforces them.
+const DEFAULT_DIRECTIVES: &str =
+    "info,longbridge_mcp=debug,longbridge_httpcli=warn,longbridge_wscli=warn,rmcp=warn";
+
+/// Set this to `1`/`true`/`yes` to log request/response payloads anyway.
+const LOG_PAYLOADS_ENV: &str = "LONGBRIDGE_MCP_LOG_PAYLOADS";
+
+/// Env vars that make the SDK install its own subscriber, out of our reach.
+const SDK_LOG_PATH_ENVS: &[&str] = &["LONGBRIDGE_LOG_PATH", "LONGPORT_LOG_PATH"];
+
+/// The most verbose level each payload-logging target may emit.
+///
+/// Matched by prefix, the same way `EnvFilter` matches targets, so
+/// `longbridge_httpcli::request` is covered by the `longbridge_httpcli` entry.
+const PAYLOAD_CAPS: &[(&str, LevelFilter)] = &[
+    // Full OpenAPI request and response bodies at INFO.
+    ("longbridge_httpcli", LevelFilter::WARN),
+    // Full WebSocket frames at INFO, auth token included.
+    ("longbridge_wscli", LevelFilter::WARN),
+    // Order push events at INFO.
+    ("longbridge::trade", LevelFilter::WARN),
+    // Decoded MCP requests and tool results at DEBUG, raw frames at TRACE.
+    // INFO stays allowed: it only names the tool being called.
+    ("rmcp", LevelFilter::INFO),
+];
+
+/// Whether an event from `target` at `level` may be logged.
+fn payload_allowed(target: &str, level: tracing::Level) -> bool {
+    PAYLOAD_CAPS
+        .iter()
+        .filter(|(prefix, _)| target.starts_with(prefix))
+        .all(|(_, cap)| *cap >= level)
+}
+
+/// Whether the operator opted into payload logging.
+fn log_payloads_enabled() -> bool {
+    std::env::var(LOG_PAYLOADS_ENV)
+        .map(|v| matches!(v.trim(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+fn metadata_allowed(meta: &Metadata<'_>) -> bool {
+    payload_allowed(meta.target(), *meta.level())
+}
+
+/// Filter layer that drops payload-bearing events above their cap.
+///
+/// `None` when the operator opted into payload logging, leaving only the
+/// `EnvFilter` in effect.
+fn payload_guard() -> Option<filter::FilterFn> {
+    if log_payloads_enabled() {
+        return None;
+    }
+    Some(filter::filter_fn(
+        metadata_allowed as fn(&Metadata<'_>) -> bool,
+    ))
+}
+
+fn env_filter(default: &str) -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default))
+}
+
+/// Warn when the SDK has been pointed at a log directory of its own.
+///
+/// `longbridge::Config` reads that path from the environment and installs a
+/// private subscriber that writes every `longbridge*` event at INFO — request
+/// and response bodies included — into that directory. It bypasses the
+/// subscriber we install here, so [`payload_guard`] cannot cover it.
+fn warn_on_sdk_log_path() {
+    if log_payloads_enabled() {
+        return;
+    }
+    for env in SDK_LOG_PATH_ENVS {
+        if std::env::var_os(env).is_some() {
+            tracing::warn!(
+                env,
+                "SDK log directory is set: the Longbridge SDK writes unfiltered request and \
+                 response payloads there, outside this server's log filter. Unset it in production."
+            );
+        }
+    }
+}
+
+/// Initialise logging for the HTTP server.
+///
+/// Writes rolling daily files to `log_dir` when given, otherwise stdout.
+pub fn init(log_dir: Option<&Path>) {
+    let registry = tracing_subscriber::registry()
+        .with(env_filter(DEFAULT_DIRECTIVES))
+        .with(payload_guard());
+
+    match log_dir {
+        Some(dir) => {
+            let file_appender = tracing_appender::rolling::daily(dir, "longbridge-mcp.log");
+            registry
+                .with(fmt::layer().with_writer(file_appender).with_ansi(false))
+                .init();
+        }
+        None => registry.with(fmt::layer()).init(),
+    }
+
+    warn_on_sdk_log_path();
+}
+
+/// Initialise logging for `--stdio` mode, where stdout is the MCP transport and
+/// every log line has to go to stderr.
+pub fn init_stdio() {
+    tracing_subscriber::registry()
+        .with(env_filter("info"))
+        .with(payload_guard())
+        .with(fmt::layer().with_writer(std::io::stderr))
+        .init();
+
+    warn_on_sdk_log_path();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+
+    use tracing::Level;
+
+    use super::*;
+
+    /// Collects formatted log output so a test can assert on it.
+    #[derive(Clone)]
+    struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
+
+    impl SharedBuffer {
+        fn new() -> Self {
+            Self(Arc::new(Mutex::new(Vec::new())))
+        }
+
+        fn contents(&self) -> String {
+            String::from_utf8(self.0.lock().expect("buffer poisoned").clone())
+                .expect("log output is not utf-8")
+        }
+    }
+
+    impl Write for SharedBuffer {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("buffer poisoned").write(buf)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn http_and_ws_payloads_are_capped_at_warn() {
+        // `http request` / `http response` and `ws request` / `ws response` are
+        // emitted at INFO and carry account data and credentials.
+        assert!(!payload_allowed("longbridge_httpcli::request", Level::INFO));
+        assert!(!payload_allowed(
+            "longbridge_httpcli::request",
+            Level::DEBUG
+        ));
+        assert!(!payload_allowed("longbridge_wscli::client", Level::INFO));
+        assert!(payload_allowed("longbridge_httpcli::request", Level::WARN));
+        assert!(payload_allowed("longbridge_wscli::client", Level::ERROR));
+    }
+
+    #[test]
+    fn trade_push_events_are_capped_at_warn() {
+        assert!(!payload_allowed("longbridge::trade::core", Level::INFO));
+        assert!(payload_allowed("longbridge::trade::core", Level::WARN));
+        // Quote-side logs carry symbols only, so they keep their INFO level.
+        assert!(payload_allowed("longbridge::quote::core", Level::INFO));
+    }
+
+    #[test]
+    fn mcp_request_and_result_logging_is_capped_at_info() {
+        // `received request` and `response message` are DEBUG, raw frames TRACE.
+        assert!(!payload_allowed("rmcp::service", Level::DEBUG));
+        assert!(!payload_allowed(
+            "rmcp::transport::streamable_http_server::tower",
+            Level::TRACE
+        ));
+        // INFO only names the tool being called.
+        assert!(payload_allowed("rmcp::handler::server", Level::INFO));
+    }
+
+    #[test]
+    fn unrelated_targets_are_untouched() {
+        assert!(payload_allowed("longbridge_mcp::tools", Level::TRACE));
+        assert!(payload_allowed("longbridge_mcp::auth", Level::DEBUG));
+        assert!(payload_allowed("axum::serve", Level::TRACE));
+        assert!(payload_allowed("", Level::TRACE));
+    }
+
+    /// The guard has to hold even when the operator asks for everything, which
+    /// is the case that used to leak.
+    #[test]
+    fn rust_log_trace_still_cannot_write_payloads() {
+        let buffer = SharedBuffer::new();
+        let writer = buffer.clone();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::new("trace"))
+            .with(filter::filter_fn(
+                metadata_allowed as fn(&Metadata<'_>) -> bool,
+            ))
+            .with(
+                fmt::layer()
+                    .with_writer(move || writer.clone())
+                    .with_ansi(false)
+                    .without_time(),
+            );
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(target: "longbridge_httpcli::request", body = "{\"total_cash\":\"123456\"}", "http response");
+            tracing::info!(target: "longbridge_wscli::client", message = "AuthRequest { token: \"secret\" }", "ws request");
+            tracing::info!(target: "longbridge::trade::core", event = "OrderChanged { quantity: 100 }", "push event");
+            tracing::debug!(target: "rmcp::service", result = "{\"positions\":[]}", "response message");
+            tracing::info!(target: "longbridge_mcp::tools", count = 151, "tools registered");
+        });
+
+        let logged = buffer.contents();
+        assert!(!logged.contains("http response"), "leaked: {logged}");
+        assert!(!logged.contains("ws request"), "leaked: {logged}");
+        assert!(!logged.contains("push event"), "leaked: {logged}");
+        assert!(!logged.contains("response message"), "leaked: {logged}");
+        assert!(!logged.contains("total_cash"), "leaked: {logged}");
+        assert!(!logged.contains("secret"), "leaked: {logged}");
+        // Our own events still get through.
+        assert!(logged.contains("tools registered"), "missing: {logged}");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod auth;
 mod counter;
 mod error;
+mod logging;
 mod metrics;
 mod serialize;
 mod tools;
@@ -13,7 +14,6 @@ use std::sync::Arc;
 use clap::Parser;
 use serde::Deserialize;
 use tokio::net::TcpListener;
-use tracing_subscriber::EnvFilter;
 
 fn default_bind() -> SocketAddr {
     "127.0.0.1:8000".parse().unwrap()
@@ -112,23 +112,6 @@ fn load_config() -> AppConfig {
     }
 }
 
-fn init_logging(log_dir: Option<&PathBuf>) {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        EnvFilter::new("info,longbridge_mcp=debug,longbridge_httpcli=warn,rmcp=warn")
-    });
-
-    if let Some(dir) = log_dir {
-        let file_appender = tracing_appender::rolling::daily(dir, "longbridge-mcp.log");
-        tracing_subscriber::fmt()
-            .with_env_filter(filter)
-            .with_writer(file_appender)
-            .with_ansi(false)
-            .init();
-    } else {
-        tracing_subscriber::fmt().with_env_filter(filter).init();
-    }
-}
-
 /// Human-facing startup summary printed to stderr.
 ///
 /// Structured `tracing` events go to the log file and are meant for machines;
@@ -205,12 +188,7 @@ async fn main() -> anyhow::Result<()> {
     // tools/list works without credentials; tools/call returns auth errors.
     if std::env::args().any(|a| a == "--stdio") {
         // In stdio mode stdout is the MCP transport; send all logs to stderr.
-        let filter = tracing_subscriber::EnvFilter::try_from_default_env()
-            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
-        tracing_subscriber::fmt()
-            .with_env_filter(filter)
-            .with_writer(std::io::stderr)
-            .init();
+        crate::logging::init_stdio();
         let tools = crate::tools::list_tools();
         // count includes all registered tools; authenticated clients on /mcp see one fewer
         // (the `authenticate` tool is only surfaced on the unauthenticated /agent endpoint).
@@ -227,7 +205,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let config = load_config();
-    init_logging(config.log_dir.as_ref());
+    crate::logging::init(config.log_dir.as_deref());
 
     let app_state = Arc::new(crate::auth::AppState {
         base_url: config.base_url.clone(),


### PR DESCRIPTION
## Problem

MCP requests and responses were reaching the server's log files, carrying customer account data — cash balances, positions, order history — plus SDK access tokens. None of it comes from this repo's own log calls; it comes from dependency targets:

| Target | Level | What it printed |
|---|---|---|
| `rmcp::service` | DEBUG | `received request` / `response message` — full MCP request and tool result |
| `rmcp::transport::…::tower` | TRACE | raw JSON-RPC frames |
| `longbridge_httpcli` | **INFO** | `http request` / `http response` — full OpenAPI response body |
| `longbridge_wscli` | **INFO** | every WS frame, session token/OTP included |
| `longbridge::trade::core` | **INFO** | `push event` — order push events |

The old `EnvFilter::try_from_default_env().unwrap_or_else(|| EnvFilter::new("info,…,rmcp=warn"))` only suppressed these when `RUST_LOG` was **unset**. Setting `RUST_LOG` replaces the whole default string, so `RUST_LOG=debug` — exported to debug something unrelated — silently re-enabled payload logging.

## Fix

New `src/logging.rs` moves the caps out of the default string into a `FilterFn` layer composed alongside the `EnvFilter` (AND semantics), so they hold regardless of `RUST_LOG`: httpcli / wscli / trade capped at `warn`, `rmcp` at `info` (INFO only names the tool being called, so it stays). `LONGBRIDGE_MCP_LOG_PAYLOADS=1` lifts the caps for local debugging against a test account.

`LONGBRIDGE_LOG_PATH` is a second channel this filter cannot cover: `longbridge::Config` installs its own subscriber via `dispatcher::with_default` that writes `longbridge*` INFO events — bodies included — into that directory. The field is private with no way to clear it, so the server now logs a WARN at startup when it is set, and the README says to leave it unset in production. **Worth checking whether it is set on the deployed servers.**

## Verification

```
RUST_LOG=debug                                  → 0 payload log lines
RUST_LOG=debug LONGBRIDGE_MCP_LOG_PAYLOADS=1    → 2 lines (the ones that were leaking)
```

Five unit tests, including an end-to-end one that emits fake balance / token / order-push / tool-result events under `RUST_LOG=trace` and asserts neither `total_cash` nor `secret` reaches the output while this crate's own events still do. `cargo test` 146 passed, `cargo clippy --all-features --all-targets` clean, `cargo +nightly fmt` applied.

The same change is applied to `longport-mcp` in a companion PR — where the default filter additionally had `longport_httpcli=warn`, a directive that never matched anything (the SDK crate is `longbridge-httpcli`), meaning full HTTP response bodies and WS tokens were being logged there under the *default* config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
