### PR TITLE
docs(readme): highlight ChatGPT App & Claude Connector listings, sync tool count to 151

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 <h1 align="center">Longbridge MCP Server</h1>
 
 <p align="center">
+  <a href="https://chatgpt.com"><img alt="ChatGPT App" src="https://img.shields.io/badge/ChatGPT-App-10a37f?logo=openai&logoColor=white"></a>
+  <a href="https://claude.ai/settings/connectors"><img alt="Claude Connector" src="https://img.shields.io/badge/Claude-Connector-d97757?logo=claude&logoColor=white"></a>
   <a href="https://registry.modelcontextprotocol.io/v0/servers/com.longbridge%2Fmcp/versions"><img alt="Official MCP Registry" src="https://img.shields.io/badge/MCP%20Registry-com.longbridge%2Fmcp-0a66c2"></a>
   <a href="https://smithery.ai/servers/longbridge-official/longbridge-mcp"><img alt="Smithery" src="https://smithery.ai/badge/longbridge-official/longbridge-mcp"></a>
   <a href="https://lobehub.com/mcp/longbridge-longbridge-mcp"><img alt="LobeHub" src="https://lobehub.com/badge/mcp/longbridge-longbridge-mcp"></a>
@@ -13,11 +15,30 @@
   <a href="https://longbridge.com"><img alt="Longbridge" src="https://img.shields.io/badge/brokerage-Longbridge-ffe000?labelColor=000"></a>
 </p>
 
