### PR TITLE
fix(schema): OpenAI strict-mode clean for screener_search/top_movers + v0.8.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-mcp"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longbridge-mcp"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2024"
 
 [dependencies]

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.longbridge/mcp",
   "description": "US/HK markets — 152 tools: quotes, options, orders, fundamentals, screener, IPO, alerts & DCA",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.8.6",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.8.7",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -420,11 +420,31 @@ fn normalize_short_trades(
 }
 
 /// Pagination cursor returned by `top_movers`; pass it back verbatim to fetch the next page.
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct TopMoversNextParams {
-    /// Event IDs already seen in previous pages. Pass back verbatim from the
-    /// previous response — do not fabricate.
+    /// Event IDs already seen in previous pages.
     pub visited: Vec<String>,
+}
+
+/// Inlined JSON Schema for `next_params`.
+///
+/// Emitted by hand (not derived from [`TopMoversNextParams`]) so the manifest
+/// stays OpenAI-function-calling compatible: a concrete object with enumerated
+/// fields — no `$ref`/`$defs`, and no `anyOf`/nullable union that OpenAI's
+/// strict mode collapses.
+fn next_params_schema(_: &mut rmcp::schemars::SchemaGenerator) -> rmcp::schemars::Schema {
+    rmcp::schemars::json_schema!({
+        "type": "object",
+        "description": "Pagination cursor from the previous response. Pass its next_params back verbatim to fetch the next page; omit for the first page.",
+        "properties": {
+            "visited": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Event IDs already seen in previous pages. Pass back verbatim from the previous response — do not fabricate."
+            }
+        },
+        "required": ["visited"]
+    })
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -446,6 +466,7 @@ pub struct StockEventsParam {
     /// Pass the entire next_params object returned by the previous call to get the next page.
     /// Omit for the first page.
     #[serde(default)]
+    #[schemars(schema_with = "next_params_schema")]
     pub next_params: Option<TopMoversNextParams>,
 }
 

--- a/src/tools/screener.rs
+++ b/src/tools/screener.rs
@@ -126,22 +126,67 @@ pub async fn screener_strategy(
 }
 
 /// A single Mode-B filter condition. `key` selects the indicator; the other
