### PR TITLE
chore(deps): Update longbridge SDK to `32cb424b`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,7 +1491,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 [[package]]
 name = "longbridge"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",
@@ -1527,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "bitflags 2.13.1",
  "num-traits",
@@ -1539,7 +1539,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "dotenv",
  "eventsource-stream",
@@ -1602,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "dirs",
  "futures-util",
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "prost",
  "serde",
@@ -1628,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "byteorder",
  "flate2",


### PR DESCRIPTION
Picks up [longbridge/openapi#576](https://github.com/longbridge/openapi/pull/576).

`SPCX.US` resolved to the counter_id `ETF/US/SPCX` instead of `ST/US/SPCX`, so every counter_id-based endpoint queried the wrong instrument type and the backend returned `code=2601400: internal server error`. SPCX used to be the AXS SPAC and New Issue ETF, which has since delisted; the ticker now belongs to SpaceX (a stock). The SDK's embedded counter_id directory still carried the stale ETF entry.

Lockfile-only change. `cargo clippy --all-features --all-targets` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)