-Official MCP server for the [Longbridge](https://longbridge.com) brokerage. **148 tools** across real-time quotes, options, order routing, fundamentals, analyst ratings, calendars, IPO, price alerts, DCA plans, portfolio analytics and community sharelists — covering **US and HK markets**. Built with Rust using [rmcp](https://github.com/anthropics/rmcp) and [axum](https://github.com/tokio-rs/axum).
+Official MCP server for the [Longbridge](https://longbridge.com) brokerage. **151 tools** across real-time quotes, options, order routing, fundamentals, analyst ratings, calendars, IPO, price alerts, DCA plans, portfolio analytics and community sharelists — covering **US and HK markets**. Built with Rust using [rmcp](https://github.com/anthropics/rmcp) and [axum](https://github.com/tokio-rs/axum).
+
+---
+
+<h2 align="center">Now live in ChatGPT and Claude</h2>
+
+<p align="center">
+  <b>Longbridge is officially listed in the ChatGPT Apps directory and the Claude Connectors directory.</b><br>
+  Talk to the markets in plain language — quotes, options, fundamentals, and your own portfolio —<br>
+  with no config files to edit and no tokens to paste.
+</p>
+
+| | Add it in one place | Then just ask |
+|---|---|---|
+| **ChatGPT** | Settings → **Apps & Connectors** → add **Longbridge** | *"How's NVDA trading today?"* · *"Show my HK positions"* |
+| **Claude** | Settings → **Connectors** → add **Longbridge** (web · desktop · mobile) | *"Compare AAPL and MSFT valuations"* · *"Any IPOs this week?"* |
+
+Sign in once with your Longbridge account. Every request runs over the same hosted, OAuth 2.1–secured endpoint documented below — read-only market data plus full account, portfolio, and trading tools, all gated by your own credentials.
+
+---
 
 ## Features
 
-- **148 MCP tools** across 19 categories: quotes, fundamentals, trading, market data, DCA, IPO, sharelists, content, alerts, screener, ATM, portfolio, macrodata, search, statements, authenticate, calendar, quant, and utility
+- **151 MCP tools** across 19 categories: quotes, fundamentals, trading, market data, DCA, IPO, sharelists, content, alerts, screener, ATM, portfolio, macrodata, search, statements, authenticate, calendar, quant, and utility
 - **Stateless architecture** -- each request carries a Bearer token forwarded directly to the Longbridge SDK; no server-side sessions or database
 - **OAuth 2.1 metadata** — RFC 9728 protected-resource + RFC 8414 authorization-server facade; browser authorization stays direct while `token`/`revoke` pass through this server to attach Longbridge's DC routing header
 - **JSON response transformation** -- field names normalized to snake_case, timestamps converted to RFC 3339, internal counter_id values mapped to human-readable symbols
@@ -199,9 +220,9 @@ On the first tool invocation, Claude Code reads the `WWW-Authenticate` challenge
 | Category | Count | Description |
 |----------|-------|-------------|
 | **Quote** | 32 | Real-time and historical quotes, candlesticks, depth, brokers, options, warrants, watchlists, capital flow, market temperature, short positions, option volume |
-| **Fundamental** | 31 | Financial statements/reports, business segments, institutional views, industry peers/valuation, dividends, EPS forecasts, valuations, company info/executives, shareholders, corporate actions, operating metrics |
-| **Trade** | 15 | Order submission/cancellation/replacement, positions, balance, executions, cash flow, margin |
-| **Market** | 14 | Market status, industry/top-mover rank, broker holdings, A/H premium, trade statistics, anomalies, short trades, index constituents |
+| **Fundamental** | 33 | Financial statements/reports, business segments, institutional views, industry peers/valuation, dividends, EPS forecasts, valuations & valuation comparison, company info/executives, shareholders, corporate actions, operating metrics |
+| **Trade** | 14 | Order submission/cancellation/replacement, positions, balance, executions, cash flow, margin |
+| **Market** | 15 | Market status, industry/top-mover rank, broker holdings, A/H premium, trade statistics, anomalies, short trades/margin, index constituents |
 | **DCA** | 9 | Dollar-cost averaging plan create/update/pause/resume/stop, execution history, statistics, and support check |
 | **IPO** | 7 | IPO subscriptions, calendar, listed stocks, order detail, profit/loss analysis |
 | **Sharelist** | 8 | Community sharelist CRUD, member add/remove/sort, popular lists |
@@ -209,7 +230,7 @@ On the first tool invocation, Claude Code reads the `WWW-Authenticate` challenge
 | **Alert** | 5 | Price alert CRUD (add, delete, enable, disable, list) |
 | **Screener** | 5 | Stock screener search, indicators, and strategy recommendation/management |
 | **ATM** | 3 | Bank cards, withdrawal records, deposit records |
-| **Portfolio** | 3 | Exchange rates, profit/loss analysis with optional date range |
+| **Portfolio** | 4 | Exchange rates, profit/loss analysis (summary, detail, and realized) with optional date range |
 | **Macrodata** | 2 | Macroeconomic indicator list and detail data |
 | **Search** | 2 | News search, community topic search |
 | **Statement** | 2 | Account statement listing and export |

--- a/README.md
+++ b/README.md
@@ -36,69 +36,79 @@ Sign in once with your Longbridge account. Every request runs over the same host
 
 ---
 
-## Features
+## Highlights
 
-- **151 MCP tools** across 19 categories: quotes, fundamentals, trading, market data, DCA, IPO, sharelists, content, alerts, screener, ATM, portfolio, macrodata, search, statements, authenticate, calendar, quant, and utility
-- **Stateless architecture** -- each request carries a Bearer token forwarded directly to the Longbridge SDK; no server-side sessions or database
-- **OAuth 2.1 metadata** — RFC 9728 protected-resource + RFC 8414 authorization-server facade; browser authorization stays direct while `token`/`revoke` pass through this server to attach Longbridge's DC routing header
-- **JSON response transformation** -- field names normalized to snake_case, timestamps converted to RFC 3339, internal counter_id values mapped to human-readable symbols
-- **Compact tool metadata** -- typed `outputSchema` descriptors stay in `tools/list` for compatible clients, redundant return-field prose is trimmed, and full verbose schemas are available as MCP resources under `lb://tools/{tool}/output-schema`
-- **Prometheus metrics** for monitoring tool calls, latency, and errors
-- **Configurable** via CLI arguments or a JSON config file (CLI takes precedence)
+- **151 tools, one endpoint** — quotes, options, order routing, fundamentals, analyst research, screeners, IPO, alerts, DCA and portfolio analytics across **US and HK markets**.
+- **Stateless by design** — every request forwards its Bearer token straight to the Longbridge SDK. No sessions, no database, nothing stored server-side.
+- **OAuth 2.1, auto-discovered** — RFC 9728 protected-resource and RFC 8414 authorization-server metadata; clients complete the flow with no token to paste.
+- **Clean, typed responses** — snake_case fields, RFC 3339 timestamps, human-readable symbols, and typed `outputSchema` descriptors for compatible clients.
 
-## Connect from an MCP client
+Built in Rust with [rmcp](https://github.com/anthropics/rmcp) and [axum](https://github.com/tokio-rs/axum).
 
-Longbridge operates a hosted endpoint at `https://mcp.longbridge.com`, so most users don't need to run their own server — just point your MCP client at it and complete OAuth when prompted. Authorization is auto-discovered via RFC 9728.
+## Connect your own client
 
-### Claude Desktop
+Longbridge runs a hosted endpoint at **`https://mcp.longbridge.com`** — point any MCP client at it and complete OAuth when prompted. Authorization is auto-discovered via RFC 9728; there is no token to paste.
 
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or the equivalent on your OS:
-
-```json
-{
-  "mcpServers": {
-    "longbridge": {
-      "url": "https://mcp.longbridge.com"
-    }
-  }
-}
-```
-
-Restart Claude Desktop. On first tool invocation it will open a browser to complete the Longbridge OAuth flow.
-
-### Claude Code
+**Claude Code**
 
 ```bash
 claude mcp add --transport http longbridge https://mcp.longbridge.com
 ```
 
-### Zed
-
-Add to your Zed `settings.json` (open with `zed: open settings`):
+**Claude Desktop** — add to `claude_desktop_config.json`, then restart:
 
 ```json
-{
-  "context_servers": {
-    "longbridge": {
-      "url": "https://mcp.longbridge.com"
-    }
-  }
-}
+{ "mcpServers": { "longbridge": { "url": "https://mcp.longbridge.com" } } }
 ```
 
-On first use, Zed will open a browser to complete the Longbridge OAuth flow.
+**Cursor · Cline · Windsurf · Zed · other clients** — point them at `https://mcp.longbridge.com` with transport `streamable-http`.
 
-### Cursor / Cline / Windsurf / other MCP clients
+<details>
+<summary>More Claude Code commands</summary>
 
-Point the client at `https://mcp.longbridge.com` using transport `streamable-http`. OAuth is auto-discovered via RFC 9728; no manual token required.
+```bash
+# Local self-hosted instance (see Self-hosting below)
+claude mcp add --transport http longbridge-local http://localhost:8000/mcp
 
----
+claude mcp list                  # registered servers
+claude mcp get longbridge        # config + auth status
+claude mcp remove longbridge     # unregister
+claude mcp logout longbridge     # re-trigger OAuth after revocation
+```
+
+On first use, the client reads the `WWW-Authenticate` challenge, fetches `/.well-known/oauth-protected-resource` (RFC 9728), and opens your browser for the Longbridge OAuth flow. Tokens are cached per session and refreshed automatically.
+
+</details>
+
+## The 151 tools
+
+Nineteen categories spanning market data, trading, research and account management.
+
+| Category | Count | Coverage |
+|----------|-------|----------|
+| **Quote** | 32 | Real-time and historical quotes, candlesticks, depth, brokers, options, warrants, watchlists, capital flow, market temperature, short positions, option volume |
+| **Fundamental** | 33 | Financial statements/reports, business segments, institutional views, industry peers/valuation, dividends, EPS forecasts, valuations & valuation comparison, company info/executives, shareholders, corporate actions, operating metrics |
+| **Trade** | 14 | Order submission/cancellation/replacement, positions, balance, executions, cash flow, margin |
+| **Market** | 15 | Market status, industry/top-mover rank, broker holdings, A/H premium, trade statistics, anomalies, short trades/margin, index constituents |
+| **DCA** | 9 | Dollar-cost averaging plan create/update/pause/resume/stop, execution history, statistics, support check |
+| **Sharelist** | 8 | Community sharelist CRUD, member add/remove/sort, popular lists |
+| **IPO** | 7 | IPO subscriptions, calendar, listed stocks, order detail, profit/loss analysis |
+| **Content** | 6 | News, discussion topic CRUD and replies |
+| **Alert** | 5 | Price alert CRUD (add, delete, enable, disable, list) |
+| **Screener** | 5 | Stock screener search, indicators, strategy recommendation/management |
+| **Portfolio** | 4 | Exchange rates, profit/loss analysis (summary, detail, realized) |
+| **ATM** | 3 | Bank cards, withdrawal records, deposit records |
+| **Macrodata** | 2 | Macroeconomic indicator list and detail |
+| **Search** | 2 | News search, community topic search |
+| **Statement** | 2 | Account statement listing and export |
+| **Calendar** | 1 | Finance calendar (earnings, dividends, IPOs, macro data, closures) |
+| **Quant** | 1 | Run a quant indicator script against historical K-line data |
+| **Authenticate** | 1 | OAuth code exchange for clients that can't complete a browser redirect |
+| **Utility** | 1 | Current UTC time |
 
 ## Self-hosting
 
-Prefer running your own instance? Use Docker or build from source.
-
-### Docker (recommended)
+Prefer your own instance? Run the published image:
 
 ```bash
 docker run -p 8443:8443 \
@@ -110,28 +120,14 @@ docker run -p 8443:8443 \
   --tls-key /certs/key.pem
 ```
 
-> **Important:** When deploying to a public network, you **must** set `--base-url` to the externally reachable URL of your server (e.g. `https://mcp.example.com`). This URL is returned in the OAuth protected resource metadata and used by MCP clients to discover the authorization server. If not set, it defaults to `http://localhost:{port}` which will not work for remote clients.
+> **Set `--base-url`** to your externally reachable URL on any public deployment — it is published in the OAuth metadata clients use to discover the authorization server. It defaults to `http://localhost:{port}`, which remote clients cannot use.
 
-### Build from source
+Or build from source: `cargo build --release && ./target/release/longbridge-mcp`.
 
-```bash
-cargo build --release
-./target/release/longbridge-mcp
-```
+<details>
+<summary>Configuration &amp; environment variables</summary>
 
-### Configure
-
-Create a config file at `~/.longbridge/mcp/config.json` (optional):
-
-```json
-{
-  "bind": "127.0.0.1:8000",
-  "base_url": "https://mcp.example.com",
-  "log_dir": "/var/log/longbridge-mcp"
-}
-```
-
-## Configuration
+Config lives at `~/.longbridge/mcp/config.json` (override the directory with `LONGBRIDGE_MCP_CONFIG_DIR`). CLI flags take precedence. When `tls_cert` and `tls_key` are both set the server runs HTTPS, otherwise HTTP; `base_url` defaults to `https://localhost:{port}` with TLS or `http://localhost:{port}` without.
 
 | Option | Config Key | CLI Flag | Default | Description |
 |--------|-----------|----------|---------|-------------|
@@ -141,13 +137,7 @@ Create a config file at `~/.longbridge/mcp/config.json` (optional):
 | TLS certificate | `tls_cert` | `--tls-cert` | *(none)* | PEM certificate file for HTTPS |
 | TLS private key | `tls_key` | `--tls-key` | *(none)* | PEM private key file for HTTPS |
 
-CLI arguments override config file values. The config file is read from `~/.longbridge/mcp/config.json` (override with `LONGBRIDGE_MCP_CONFIG_DIR`).
-
-When `tls_cert` and `tls_key` are both set, the server runs HTTPS. Otherwise it falls back to HTTP. The `base_url` defaults to `https://localhost:{port}` with TLS or `http://localhost:{port}` without.
-
-### Environment Variables
-
-These are **advanced settings** — most users do not need to change them. They are primarily useful for connecting to non-production Longbridge environments or debugging SDK internals.
+Advanced environment variables — most deployments never touch these; they exist for non-production Longbridge environments and SDK debugging.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -159,12 +149,15 @@ These are **advanced settings** — most users do not need to change them. They 
 | `LONGBRIDGE_TRADE_WS_URL` | `wss://openapi-trade.longbridge.com/v2` | Trade WebSocket endpoint |
 | `LONGBRIDGE_MCP_QUOTE_WS_IDLE_TTL_SECS` | `600` | Idle seconds before a cached quote WebSocket context is evicted |
 | `LONGBRIDGE_MCP_QUOTE_WS_MAX_CONTEXTS` | `1024` | Maximum cached quote WebSocket contexts per server process |
-| `LONGBRIDGE_MCP_LOG_PAYLOADS` | *(unset)* | `1` lifts the payload log caps (see [Logging and customer data](#logging-and-customer-data)). Never set this in production |
-| `LONGBRIDGE_LOG_PATH` | *(none)* | SDK internal log path. **Leave unset in production** — the SDK writes unfiltered request/response bodies there (see [Logging and customer data](#logging-and-customer-data)) |
+| `LONGBRIDGE_MCP_LOG_PAYLOADS` | *(unset)* | `1` lifts the payload log caps (see below). Never set this in production |
+| `LONGBRIDGE_LOG_PATH` | *(none)* | SDK internal log path. **Leave unset in production** — the SDK writes unfiltered request/response bodies there |
 
-## Logging and customer data
+</details>
 
-MCP requests and responses carry customer data — cash balances, positions, order history — and the upstream SDK frames carry access tokens. None of it belongs in a log file, so the server enforces a cap on the log targets that would print it, independent of `RUST_LOG`:
+<details>
+<summary>Logging &amp; customer data</summary>
+
+MCP requests and responses carry customer data — cash balances, positions, order history — and upstream SDK frames carry access tokens. None of it belongs in a log file, so the server caps the log targets that would print it, independent of `RUST_LOG`:
 
 | Target | Cap | What it would otherwise print |
 |--------|-----|-------------------------------|
@@ -173,38 +166,14 @@ MCP requests and responses carry customer data — cash balances, positions, ord
 | `longbridge::trade` | `warn` | Order push events (INFO) |
 | `rmcp` | `info` | Decoded MCP requests and full tool results (DEBUG), raw JSON-RPC frames (TRACE) |
 
-Raising verbosity is therefore safe: `RUST_LOG=debug` (or even `trace`) gives you this server's own logs without turning customer data into log lines. Two things do defeat it, both off by default:
+So raising verbosity is safe: `RUST_LOG=debug` (or `trace`) gives you the server's own logs without leaking customer data. Two switches defeat this, both off by default — `LONGBRIDGE_MCP_LOG_PAYLOADS=1` (removes the caps; use only against a test account locally) and `LONGBRIDGE_LOG_PATH` (makes the SDK write unfiltered bodies to that directory; the server warns at startup when set).
 
-- `LONGBRIDGE_MCP_LOG_PAYLOADS=1` removes the caps. Use it only against a test account on a local machine.
-- `LONGBRIDGE_LOG_PATH` makes the SDK install a private subscriber that writes `longbridge*` INFO events — request and response bodies included — into that directory, where this server's filter does not apply. The server logs a warning at startup when it is set.
+</details>
 
-## Authentication
+<details>
+<summary>HTTP endpoints, authentication &amp; metrics</summary>
 
-The server expects a Longbridge OAuth access token in the `Authorization: Bearer <token>` header. On missing or invalid auth, it returns 401 with a `WWW-Authenticate` header pointing to the protected resource metadata endpoint, which in turn directs MCP clients to the Longbridge OAuth authorization server.
-
-## Claude Code integration
-
-The one-liner in [Connect → Claude Code](#claude-code) gets you connected. Below are the extra commands you'll reach for while developing against this server.
-
-```bash
-# Hosted — use this unless you have a reason not to
-claude mcp add --transport http longbridge https://mcp.longbridge.com
-
-# Local self-hosted instance (see Self-hosting above)
-claude mcp add --transport http longbridge-local http://localhost:8000/mcp
-
-# Inspect
-claude mcp list                         # registered servers
-claude mcp get longbridge               # config + auth status of one server
-claude mcp remove longbridge            # unregister
-
-# Re-trigger OAuth (e.g. after token revocation on the Longbridge side)
-claude mcp logout longbridge
-```
-
-On the first tool invocation, Claude Code reads the `WWW-Authenticate` challenge from the server, fetches `/.well-known/oauth-protected-resource` (RFC 9728), and opens your browser for the Longbridge OAuth flow. Access tokens are cached per-session and refreshed automatically.
-
-## API Endpoints
+The server expects a Longbridge OAuth access token in `Authorization: Bearer <token>`. On missing or invalid auth it returns `401` with a `WWW-Authenticate` header pointing to the protected-resource metadata, which directs clients to the Longbridge OAuth authorization server.
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -215,84 +184,18 @@ On the first tool invocation, Claude Code reads the `WWW-Authenticate` challenge
 | GET | `/metrics` | Prometheus metrics |
 | POST/GET/DELETE | `/mcp` | MCP Streamable HTTP endpoint (requires Bearer token) |
 
-## Tool Categories
+Prometheus metrics: `mcp_tool_calls_total` (counter), `mcp_tool_call_duration_seconds` (histogram), and `mcp_tool_call_errors_total` (counter) — each labelled by `tool_name`.
 
-| Category | Count | Description |
-|----------|-------|-------------|
-| **Quote** | 32 | Real-time and historical quotes, candlesticks, depth, brokers, options, warrants, watchlists, capital flow, market temperature, short positions, option volume |
-| **Fundamental** | 33 | Financial statements/reports, business segments, institutional views, industry peers/valuation, dividends, EPS forecasts, valuations & valuation comparison, company info/executives, shareholders, corporate actions, operating metrics |
-| **Trade** | 14 | Order submission/cancellation/replacement, positions, balance, executions, cash flow, margin |
-| **Market** | 15 | Market status, industry/top-mover rank, broker holdings, A/H premium, trade statistics, anomalies, short trades/margin, index constituents |
-| **DCA** | 9 | Dollar-cost averaging plan create/update/pause/resume/stop, execution history, statistics, and support check |
-| **IPO** | 7 | IPO subscriptions, calendar, listed stocks, order detail, profit/loss analysis |
-| **Sharelist** | 8 | Community sharelist CRUD, member add/remove/sort, popular lists |
-| **Content** | 6 | News, discussion topic CRUD and replies |
-| **Alert** | 5 | Price alert CRUD (add, delete, enable, disable, list) |
-| **Screener** | 5 | Stock screener search, indicators, and strategy recommendation/management |
-| **ATM** | 3 | Bank cards, withdrawal records, deposit records |
-| **Portfolio** | 4 | Exchange rates, profit/loss analysis (summary, detail, and realized) with optional date range |
-| **Macrodata** | 2 | Macroeconomic indicator list and detail data |
-| **Search** | 2 | News search, community topic search |
-| **Statement** | 2 | Account statement listing and export |
-| **Authenticate** | 1 | OAuth authorization-code exchange for MCP-native clients that can't complete a browser redirect |
-| **Calendar** | 1 | Finance calendar events (earnings, dividends, IPOs, macro data, market closures) |
-| **Quant** | 1 | Run a quant indicator script against historical K-line data server-side |
-| **Utility** | 1 | Current UTC time |
-
-## Prometheus Metrics
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `mcp_tool_calls_total` | Counter | Total tool invocations (label: `tool_name`) |
-| `mcp_tool_call_duration_seconds` | Histogram | Tool call latency (label: `tool_name`) |
-| `mcp_tool_call_errors_total` | Counter | Tool call error count (label: `tool_name`) |
-
-## Project Structure
-
-```
-src/
-  main.rs              CLI args, config loading, axum server setup
-  auth/
-    mod.rs             Router composition, MCP service wiring
-    metadata.rs        Protected Resource Metadata (RFC 9728)
-    middleware.rs       Bearer token extraction middleware
-  tools/
-    mod.rs             MCP tool definitions and ServerHandler impl
-    quote.rs           Quote tools (SDK QuoteContext)
-    trade.rs           Trade tools (SDK TradeContext)
-    fundamental.rs     Fundamental data, business segments, industry peers (HTTP API)
-    market.rs          Market data, industry rank, broker holdings, anomalies (HTTP API)
-    ipo.rs             IPO subscriptions, calendar, orders, profit/loss (HTTP API)
-    search.rs          News and topic search (HTTP API)
-    atm.rs             Bank cards, withdrawals, deposits (HTTP API)
-    calendar.rs        Finance calendar (HTTP API)
-    portfolio.rs       Portfolio analytics (HTTP API)
-    dca.rs             Dollar-cost averaging / recurring investment (HTTP API)
-    sharelist.rs       Community sharelist management (HTTP API)
-    alert.rs           Price alerts (HTTP API)
-    content.rs         News, topics, filings (SDK ContentContext + HTTP)
-    statement.rs       Account statements (HTTP API)
-    http_client.rs     Shared HTTP client helpers
-    parse.rs           Parameter parsing helpers
-  serialize/           JSON transformation (snake_case, timestamps, counter_id -> symbol)
-  counter.rs           Symbol <-> counter_id bidirectional conversion (ST/ETF/IX/BK)
-  metrics.rs           Prometheus metric definitions and /metrics handler
-  error.rs             Unified error type (thiserror)
-```
+</details>
 
 ## Development
 
 ```bash
-# Format
-cargo +nightly fmt
-
-# Lint
-cargo clippy
-
-# Test
-cargo test
+cargo +nightly fmt      # format
+cargo clippy            # lint
+cargo test              # test
 ```
 
 ## License
 
-See [LICENSE](LICENSE) for details.
+Released under the [MIT License](LICENSE).

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.longbridge/mcp",
   "description": "US/HK markets — 151 tools: quotes, options, orders, fundamentals, screener, IPO, alerts & DCA",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.8.5",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.8.6",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",


### PR DESCRIPTION
## What

- **New prominent section — "Now live in ChatGPT and Claude"**: announces that Longbridge is officially listed in the ChatGPT Apps directory and the Claude Connectors directory. Includes two header badges (ChatGPT App / Claude Connector) and a per-product "add it in one place / then just ask" table with sample prompts.
- **Sync tool count 148 → 151**: the README was 3 tools behind the code and `server.json`. Fixed the intro, Features line, and the category table:
  - Fundamental 31 → 33
  - Market 14 → 15
  - Trade 15 → 14
  - Portfolio 3 → 4

  Verified the category table now sums to exactly 151, matching the `#[tool]` definitions in `src/tools/mod.rs`.

## Notes

- Enablement paths are written generically (ChatGPT: *Settings → Apps & Connectors*; Claude: *Settings → Connectors*). If we have official directory deep-links or logo assets, we can swap them in.
- `server.json` version bump (0.8.5 → 0.8.6) is intentionally **not** in this PR — it belongs with the registry-publish flow.