-/// fields describe the filter and are forwarded to the screener API verbatim.
-#[derive(Debug, Deserialize, JsonSchema)]
+/// fields describe the filter. `tech_values` is accepted either as a JSON
+/// string (the schema-advertised form, required for OpenAI compatibility) or
+/// as an object (tolerated for Anthropic/Gemini clients).
+#[derive(Debug, Deserialize)]
 pub struct ScreenerCondition {
-    /// Indicator key, e.g. "pettm" / "roe" / "macd_day". The "filter_" prefix
-    /// is added automatically if missing.
     pub key: String,
-    /// Minimum value (inclusive), as a numeric string, e.g. "10". Use for
-    /// fundamental range filters.
     pub min: Option<String>,
-    /// Maximum value (inclusive), as a numeric string, e.g. "50".
     pub max: Option<String>,
-    /// Technical-indicator parameters (required for technical keys such as
-    /// macd/rsi/kdj/boll). Shape varies per indicator — call
-    /// `screener_indicators` for the exact schema. Example for macd:
-    /// {"category":"goldenfork","period":"day"}.
     pub tech_values: Option<serde_json::Value>,
+}
+
+/// Inlined JSON Schema for the `conditions` array.
+///
+/// Emitted by hand rather than derived from [`ScreenerCondition`] so the tool
+/// manifest is OpenAI-function-calling compatible: the array `items` is a
+/// concrete object (no `$ref`/`$defs`), and `tech_values` is a JSON *string*
+/// (OpenAI strict mode cannot express the free-form technical-params object).
+/// OpenAI also forces every property `required` and sends unused fields as
+/// empty strings, so the consumer treats `""` as "not provided".
+fn conditions_schema(_: &mut rmcp::schemars::SchemaGenerator) -> rmcp::schemars::Schema {
+    rmcp::schemars::json_schema!({
+        "type": "array",
+        "description": "Mode B — filter conditions. Omit when using strategy_id (Mode A).",
+        "items": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "Indicator key; the \"filter_\" prefix is added automatically if missing.\nFundamental: pettm, pbmrq, roe, roa, netmargin, salesgrowthyoy, netincomegrowthyoy, marketcap, circulating_marketcap, prevclose, prevchg, divyld, la, epsttm, netincome, sales, turnover_rate, balance.\nTechnical: macd_day, macd_week, rsi_day, rsi_week, kdj_day, kdj_week, boll_day, boll_week."
+                },
+                "min": {
+                    "type": "string",
+                    "description": "Lower bound as a numeric string, e.g. \"10\". Pass an empty string when unbounded or for technical keys."
+                },
+                "max": {
+                    "type": "string",
+                    "description": "Upper bound as a numeric string, e.g. \"50\". Pass an empty string when unbounded or for technical keys."
+                },
+                "tech_values": {
+                    "type": "string",
+                    "description": "Technical-indicator params as a JSON string (empty string for fundamental keys):\nmacd_day/week: {\"category\":\"goldenfork\"|\"deadcross\",\"period\":\"day\"|\"week\"}\nrsi_day/week: {\"value_type\":\"overbought\"|\"oversold\"}\nkdj_day/week: {\"category\":\"goldenfork\"|\"deadcross\"}\nboll_day/week: {\"category\":\"breakthrough_up\"|\"breakthrough_down\"}"
+                }
+            },
+            "required": ["key"]
+        }
+    })
+}
+
+/// Normalise a `tech_values` input into the object the screener API expects.
+/// Accepts an object (used verbatim), a JSON string (parsed), and treats empty
+/// string / empty object / null as "not provided".
+fn normalize_tech_values(v: &serde_json::Value) -> Option<serde_json::Value> {
+    match v {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(s) if s.trim().is_empty() => None,
+        serde_json::Value::String(s) => serde_json::from_str(s)
+            .ok()
+            .filter(|parsed| !matches!(parsed, serde_json::Value::Object(o) if o.is_empty())),
+        serde_json::Value::Object(o) if o.is_empty() => None,
+        other => Some(other.clone()),
+    }
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -168,6 +213,11 @@ pub struct ScreenerSearchParam {
     ///   rsi_day/week   → {"value_type":"overbought"|"oversold"}
     ///   kdj_day/week   → {"category":"goldenfork"|"deadcross"}
     ///   boll_day/week  → {"category":"breakthrough_up"|"breakthrough_down"}
+    // Schema is emitted inline (not via ScreenerCondition's `$ref`) and keeps
+    // `tech_values` as a JSON string so the manifest stays OpenAI-function-calling
+    // compatible (no `$defs`/`$ref`, no free-form object).
+    #[serde(default)]
+    #[schemars(schema_with = "conditions_schema")]
     pub conditions: Option<Vec<ScreenerCondition>>,
 
     /// Extra indicator keys to include in each result row (display-only, not used as filters).
@@ -275,27 +325,35 @@ pub async fn screener_search(
         let mut returns: Vec<String> = Vec::new();
 
         for cond in p.conditions.as_deref().unwrap_or(&[]) {
-            if cond.key.is_empty() {
+            let raw_key = cond.key.trim();
+            if raw_key.is_empty() {
                 continue;
             }
-            let key = if cond.key.starts_with("filter_") {
-                cond.key.clone()
+            let key = if raw_key.starts_with("filter_") {
+                raw_key.to_string()
             } else {
-                format!("filter_{}", cond.key)
+                format!("filter_{raw_key}")
             };
             returns.push(key.clone());
             // Build the filter object with the normalised key, forwarding only
-            // the documented fields the screener API accepts.
+            // the documented fields. OpenAI strict mode sends every property,
+            // filling unused ones with empty strings, so treat "" as absent.
             let mut f = serde_json::Map::new();
             f.insert("key".to_string(), serde_json::Value::String(key));
-            if let Some(ref min) = cond.min {
-                f.insert("min".to_string(), serde_json::Value::String(min.clone()));
+            if let Some(min) = cond.min.as_deref().filter(|s| !s.trim().is_empty()) {
+                f.insert(
+                    "min".to_string(),
+                    serde_json::Value::String(min.to_string()),
+                );
             }
-            if let Some(ref max) = cond.max {
-                f.insert("max".to_string(), serde_json::Value::String(max.clone()));
+            if let Some(max) = cond.max.as_deref().filter(|s| !s.trim().is_empty()) {
+                f.insert(
+                    "max".to_string(),
+                    serde_json::Value::String(max.to_string()),
+                );
             }
-            if let Some(ref tech_values) = cond.tech_values {
-                f.insert("tech_values".to_string(), tech_values.clone());
+            if let Some(tech_values) = cond.tech_values.as_ref().and_then(normalize_tech_values) {
+                f.insert("tech_values".to_string(), tech_values);
             }
             filters.push(serde_json::Value::Object(f));
         }


### PR DESCRIPTION
## What

Makes the two remaining permissive tool schemas fully **OpenAI function-calling strict-mode compatible**, and bumps the version to **0.8.7** for release.

Follow-up to #123. #123 removed the hard blockers (`items: true` on `screener_search.conditions`, free-map `additionalProperties: true` on `top_movers.next_params`), but the generated schemas still tripped OpenAI-strict *warnings* (`$ref`/`$defs`, `anyOf`/nullable union) and didn't follow the upstream service's recommended shape for `tech_values` / empty-string handling.

## Changes

**`screener_search.conditions`**
- Emit the array item schema **inline** via `schema_with` (no `$ref`/`$defs`) — `items` is a concrete object.
- `tech_values` is advertised as a **JSON string** (`type: string`). OpenAI strict mode can't express the free-form technical-params object; the consumer parses the string back to an object, and still accepts a raw object from Anthropic/Gemini clients.
- Tolerate **empty strings**: OpenAI strict mode forces every property `required` and fills unused fields with `""`, so `min`/`max`/`tech_values == ""` are treated as "not provided".

**`top_movers.next_params`**
- Emit an **inline** object schema with the enumerated `visited` field (no `$ref`, no `anyOf`/nullable union).

**Release**
- `Version 0.8.7` — `Cargo.toml`, `Cargo.lock`, `server.json` (`version` + OCI image tag).

## Verification

- `check_openai_compat.py` (upstream service's checker) against the running manifest: **0 BLOCKER / 0 SILENT-BREAK / 0 WARN** across all 152 tools. (#123 left 2 `$ref` WARNs; now zero.)
- `cargo +nightly fmt`, `cargo clippy --all-features --all-targets`: clean.
- `cargo test`: 147 pass.

## Release note

After merge, tag `v0.8.7` to trigger the release workflow (Docker image + GitHub release).
