### PR TITLE
feat(content): add news_detail tool (GET /v1/content/news/:id)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://longbridge.com"><img alt="Longbridge" src="https://img.shields.io/badge/brokerage-Longbridge-ffe000?labelColor=000"></a>
 </p>
 
-Official MCP server for the [Longbridge](https://longbridge.com) brokerage. **151 tools** across real-time quotes, options, order routing, fundamentals, analyst ratings, calendars, IPO, price alerts, DCA plans, portfolio analytics and community sharelists — covering **US and HK markets**. Built with Rust using [rmcp](https://github.com/anthropics/rmcp) and [axum](https://github.com/tokio-rs/axum).
+Official MCP server for the [Longbridge](https://longbridge.com) brokerage. **152 tools** across real-time quotes, options, order routing, fundamentals, analyst ratings, calendars, IPO, price alerts, DCA plans, portfolio analytics and community sharelists — covering **US and HK markets**. Built with Rust using [rmcp](https://github.com/anthropics/rmcp) and [axum](https://github.com/tokio-rs/axum).
 
 ---
 
@@ -38,7 +38,7 @@ Sign in once with your Longbridge account. Every request runs over the same host
 
 ## Highlights
 
-- **151 tools, one endpoint** — quotes, options, order routing, fundamentals, analyst research, screeners, IPO, alerts, DCA and portfolio analytics across **US and HK markets**.
+- **152 tools, one endpoint** — quotes, options, order routing, fundamentals, analyst research, screeners, IPO, alerts, DCA and portfolio analytics across **US and HK markets**.
 - **Stateless by design** — every request forwards its Bearer token straight to the Longbridge SDK. No sessions, no database, nothing stored server-side.
 - **OAuth 2.1, auto-discovered** — RFC 9728 protected-resource and RFC 8414 authorization-server metadata; clients complete the flow with no token to paste.
 - **Clean, typed responses** — snake_case fields, RFC 3339 timestamps, human-readable symbols, and typed `outputSchema` descriptors for compatible clients.
@@ -80,7 +80,7 @@ On first use, the client reads the `WWW-Authenticate` challenge, fetches `/.well
 
 </details>
 
-## The 151 tools
+## The 152 tools
 
 Nineteen categories spanning market data, trading, research and account management.
 
@@ -93,7 +93,7 @@ Nineteen categories spanning market data, trading, research and account manageme
 | **DCA** | 9 | Dollar-cost averaging plan create/update/pause/resume/stop, execution history, statistics, support check |
 | **Sharelist** | 8 | Community sharelist CRUD, member add/remove/sort, popular lists |
 | **IPO** | 7 | IPO subscriptions, calendar, listed stocks, order detail, profit/loss analysis |
-| **Content** | 6 | News, discussion topic CRUD and replies |
+| **Content** | 7 | News list/detail, discussion topic CRUD and replies |
 | **Alert** | 5 | Price alert CRUD (add, delete, enable, disable, list) |
 | **Screener** | 5 | Stock screener search, indicators, strategy recommendation/management |
 | **Portfolio** | 4 | Exchange rates, profit/loss analysis (summary, detail, realized) |

--- a/data/scopes.json
+++ b/data/scopes.json
@@ -65,6 +65,7 @@
         "market_status",
         "market_temperature",
         "news",
+        "news_detail",
         "news_search",
         "now",
         "operating",

--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -640,6 +640,13 @@
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
+    "news_detail": {
+      "title": "资讯详情",
+      "description": "按 id 获取单篇资讯的完整内容（id 来自 news / news_search）。返回 {id, title, description, body (Markdown), url, author{name}, images[], comments_count, likes_count, shares_count, published_at, tickers[]}",
+      "properties": {
+        "id": "资讯文章 ID（数字），例如 \"7123456789012345678\"。可从 news 或 news_search 获取"
+      }
+    },
     "now": {
       "title": "当前时间",
       "description": "获取当前 UTC 时间（RFC3339 格式），用于在发起日期相关查询前确认当前日期"

--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -642,7 +642,7 @@
     },
     "news_detail": {
       "title": "资讯详情",
-      "description": "按 id 获取单篇资讯的完整内容（id 来自 news / news_search）。返回 {id, title, description, body (Markdown), url, author{name}, images[], comments_count, likes_count, shares_count, published_at, tickers[]}",
+      "description": "按 id 获取单篇资讯的完整内容（id 来自 news / news_search）。返回 {id, title, description, body (Markdown), url, author{id,name,avatar}, images[], comments_count, likes_count, shares_count, published_at, tickers[]}",
       "properties": {
         "id": "资讯文章 ID（数字），例如 \"7123456789012345678\"。可从 news 或 news_search 获取"
       }

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -640,6 +640,13 @@
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
+    "news_detail": {
+      "title": "資訊詳情",
+      "description": "按 id 獲取單篇資訊的完整內容（id 來自 news / news_search）。返回 {id, title, description, body (Markdown), url, author{name}, images[], comments_count, likes_count, shares_count, published_at, tickers[]}",
+      "properties": {
+        "id": "資訊文章 ID（數字），例如 \"7123456789012345678\"。可從 news 或 news_search 獲取"
+      }
+    },
     "now": {
       "title": "當前時間",
       "description": "獲取當前 UTC 時間（RFC3339 時間格式），用於在發起日期相關查詢前確認當前日期"

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -642,7 +642,7 @@
     },
     "news_detail": {
       "title": "資訊詳情",
-      "description": "按 id 獲取單篇資訊的完整內容（id 來自 news / news_search）。返回 {id, title, description, body (Markdown), url, author{name}, images[], comments_count, likes_count, shares_count, published_at, tickers[]}",
+      "description": "按 id 獲取單篇資訊的完整內容（id 來自 news / news_search）。返回 {id, title, description, body (Markdown), url, author{id,name,avatar}, images[], comments_count, likes_count, shares_count, published_at, tickers[]}",
       "properties": {
         "id": "資訊文章 ID（數字），例如 \"7123456789012345678\"。可從 news 或 news_search 獲取"
       }

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.longbridge/mcp",
-  "description": "US/HK markets — 151 tools: quotes, options, orders, fundamentals, screener, IPO, alerts & DCA",
+  "description": "US/HK markets — 152 tools: quotes, options, orders, fundamentals, screener, IPO, alerts & DCA",
   "version": "0.8.6",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
@@ -92,9 +92,9 @@
         }
       },
       "localizedDescriptions": {
-        "en": "Longbridge — official MCP server for the Longbridge brokerage. 151 tools across real-time quotes, options, order routing, fundamentals, stock screener, shareholders, short selling, IPO, calendars, alerts, DCA and portfolio analytics for US / HK markets.",
-        "zh-CN": "长桥证券官方 MCP 服务：151 个工具覆盖美股 / 港股的实时行情、期权、下单路由、基本面、选股器、股东持仓、卖空数据、IPO 打新、财报日历、价格预警、定投计划与组合分析。",
-        "zh-HK": "長橋證券官方 MCP 伺服器：151 個工具覆蓋美股 / 港股的即時行情、期權、下單路由、基本面、選股器、股東持倉、賣空數據、IPO 打新、財報日曆、價格警示、定投計劃與組合分析。"
+        "en": "Longbridge — official MCP server for the Longbridge brokerage. 152 tools across real-time quotes, options, order routing, fundamentals, stock screener, shareholders, short selling, IPO, calendars, alerts, DCA and portfolio analytics for US / HK markets.",
+        "zh-CN": "长桥证券官方 MCP 服务：152 个工具覆盖美股 / 港股的实时行情、期权、下单路由、基本面、选股器、股东持仓、卖空数据、IPO 打新、财报日历、价格预警、定投计划与组合分析。",
+        "zh-HK": "長橋證券官方 MCP 伺服器：152 個工具覆蓋美股 / 港股的即時行情、期權、下單路由、基本面、選股器、股東持倉、賣空數據、IPO 打新、財報日曆、價格警示、定投計劃與組合分析。"
       },
       "icons": [
         {
@@ -138,7 +138,7 @@
           "name": "Hong Kong"
         }
       ],
-      "toolCount": 151,
+      "toolCount": 152,
       "toolCategories": {
         "quote": 32,
         "fundamental": 24,

--- a/server.json
+++ b/server.json
@@ -147,7 +147,7 @@
         "screener": 5,
         "dca": 9,
         "ipo": 8,
-        "content": 8,
+        "content": 9,
         "sharelist": 8,
         "alert": 5,
         "atm": 3,

--- a/src/tools/content.rs
+++ b/src/tools/content.rs
@@ -109,7 +109,17 @@ pub async fn news_detail(
         .response::<Json<serde_json::Value>>()
         .send()
         .await
-        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        .map_err(|e| match &e {
+            // 1901107: content does not exist or has been deleted — the
+            // caller's id was wrong, not a server fault.
+            longbridge::httpclient::HttpClientError::OpenApi { code: 1901107, .. } => {
+                McpError::invalid_params(
+                    format!("news article {id} not found; get a valid id from news/news_search"),
+                    None,
+                )
+            }
+            _ => McpError::internal_error(e.to_string(), None),
+        })?;
     // The tool declares an outputSchema, so it must return a structured
     // object — never a bare `null` if the payload is missing `item`.
     let item = &resp.0["item"];

--- a/src/tools/content.rs
+++ b/src/tools/content.rs
@@ -75,16 +75,17 @@ pub struct NewsIdParam {
 /// Accept the article id as either a JSON string or a bare number — models
 /// often echo the numeric id from `news_search` results as a number.
 fn tolerant_id_string<'de, D: rmcp::serde::Deserializer<'de>>(d: D) -> Result<String, D::Error> {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum Value {
-        String(String),
-        Number(i64),
+    let value = serde_json::Value::deserialize(d)?;
+    match value {
+        serde_json::Value::String(s) => Ok(s),
+        serde_json::Value::Number(n) => n
+            .as_i64()
+            .map(|n| n.to_string())
+            .ok_or_else(|| rmcp::serde::de::Error::custom("id must be an integer article ID")),
+        other => Err(rmcp::serde::de::Error::custom(format!(
+            "id must be a string or integer article ID, got {other}"
+        ))),
     }
-    Ok(match Value::deserialize(d)? {
-        Value::String(s) => s,
-        Value::Number(n) => n.to_string(),
-    })
 }
 
 /// `GET /v1/content/news/{id}` — one article's full detail. This endpoint is
@@ -113,8 +114,10 @@ pub async fn news_detail(
     // object — never a bare `null` if the payload is missing `item`.
     let item = &resp.0["item"];
     if !item.is_object() {
-        return Err(McpError::internal_error(
-            format!("news article {id} not found or response missing `item`"),
+        // The id didn't resolve to an article — that's the caller's input,
+        // not a server fault, so signal it as such.
+        return Err(McpError::invalid_params(
+            format!("news article {id} not found; get a valid id from news/news_search"),
             None,
         ));
     }

--- a/src/tools/content.rs
+++ b/src/tools/content.rs
@@ -64,6 +64,37 @@ pub async fn news(
     tool_json(&result)
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct NewsIdParam {
+    /// News article ID (numeric), e.g. "7123456789012345678". Get IDs from `news` or `news_search`.
+    pub id: String,
+}
+
+/// `GET /v1/content/news/{id}` — one article's full detail. This endpoint is
+/// not part of the language SDKs, so it is called through the signed raw HTTP
+/// client.
+pub async fn news_detail(
+    mctx: &crate::tools::McpContext,
+    p: NewsIdParam,
+) -> Result<CallToolResult, McpError> {
+    use longbridge::httpclient::{Json, Method};
+
+    let id: i64 = p.id.trim().parse().map_err(|_| {
+        McpError::invalid_params(
+            "id must be a numeric news article ID (from news/news_search)",
+            None,
+        )
+    })?;
+    let resp = mctx
+        .create_http_client()
+        .request(Method::GET, format!("/v1/content/news/{id}"))
+        .response::<Json<serde_json::Value>>()
+        .send()
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+    tool_json(&resp.0["item"])
+}
+
 pub async fn topic(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,

--- a/src/tools/content.rs
+++ b/src/tools/content.rs
@@ -67,7 +67,24 @@ pub async fn news(
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct NewsIdParam {
     /// News article ID (numeric), e.g. "7123456789012345678". Get IDs from `news` or `news_search`.
+    #[serde(deserialize_with = "tolerant_id_string")]
+    #[schemars(with = "String")]
     pub id: String,
+}
+
+/// Accept the article id as either a JSON string or a bare number — models
+/// often echo the numeric id from `news_search` results as a number.
+fn tolerant_id_string<'de, D: rmcp::serde::Deserializer<'de>>(d: D) -> Result<String, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Value {
+        String(String),
+        Number(i64),
+    }
+    Ok(match Value::deserialize(d)? {
+        Value::String(s) => s,
+        Value::Number(n) => n.to_string(),
+    })
 }
 
 /// `GET /v1/content/news/{id}` — one article's full detail. This endpoint is
@@ -92,7 +109,16 @@ pub async fn news_detail(
         .send()
         .await
         .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-    tool_json(&resp.0["item"])
+    // The tool declares an outputSchema, so it must return a structured
+    // object — never a bare `null` if the payload is missing `item`.
+    let item = &resp.0["item"];
+    if !item.is_object() {
+        return Err(McpError::internal_error(
+            format!("news article {id} not found or response missing `item`"),
+            None,
+        ));
+    }
+    tool_json(item)
 }
 
 pub async fn topic(

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -918,13 +918,12 @@ fn strip_schema_documentation_keys(value: &mut serde_json::Value) {
                 if matches!(
                     key.as_str(),
                     "properties" | "patternProperties" | "$defs" | "definitions"
-                ) {
-                    if let serde_json::Value::Object(children) = v {
-                        for child in children.values_mut() {
-                            strip_schema_documentation_keys(child);
-                        }
-                        continue;
+                ) && let serde_json::Value::Object(children) = v
+                {
+                    for child in children.values_mut() {
+                        strip_schema_documentation_keys(child);
                     }
+                    continue;
                 }
                 strip_schema_documentation_keys(v);
             }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -909,7 +909,23 @@ fn strip_schema_documentation_keys(value: &mut serde_json::Value) {
             map.remove("$schema");
             map.remove("title");
             map.remove("description");
-            for v in map.values_mut() {
+            for (key, v) in map.iter_mut() {
+                // The values of these keywords are maps keyed by *names*
+                // (property / definition names), not schema objects — a
+                // property legitimately named "title" or "description" must
+                // not be stripped. Recurse into each named child schema
+                // directly instead.
+                if matches!(
+                    key.as_str(),
+                    "properties" | "patternProperties" | "$defs" | "definitions"
+                ) {
+                    if let serde_json::Value::Object(children) = v {
+                        for child in children.values_mut() {
+                            strip_schema_documentation_keys(child);
+                        }
+                        continue;
+                    }
+                }
                 strip_schema_documentation_keys(v);
             }
         }
@@ -4453,6 +4469,37 @@ impl ServerHandler for Longbridge {
 
 #[cfg(test)]
 mod tests {
+    use super::strip_schema_documentation_keys;
+
+    #[test]
+    fn schema_compactor_keeps_properties_named_title_or_description() {
+        // "title"/"description" are documentation keywords on a *schema*
+        // object, but inside a `properties` map they are property *names* —
+        // stripping them there deletes real fields (news_detail's headline
+        // fields) from the advertised outputSchema.
+        let mut schema = serde_json::json!({
+            "title": "NewsDetailResponse",
+            "description": "doc",
+            "type": "object",
+            "properties": {
+                "title": { "type": "string", "description": "Title." },
+                "description": { "type": "string", "description": "Excerpt." },
+                "body": { "type": "string", "description": "Markdown." }
+            }
+        });
+        strip_schema_documentation_keys(&mut schema);
+        let props = schema["properties"].as_object().unwrap();
+        assert!(props.contains_key("title"), "property name must survive");
+        assert!(
+            props.contains_key("description"),
+            "property name must survive"
+        );
+        // Schema-level annotations are stripped, including on child schemas.
+        assert!(schema.get("title").is_none());
+        assert!(schema.get("description").is_none());
+        assert!(props["body"].get("description").is_none());
+    }
+
     use axum::http::{HeaderMap, HeaderName, HeaderValue};
 
     use super::collect_headers;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -672,6 +672,7 @@ const TOOL_ENDPOINTS: &[(&str, u8)] = &[
     ("intraday", V2),
     ("market_status", V2),
     ("news", V2),
+    ("news_detail", V2),
     ("news_search", V2),
     ("quote", V2),
     ("rank_list", V2),
@@ -2840,6 +2841,26 @@ impl Longbridge {
     ) -> Result<CallToolResult, McpError> {
         let mctx = extract_context(&ctx)?;
         measured_tool_call("news", || content::news(&mctx, p)).await
+    }
+
+    /// Get one news article's full detail.
+    #[tool(
+        title = "News Detail",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
+        description = "Get one news article's full detail by id (from news/news_search). Returns {id, title, description, body (Markdown), url, author{name}, images[], comments_count, likes_count, shares_count, published_at, tickers[]}."
+    )]
+    async fn news_detail(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<content::NewsIdParam>,
+    ) -> Result<CallToolResult, McpError> {
+        let mctx = extract_context(&ctx)?;
+        measured_tool_call("news_detail", || content::news_detail(&mctx, p)).await
     }
 
     /// Get discussion topics for a symbol.

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2852,6 +2852,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
+        output_schema = schema_for::<output::social::NewsDetailResponse>(),
         description = "Get one news article's full detail by id (from news/news_search). Returns {id, title, description, body (Markdown), url, author{name}, images[], comments_count, likes_count, shares_count, published_at, tickers[]}."
     )]
     async fn news_detail(

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -580,7 +580,7 @@ fn all_tools_full_cached() -> &'static [rmcp::model::Tool] {
 ///
 /// Returns all tools, processed once and cached for the lifetime of the process.
 ///
-/// Building the router (151 entries) and recursively traversing every JSON Schema
+/// Building the router (152 entries) and recursively traversing every JSON Schema
 /// is expensive; doing it on each `tools/list` request was the primary CPU hotspot.
 /// The result is immutable after startup, so a `OnceLock` is safe.
 fn all_tools_cached() -> &'static [rmcp::model::Tool] {
@@ -2853,7 +2853,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::social::NewsDetailResponse>(),
-        description = "Get one news article's full detail by id (from news/news_search). Returns {id, title, description, body (Markdown), url, author{name}, images[], comments_count, likes_count, shares_count, published_at, tickers[]}."
+        description = "Get one news article's full detail by id (from news/news_search). Returns {id, title, description, body (Markdown), url, author{id,name,avatar}, images[], comments_count, likes_count, shares_count, published_at, tickers[]}."
     )]
     async fn news_detail(
         &self,
@@ -5234,7 +5234,7 @@ mod quote_cmd_tests {
         }
         let hot_elapsed = start.elapsed();
 
-        // ── list_tools() path: all_tools_cached().to_vec() (all 151 tools) ──
+        // ── list_tools() path: all_tools_cached().to_vec() (all 152 tools) ──
         let start = Instant::now();
         for _ in 0..n {
             let _ = black_box(list_tools());
@@ -5270,7 +5270,7 @@ mod quote_cmd_tests {
             hot_us, hot_elapsed
         );
         eprintln!(
-            "list_tools (all 151 tools):     {:>8.1} µs/call  ({n} calls, {:?} total)",
+            "list_tools (all 152 tools):     {:>8.1} µs/call  ({n} calls, {:?} total)",
             cached_us, cached_elapsed
         );
         eprintln!(

--- a/src/tools/output/social.rs
+++ b/src/tools/output/social.rs
@@ -93,55 +93,56 @@ pub struct TopicImage {
 /// HTTP passthrough of `GET /v1/content/news/{id}`'s `item`. proto3 JSON
 /// encodes `int64` as a string, so `id` / `author.id` arrive as strings;
 /// `published_at` (unix seconds) is converted to RFC3339 by the transform
-/// pipeline.
+/// pipeline. Per the passthrough convention above, every field is `Option` —
+/// the upstream may omit unpopulated proto3 fields.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct NewsDetailResponse {
     /// News article ID (numeric string).
-    pub id: String,
+    pub id: Option<String>,
     /// Title.
-    pub title: String,
+    pub title: Option<String>,
     /// Plain-text excerpt, no HTML tags.
-    pub description: String,
+    pub description: Option<String>,
     /// Markdown content.
-    pub body: String,
+    pub body: Option<String>,
     /// URL to the full article page.
-    pub url: String,
+    pub url: Option<String>,
     /// Article author.
-    pub author: NewsAuthor,
+    pub author: Option<NewsAuthor>,
     /// Attached images.
-    pub images: Vec<NewsImage>,
+    pub images: Option<Vec<NewsImage>>,
     /// Comments count.
-    pub comments_count: i32,
+    pub comments_count: Option<i32>,
     /// Likes count.
-    pub likes_count: i32,
+    pub likes_count: Option<i32>,
     /// Shares count.
-    pub shares_count: i32,
+    pub shares_count: Option<i32>,
     /// Published time (RFC3339).
-    pub published_at: String,
+    pub published_at: Option<String>,
     /// Related stock tickers, format `<CODE>.<MARKET>` (e.g. "AAPL.US").
-    pub tickers: Vec<String>,
+    pub tickers: Option<Vec<String>>,
 }
 
 /// Author of a news article.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct NewsAuthor {
     /// Author ID (numeric string).
-    pub id: String,
+    pub id: Option<String>,
     /// Display name.
-    pub name: String,
+    pub name: Option<String>,
     /// Avatar URL.
-    pub avatar: String,
+    pub avatar: Option<String>,
 }
 
 /// An image attached to a news article.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct NewsImage {
     /// Image URL.
-    pub url: String,
+    pub url: Option<String>,
     /// Width in pixels.
-    pub width: i32,
+    pub width: Option<i32>,
     /// Height in pixels.
-    pub height: i32,
+    pub height: Option<i32>,
 }
 
 /// Returned by `topic_create`. The handler wraps the new topic ID in a single

--- a/src/tools/output/social.rs
+++ b/src/tools/output/social.rs
@@ -88,6 +88,62 @@ pub struct TopicImage {
     pub lg: String,
 }
 
+/// Returned by `news_detail`. One news article's full detail.
+///
+/// HTTP passthrough of `GET /v1/content/news/{id}`'s `item`. proto3 JSON
+/// encodes `int64` as a string, so `id` / `author.id` arrive as strings;
+/// `published_at` (unix seconds) is converted to RFC3339 by the transform
+/// pipeline.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct NewsDetailResponse {
+    /// News article ID (numeric string).
+    pub id: String,
+    /// Title.
+    pub title: String,
+    /// Plain-text excerpt, no HTML tags.
+    pub description: String,
+    /// Markdown content.
+    pub body: String,
+    /// URL to the full article page.
+    pub url: String,
+    /// Article author.
+    pub author: NewsAuthor,
+    /// Attached images.
+    pub images: Vec<NewsImage>,
+    /// Comments count.
+    pub comments_count: i32,
+    /// Likes count.
+    pub likes_count: i32,
+    /// Shares count.
+    pub shares_count: i32,
+    /// Published time (RFC3339).
+    pub published_at: String,
+    /// Related stock tickers, format `<CODE>.<MARKET>` (e.g. "AAPL.US").
+    pub tickers: Vec<String>,
+}
+
+/// Author of a news article.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct NewsAuthor {
+    /// Author ID (numeric string).
+    pub id: String,
+    /// Display name.
+    pub name: String,
+    /// Avatar URL.
+    pub avatar: String,
+}
+
+/// An image attached to a news article.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct NewsImage {
+    /// Image URL.
+    pub url: String,
+    /// Width in pixels.
+    pub width: i32,
+    /// Height in pixels.
+    pub height: i32,
+}
+
 /// Returned by `topic_create`. The handler wraps the new topic ID in a single
 /// `{ "id": ... }` object.
 #[derive(Debug, Serialize, JsonSchema)]


### PR DESCRIPTION
## What

New `news_detail` tool: fetch one news article's full detail by id (ids come from `news` / `news_search`).

Returns `{id, title, description, body (Markdown), url, author{name}, images[], comments_count, likes_count, shares_count, published_at, tickers[]}`.

## Notes

- The endpoint `GET /v1/content/news/:id` is intentionally **not** part of the language SDKs — the tool calls it through the signed raw HTTP client (same pattern as the alert tools).
- Exposed on `/v2` (read-only whitelist), added to the default scope set.
- zh-CN / zh-HK locale entries added; README / server.json tool counts synced 151 → 152.

## Verified

- `cargo clippy` clean; all 146 tests pass (tool-registry invariants, locale drift, scopes).
- Endpoint verified live on staging via the matching CLI change (longbridge/longbridge-terminal#295); production currently returns code=12 (not yet deployed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)