### PR TITLE
fix(tools): report tool failures as isError and stop requiring avoidable params

### DIFF
--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -488,12 +488,12 @@
     },
     "finance_calendar": {
       "title": "财经日历",
-      "description": "获取财经日历事件。category：report（财报+业绩）/ dividend（除息日与派发日）/ split（拆股/反拆）/ ipo / macrodata（CPI、非农、议息等）/ closed（休市日）；market：HK/US/CN/SG/JP/UK/DE/AU。日期范围建议不超过 2 周；如需查询更长时间段，请拆分为多次调用以避免数据截断。",
+      "description": "获取财经日历事件。category：report（财报）/ dividend（除息与派息）/ split（拆股与反向拆股）/ ipo / macrodata（CPI、非农、议息等）/ closed（休市日）。start、end（`yyyy-mm-dd`）均可选，默认为今天起 7 天；范围建议不超过 2 周，否则结果会被截断。",
       "properties": {
         "market": "市场代码：HK、US、CN、SG，省略则查询所有市场",
-        "start": "起始日期（`yyyy-mm-dd`）",
-        "end": "结束日期（`yyyy-mm-dd`）",
-        "category": "事件类别：<br>- `financial`：业绩 / 财报公告<br>- `report`：财报披露排期<br>- `dividend`：除息日与派发日<br>- `ipo`：IPO 上市日期<br>- `macrodata`：宏观数据发布（GDP、CPI 等）<br>- `closed`：市场休市 / 停牌日期"
+        "start": "起始日期（`yyyy-mm-dd`），可选，默认为今天",
+        "end": "结束日期（`yyyy-mm-dd`），可选，默认为起始日期之后 7 天",
+        "category": "事件类别：`report`（财报披露）/ `dividend`（除息日与派发日）/ `split`（拆股与反向拆股）/ `ipo`（IPO 上市日期）/ `macrodata`（宏观数据发布，如 GDP、CPI、非农）/ `closed`（市场休市日）"
       }
     },
     "financial_report": {
@@ -662,27 +662,27 @@
     },
     "history_candlesticks_by_date": {
       "title": "历史 K 线（按日期）",
-      "description": "按日期区间获取历史 K 线（OHLCV）数据。period：1m/5m/15m/30m/60m/day/week/month/year",
+      "description": "按日期区间获取历史 K 线（OHLCV）数据。仅 symbol 必填，period 默认 day、forward_adjust 默认 false、trade_sessions 默认 all。period：1m/5m/15m/30m/60m/day/week/month/year",
       "properties": {
         "symbol": "证券代码",
-        "period": "K 线周期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`",
-        "forward_adjust": "是否对拆股 / 派息进行前复权",
+        "period": "K 线周期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`（默认 `day`）",
+        "forward_adjust": "是否对拆股 / 派息进行前复权（默认 `false`，不复权）",
         "start": "起始日期（`yyyy-mm-dd`），可选",
         "end": "结束日期（`yyyy-mm-dd`），可选",
-        "trade_sessions": "交易时段：`intraday`（仅常规时段）或 `all`（含盘前盘后）"
+        "trade_sessions": "交易时段：`intraday`（仅常规时段）或 `all`（含盘前盘后，默认）"
       }
     },
     "history_candlesticks_by_offset": {
       "title": "历史 K 线（按偏移）",
-      "description": "以参考时间为锚点按偏移量获取历史 K 线（OHLCV）数据。period：1m/5m/15m/30m/60m/day/week/month/year",
+      "description": "以参考时间为锚点按偏移量获取历史 K 线（OHLCV）数据。仅 symbol 必填，period 默认 day、count 默认 100、forward_adjust 与 forward 默认 false、trade_sessions 默认 all。",
       "properties": {
         "symbol": "证券代码",
-        "period": "K 线周期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`",
-        "forward_adjust": "是否对拆股 / 派息进行前复权",
-        "forward": "查询方向：`true` 向后（向未来），`false` 向前（向过去）",
+        "period": "K 线周期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`（默认 `day`）",
+        "forward_adjust": "是否对拆股 / 派息进行前复权（默认 `false`，不复权）",
+        "forward": "查询方向：`true` 向后（向未来），`false` 向前（向过去，默认）",
         "time": "参考时间（`yyyy-mm-ddTHH:MM:SS`），省略则以最新时间为起点",
-        "count": "K 线数量（最多 1000）",
-        "trade_sessions": "交易时段：`intraday`（仅常规时段）或 `all`（含盘前盘后）"
+        "count": "K 线数量（最多 1000，默认 100）",
+        "trade_sessions": "交易时段：`intraday`（仅常规时段）或 `all`（含盘前盘后，默认）"
       }
     },
     "history_market_temperature": {

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -488,12 +488,12 @@
     },
     "finance_calendar": {
       "title": "財經日曆",
-      "description": "獲取財經日曆事件。category：report（財報+業績）/ dividend（除息日與派發日）/ split（拆股/反拆）/ ipo / macrodata（CPI、非農、議息等）/ closed（休市日）；market：HK/US/CN/SG/JP/UK/DE/AU。日期範圍建議不超過 2 週；如需查詢更長時間段，請拆分為多次呼叫以避免資料截斷。",
+      "description": "獲取財經日曆事件。category：report（財報）/ dividend（除息與派息）/ split（拆股與反向拆股）/ ipo / macrodata（CPI、非農、議息等）/ closed（休市日）。start、end（`yyyy-mm-dd`）均為可選，預設為今天起 7 天；範圍建議不超過 2 週，否則結果會被截斷。",
       "properties": {
         "market": "市場代碼：HK、US、CN、SG，省略則查詢所有市場",
-        "start": "起始日期（`yyyy-mm-dd`）",
-        "end": "結束日期（`yyyy-mm-dd`）",
-        "category": "事件類別：<br>- `financial`：業績 / 財報公告<br>- `report`：財報披露排期<br>- `dividend`：除息日與派發日<br>- `ipo`：IPO 上市日期<br>- `macrodata`：宏觀數據發佈（GDP、CPI 等）<br>- `closed`：市場休市 / 停牌日期"
+        "start": "起始日期（`yyyy-mm-dd`），可選，預設為今天",
+        "end": "結束日期（`yyyy-mm-dd`），可選，預設為起始日期之後 7 天",
+        "category": "事件類別：`report`（財報披露）/ `dividend`（除息日與派發日）/ `split`（拆股與反向拆股）/ `ipo`（IPO 上市日期）/ `macrodata`（宏觀數據發佈，如 GDP、CPI、非農）/ `closed`（市場休市日）"
       }
     },
     "financial_report": {
@@ -662,27 +662,27 @@
     },
     "history_candlesticks_by_date": {
       "title": "歷史 K 線（按日期）",
-      "description": "按日期區間獲取歷史 K 線（OHLCV）數據。period：1m/5m/15m/30m/60m/day/week/month/year",
+      "description": "按日期區間獲取歷史 K 線（OHLCV）數據。僅 symbol 必填，period 預設 day、forward_adjust 預設 false、trade_sessions 預設 all。period：1m/5m/15m/30m/60m/day/week/month/year",
       "properties": {
         "symbol": "證券代碼",
-        "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`",
-        "forward_adjust": "是否對拆股 / 派息進行前復權",
+        "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`（預設 `day`）",
+        "forward_adjust": "是否對拆股 / 派息進行前復權（預設 `false`，不復權）",
         "start": "起始日期（`yyyy-mm-dd`），可選",
         "end": "結束日期（`yyyy-mm-dd`），可選",
-        "trade_sessions": "交易時段：`intraday`（僅常規時段）或 `all`（含盤前盤後）"
+        "trade_sessions": "交易時段：`intraday`（僅常規時段）或 `all`（含盤前盤後，預設）"
       }
     },
     "history_candlesticks_by_offset": {
       "title": "歷史 K 線（按偏移）",
-      "description": "以參考時間為錨點按偏移量獲取歷史 K 線（OHLCV）數據。period：1m/5m/15m/30m/60m/day/week/month/year",
+      "description": "以參考時間為錨點按偏移量獲取歷史 K 線（OHLCV）數據。僅 symbol 必填，period 預設 day、count 預設 100、forward_adjust 與 forward 預設 false、trade_sessions 預設 all。",
       "properties": {
         "symbol": "證券代碼",
-        "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`",
-        "forward_adjust": "是否對拆股 / 派息進行前復權",
-        "forward": "查詢方向：`true` 向後（向未來），`false` 向前（向過去）",
+        "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`（預設 `day`）",
+        "forward_adjust": "是否對拆股 / 派息進行前復權（預設 `false`，不復權）",
+        "forward": "查詢方向：`true` 向後（向未來），`false` 向前（向過去，預設）",
         "time": "參考時間（`yyyy-mm-ddTHH:MM:SS`），省略則以最新時間為起點",
-        "count": "K 線數量（最多 1000）",
-        "trade_sessions": "交易時段：`intraday`（僅常規時段）或 `all`（含盤前盤後）"
+        "count": "K 線數量（最多 1000，預設 100）",
+        "trade_sessions": "交易時段：`intraday`（僅常規時段）或 `all`（含盤前盤後，預設）"
       }
     },
     "history_market_temperature": {

--- a/src/tools/calendar.rs
+++ b/src/tools/calendar.rs
@@ -7,9 +7,19 @@ use rmcp::serde::Deserialize;
 
 use crate::error::Error;
 use crate::serialize::{convert_unix_paths, transform_json};
+use crate::tools::support::parse;
 
 /// Maximum pages to fetch per request (matches CLI behaviour).
 const MAX_PAGES: usize = 20;
+
+/// Accepted `category` values, in the order shown to callers on a bad input.
+const CATEGORIES: [&str; 6] = ["report", "dividend", "split", "ipo", "macrodata", "closed"];
+
+/// Window length used when the caller supplies `start` but omits `end`.
+const DEFAULT_RANGE_DAYS: i64 = 7;
+
+const DATE_FORMAT: &[time::format_description::FormatItem<'_>] =
+    time::macros::format_description!("[year]-[month]-[day]");
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct FinanceCalendarParam {
@@ -21,10 +31,10 @@ pub struct FinanceCalendarParam {
     /// - "macrodata": macro economic data releases (CPI, NFP, rate decisions, etc.)
     /// - "closed": market closure days
     pub category: String,
-    /// Start date in YYYY-MM-DD format (inclusive)
-    pub start: String,
-    /// End date in YYYY-MM-DD format (inclusive)
-    pub end: String,
+    /// Start date in YYYY-MM-DD format (inclusive). Defaults to today (UTC).
+    pub start: Option<String>,
+    /// End date in YYYY-MM-DD format (inclusive). Defaults to 7 days after `start`.
+    pub end: Option<String>,
     /// Optional market filter. One of: HK, US, CN, SG, JP, UK, DE, AU.
     /// Omit to include all markets.
     pub market: Option<String>,
@@ -76,20 +86,74 @@ fn merge_pages(pages: impl IntoIterator<Item = serde_json::Value>) -> serde_json
     serde_json::json!({ "list": list })
 }
 
+/// Normalize `category`, accepting any capitalization and surrounding space.
+fn normalize_category(raw: &str) -> Result<String, McpError> {
+    let lower = raw.trim().to_lowercase();
+    if CATEGORIES.contains(&lower.as_str()) {
+        Ok(lower)
+    } else {
+        Err(McpError::invalid_params(
+            format!(
+                "invalid category '{raw}', expected one of: {}",
+                CATEGORIES.join(", ")
+            ),
+            None,
+        ))
+    }
+}
+
+/// Resolve the requested window: `start` defaults to today (UTC), `end` to
+/// [`DEFAULT_RANGE_DAYS`] after `start`.
+fn resolve_range(start: Option<&str>, end: Option<&str>) -> Result<(String, String), McpError> {
+    let start_date = match start {
+        Some(s) => parse::parse_date(s)?,
+        None => time::OffsetDateTime::now_utc().date(),
+    };
+    let end_date = match end {
+        Some(s) => parse::parse_date(s)?,
+        None => start_date.saturating_add(time::Duration::days(DEFAULT_RANGE_DAYS)),
+    };
+    if end_date < start_date {
+        return Err(McpError::invalid_params(
+            format!("end date {end_date} is earlier than start date {start_date}"),
+            None,
+        ));
+    }
+
+    let fmt = |d: time::Date| -> Result<String, McpError> {
+        d.format(DATE_FORMAT)
+            .map_err(|e| Error::Other(format!("failed to format date: {e}")).into())
+    };
+    Ok((fmt(start_date)?, fmt(end_date)?))
+}
+
 pub async fn finance_calendar(
     mctx: &crate::tools::McpContext,
     p: FinanceCalendarParam,
 ) -> Result<CallToolResult, McpError> {
+    let category = normalize_category(&p.category)?;
+    let (start, end) = resolve_range(p.start.as_deref(), p.end.as_deref())?;
     let market_upper = p.market.as_deref().map(str::to_uppercase);
 
     let mut pages: Vec<serde_json::Value> = Vec::new();
-    let mut current_date = p.start.clone();
+    let mut current_date = start.clone();
+    // Set when the walk stops before covering the whole window, so the caller
+    // is told the result is short rather than silently reading it as complete.
+    let mut partial_reason: Option<String> = None;
 
-    for _ in 0..MAX_PAGES {
+    let mut fetched = 0usize;
+    loop {
+        if fetched >= MAX_PAGES {
+            partial_reason = Some(format!(
+                "stopped after {MAX_PAGES} pages; events from {current_date} to {end} are not included"
+            ));
+            break;
+        }
+
         let mut params: Vec<(&str, &str)> = vec![
             ("date", current_date.as_str()),
-            ("date_end", p.end.as_str()),
-            ("types[]", p.category.as_str()),
+            ("date_end", end.as_str()),
+            ("types[]", category.as_str()),
             ("next", "later"),
             ("count", "100"),
             ("offset", "0"),
@@ -100,23 +164,34 @@ pub async fn finance_calendar(
 
         // Create a fresh client per page — the upstream server closes the
         // connection after each response, causing SendRequest on reuse.
-        let resp: String = mctx
+        let resp = mctx
             .create_http_client()
             .request(reqwest::Method::GET, "/v1/quote/finance_calendar")
             .query_params(params)
             .response::<String>()
             .send()
-            .await
-            .map_err(|e| Error::Other(e.to_string()))?;
+            .await;
+
+        // One bad page should not discard the pages that already succeeded:
+        // report what was collected and say where the walk stopped.
+        let resp: String = match resp {
+            Ok(resp) => resp,
+            Err(e) if pages.is_empty() => return Err(Error::Other(e.to_string()).into()),
+            Err(e) => {
+                partial_reason = Some(format!(
+                    "upstream request failed at {current_date}: {e}; events from {current_date} to {end} are not included"
+                ));
+                break;
+            }
+        };
 
         let raw: serde_json::Value = serde_json::from_str(&resp).map_err(Error::Serialize)?;
         let next_date = next_date_of(&raw);
         pages.push(raw);
+        fetched += 1;
 
         match next_date {
-            Some(nd) if nd.as_str() <= p.end.as_str() && nd != current_date => {
-                current_date = nd;
-            }
+            Some(nd) if nd.as_str() <= end.as_str() && nd != current_date => current_date = nd,
             _ => break,
         }
     }
@@ -131,6 +206,10 @@ pub async fn finance_calendar(
     let mut value: serde_json::Value =
         serde_json::from_str(&transformed).map_err(Error::Serialize)?;
     convert_unix_paths(&mut value, &["list.*.infos.*.datetime"]);
+    if let Some(reason) = partial_reason {
+        value["partial"] = serde_json::Value::Bool(true);
+        value["partial_reason"] = serde_json::Value::String(reason);
+    }
     let json = serde_json::to_string(&value).map_err(Error::Serialize)?;
     Ok(crate::tools::tool_result(json))
 }
@@ -253,5 +332,63 @@ mod tests {
     #[test]
     fn next_date_equal_end_continues() {
         assert!("2026-05-30" <= "2026-05-30");
+    }
+
+    #[test]
+    fn normalize_category_accepts_known_values_case_insensitively() {
+        assert_eq!(normalize_category("report").unwrap(), "report");
+        assert_eq!(normalize_category("  MacroData ").unwrap(), "macrodata");
+    }
+
+    #[test]
+    fn normalize_category_rejects_unknown_value_and_lists_candidates() {
+        let err = normalize_category("financial").unwrap_err();
+        assert!(
+            err.message.contains("report") && err.message.contains("macrodata"),
+            "error should list the accepted categories, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn resolve_range_defaults_to_today_plus_a_week() {
+        let (start, end) = resolve_range(None, None).unwrap();
+        let today = time::OffsetDateTime::now_utc().date();
+        assert_eq!(start, today.format(DATE_FORMAT).unwrap());
+        assert_eq!(
+            end,
+            today
+                .saturating_add(time::Duration::days(DEFAULT_RANGE_DAYS))
+                .format(DATE_FORMAT)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn resolve_range_defaults_end_relative_to_given_start() {
+        let (start, end) = resolve_range(Some("2026-01-01"), None).unwrap();
+        assert_eq!(start, "2026-01-01");
+        assert_eq!(end, "2026-01-08");
+    }
+
+    #[test]
+    fn resolve_range_keeps_an_explicit_window() {
+        let (start, end) = resolve_range(Some("2026-01-01"), Some("2026-01-05")).unwrap();
+        assert_eq!((start.as_str(), end.as_str()), ("2026-01-01", "2026-01-05"));
+    }
+
+    #[test]
+    fn resolve_range_rejects_an_inverted_window() {
+        let err = resolve_range(Some("2026-01-10"), Some("2026-01-01")).unwrap_err();
+        assert!(
+            err.message.contains("earlier than"),
+            "unexpected message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn resolve_range_rejects_a_malformed_date() {
+        assert!(resolve_range(Some("2026/01/01"), None).is_err());
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -48,9 +48,64 @@ where
             let result = f().await;
             let duration = start.elapsed().as_secs_f64();
             crate::metrics::record_tool_call(name, duration, result.is_err());
-            result
+            // The request was routed and the tool ran, so a failure here is a
+            // tool-level error, not a protocol one. MCP clients render protocol
+            // errors opaquely ("tool result missing due to internal error"),
+            // which hides the reason from the model and denies it any chance to
+            // correct the call. Returning `isError` puts the message in front of
+            // the model instead. Protocol errors stay with the framework, which
+            // rejects unroutable calls (unknown tool, unparseable arguments)
+            // before this wrapper is ever reached.
+            Ok(result.unwrap_or_else(|err| tool_error(name, &err)))
         })
         .await
+}
+
+/// Render a failed tool call as a caller-visible `isError` result.
+///
+/// `structured_content` is deliberately left unset: a tool that declares an
+/// `outputSchema` must not return structured content that fails to match it,
+/// and an error payload never does.
+fn tool_error(name: &str, err: &McpError) -> CallToolResult {
+    let mut text = format!("{name} failed: {}", err.message);
+    if let Some(hint) = error_hint(err) {
+        text.push_str("\n\n");
+        text.push_str(hint);
+    }
+    CallToolResult::error(vec![Content::text(text)])
+}
+
+/// Actionable follow-up for the error classes users hit most, so the model can
+/// either fix the call itself or tell the user what to do.
+fn error_hint(err: &McpError) -> Option<&'static str> {
+    if err.code == rmcp::model::ErrorCode::INVALID_PARAMS {
+        return Some(
+            "Hint: check the argument values against this tool's input schema, then retry.",
+        );
+    }
+
+    let msg = err.message.to_lowercase();
+    if ["permission", "forbidden", "not authorized", "403", "scope"]
+        .iter()
+        .any(|needle| msg.contains(needle))
+    {
+        return Some(
+            "Hint: this is a permission error. The most common cause is that the OAuth \
+             authorization was granted with only part of the available scopes. Ask the user to \
+             reconnect this MCP server and approve the full set of permissions (watchlist, \
+             portfolio, and trading scopes) before retrying.",
+        );
+    }
+    if ["unauthorized", "401", "token", "expired"]
+        .iter()
+        .any(|needle| msg.contains(needle))
+    {
+        return Some(
+            "Hint: the access token is missing, expired, or invalid. Ask the user to reconnect \
+             this MCP server to re-authorize, granting the full set of permissions.",
+        );
+    }
+    None
 }
 
 mod alert;
@@ -1379,7 +1434,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        description = "Get historical candlestick data by offset from a reference time. period: 1m/5m/15m/30m/60m/day/week/month/year"
+        description = "Get historical candlestick data by offset from a reference time. Only symbol is required; period defaults to day (1m/5m/15m/30m/60m/day/week/month/year), count to 100, forward_adjust/forward to false, trade_sessions to all."
     )]
     async fn history_candlesticks_by_offset(
         &self,
@@ -1402,7 +1457,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        description = "Get historical candlestick data by date range. period: 1m/5m/15m/30m/60m/day/week/month/year"
+        description = "Get historical candlestick data by date range. Only symbol is required; period defaults to day (1m/5m/15m/30m/60m/day/week/month/year), forward_adjust to false, trade_sessions to all."
     )]
     async fn history_candlesticks_by_date(
         &self,
@@ -2655,7 +2710,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::market::FinanceCalendarResponse>(),
-        description = "Get finance calendar events by category and date range. category: report (earnings + financials) / dividend / split (splits & reverse splits) / ipo / macrodata (CPI, NFP, rate decisions) / closed (market holidays). market: HK/US/CN/SG/JP/UK/DE/AU (optional). Keep the date range to 2 weeks or less; for longer periods split into multiple calls to avoid truncation."
+        description = "Finance calendar by category: report (earnings) / dividend / split / ipo / macrodata (CPI, NFP, rates) / closed (holidays). start and end (YYYY-MM-DD) are optional, default today plus 7 days; keep ranges under 2 weeks or results truncate."
     )]
     async fn finance_calendar(
         &self,
@@ -5612,6 +5667,102 @@ mod quote_cmd_tests {
             hot_us * 5.0 < rebuild_us,
             "expected hot path ({hot_us:.1}µs) to be at least 5× faster \
              than rebuild ({rebuild_us:.1}µs)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tool_error_tests {
+    use super::{error_hint, measured_tool_call, tool_error, tool_result};
+    use rmcp::ErrorData as McpError;
+    use rmcp::model::CallToolResult;
+
+    fn text_of(result: &CallToolResult) -> String {
+        result
+            .content
+            .iter()
+            .filter_map(|c| c.as_text().map(|t| t.text.clone()))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn tool_error_marks_the_result_and_names_the_tool() {
+        let err = McpError::internal_error("upstream exploded", None);
+        let result = tool_error("finance_calendar", &err);
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.structured_content.is_none());
+        let text = text_of(&result);
+        assert!(
+            text.contains("finance_calendar") && text.contains("upstream exploded"),
+            "unexpected error text: {text}"
+        );
+    }
+
+    #[test]
+    fn invalid_params_hint_points_at_the_input_schema() {
+        let err = McpError::invalid_params("invalid period 'daily'", None);
+        assert!(
+            error_hint(&err).is_some_and(|h| h.contains("input schema")),
+            "expected an input-schema hint"
+        );
+    }
+
+    #[test]
+    fn permission_errors_hint_at_reconnecting_for_full_scopes() {
+        for message in [
+            "403 Forbidden",
+            "no permission for this endpoint",
+            "missing scope: trade",
+        ] {
+            let err = McpError::internal_error(message.to_string(), None);
+            let hint = error_hint(&err).unwrap_or_else(|| panic!("no hint for {message:?}"));
+            assert!(
+                hint.contains("reconnect") && hint.contains("scopes"),
+                "hint for {message:?} should mention reconnecting for full scopes, got: {hint}"
+            );
+        }
+    }
+
+    #[test]
+    fn expired_token_errors_hint_at_reauthorizing() {
+        let err = McpError::internal_error("access token expired", None);
+        assert!(
+            error_hint(&err).is_some_and(|h| h.contains("reconnect")),
+            "expected a re-authorization hint"
+        );
+    }
+
+    #[test]
+    fn ordinary_errors_get_no_hint() {
+        let err = McpError::internal_error("symbol not found", None);
+        assert!(error_hint(&err).is_none());
+    }
+
+    #[tokio::test]
+    async fn measured_tool_call_reports_failures_as_tool_errors() {
+        let result = measured_tool_call("some_tool", || async {
+            Err(McpError::internal_error("upstream 500", None))
+        })
+        .await
+        .expect("a failing tool must not surface as a protocol error");
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(text_of(&result).contains("upstream 500"));
+    }
+
+    #[tokio::test]
+    async fn measured_tool_call_passes_success_through_untouched() {
+        let result = measured_tool_call("some_tool", || async {
+            Ok(tool_result(r#"{"ok":true}"#.to_string()))
+        })
+        .await
+        .expect("successful call");
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(
+            result.structured_content,
+            Some(serde_json::json!({"ok": true}))
         );
     }
 }

--- a/src/tools/output/market.rs
+++ b/src/tools/output/market.rs
@@ -378,6 +378,13 @@ pub struct FinanceCalendarResponse {
     /// Date buckets, sorted ascending by date.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub list: Option<Vec<FinanceCalendarBucket>>,
+    /// Present and `true` when the walk stopped before covering the whole
+    /// requested window, so `list` is known to be incomplete.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partial: Option<bool>,
+    /// Why the result is partial, and which part of the window is missing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partial_reason: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -84,20 +84,25 @@ fn default_trade_sessions() -> String {
 pub struct HistoryCandlesticksByOffsetParam {
     /// Security symbol, e.g. "700.HK"
     pub symbol: String,
-    /// Period: 1m, 5m, 15m, 30m, 60m, day, week, month, year
+    /// Period: 1m, 5m, 15m, 30m, 60m, day, week, month, year (default: day)
+    #[serde(default = "default_candlestick_period")]
     pub period: String,
-    /// Whether to forward-adjust for splits/dividends
-    #[serde(deserialize_with = "tolerant_bool")]
+    /// Whether to forward-adjust for splits/dividends (default: false / no adjust)
+    #[serde(default, deserialize_with = "tolerant_bool")]
     pub forward_adjust: bool,
-    /// Whether to query forward in time (true) or backward (false)
-    #[serde(deserialize_with = "tolerant_bool")]
+    /// Whether to query forward in time (true) or backward (false; default)
+    #[serde(default, deserialize_with = "tolerant_bool")]
     pub forward: bool,
     /// Reference datetime (yyyy-mm-ddTHH:MM:SS), omit to start from latest
     pub time: Option<String>,
-    /// Number of candlesticks (max 1000)
-    #[serde(deserialize_with = "tolerant_usize")]
+    /// Number of candlesticks (optional, max 1000; default 100)
+    #[serde(
+        default = "default_candlestick_count",
+        deserialize_with = "tolerant_usize"
+    )]
     pub count: usize,
-    /// Trade sessions: "intraday" (regular hours only) or "all" (include pre-market and post-market)
+    /// Trade sessions: "intraday" (regular hours only) or "all" (include pre-market and post-market; default "all")
+    #[serde(default = "default_trade_sessions")]
     pub trade_sessions: String,
 }
 
@@ -105,16 +110,18 @@ pub struct HistoryCandlesticksByOffsetParam {
 pub struct HistoryCandlesticksByDateParam {
     /// Security symbol, e.g. "700.HK"
     pub symbol: String,
-    /// Period: 1m, 5m, 15m, 30m, 60m, day, week, month, year
+    /// Period: 1m, 5m, 15m, 30m, 60m, day, week, month, year (default: day)
+    #[serde(default = "default_candlestick_period")]
     pub period: String,
-    /// Whether to forward-adjust for splits/dividends
-    #[serde(deserialize_with = "tolerant_bool")]
+    /// Whether to forward-adjust for splits/dividends (default: false / no adjust)
+    #[serde(default, deserialize_with = "tolerant_bool")]
     pub forward_adjust: bool,
     /// Start date (yyyy-mm-dd), optional
     pub start: Option<String>,
     /// End date (yyyy-mm-dd), optional
     pub end: Option<String>,
-    /// Trade sessions: "intraday" (regular hours only) or "all" (include pre-market and post-market)
+    /// Trade sessions: "intraday" (regular hours only) or "all" (include pre-market and post-market; default "all")
+    #[serde(default = "default_trade_sessions")]
     pub trade_sessions: String,
 }
 
@@ -1047,5 +1054,45 @@ mod tests {
         assert!(obj["post_market"].is_object());
         assert!(obj["overnight"].is_null());
         assert!(obj["pre_market"].is_null());
+    }
+
+    #[test]
+    fn history_candlesticks_by_date_fills_defaults_from_symbol_alone() {
+        let p: super::HistoryCandlesticksByDateParam =
+            serde_json::from_value(json!({"symbol": "700.HK"}))
+                .expect("symbol alone should be a valid call");
+        assert_eq!(p.period, "day");
+        assert_eq!(p.trade_sessions, "all");
+        assert!(!p.forward_adjust);
+        assert!(p.start.is_none() && p.end.is_none());
+    }
+
+    #[test]
+    fn history_candlesticks_by_offset_fills_defaults_from_symbol_alone() {
+        let p: super::HistoryCandlesticksByOffsetParam =
+            serde_json::from_value(json!({"symbol": "AAPL.US"}))
+                .expect("symbol alone should be a valid call");
+        assert_eq!(p.period, "day");
+        assert_eq!(p.trade_sessions, "all");
+        assert_eq!(p.count, 100);
+        assert!(!p.forward_adjust);
+        assert!(!p.forward);
+        assert!(p.time.is_none());
+    }
+
+    #[test]
+    fn history_candlesticks_params_still_honour_explicit_values() {
+        let p: super::HistoryCandlesticksByDateParam = serde_json::from_value(json!({
+            "symbol": "700.HK",
+            "period": "week",
+            "forward_adjust": "true",
+            "trade_sessions": "intraday",
+            "start": "2026-01-01",
+        }))
+        .expect("explicit values should deserialize");
+        assert_eq!(p.period, "week");
+        assert_eq!(p.trade_sessions, "intraday");
+        assert!(p.forward_adjust);
+        assert_eq!(p.start.as_deref(), Some("2026-01-01"));
     }
 }


### PR DESCRIPTION
The Claude Directory panel shows a 6.4% 30-day error rate, almost all of it `jsonrpc_error` at the request layer (tool-result errors are only 0.3%). Three separate causes, fixed here.

## 1. Every runtime failure became a JSON-RPC `internal_error`

There was no `isError` path anywhere in the codebase — `From<Error> for McpError` mapped everything to `internal_error`, so upstream business errors (missing permission, unknown symbol, rate limits) reached clients as opaque protocol errors the model never gets to read or correct.

`measured_tool_call` now renders failures as `isError` tool results. The request was routed and the tool ran, so a failure there is a tool-level error by the MCP spec; protocol errors stay with the framework, which rejects unroutable calls (unknown tool, unparseable arguments) before this wrapper is reached. One change covers all 170 tools.

`error_hint` adds actionable follow-ups for the classes users actually hit:

- **403 / permission / scope** → the OAuth authorization was likely granted with only part of the available scopes; ask the user to reconnect the MCP server and approve the full set (watchlist, portfolio, and trading scopes).
- **401 / token / expired** → token missing or expired, reconnect to re-authorize.
- **invalid params** → check the values against the tool's input schema and retry.

Order safety is unchanged: `dry_run::Scope::verify` still returns before submission, so a mismatched confirmation code never places an order — the model can now actually read the self-heal instructions it returns.

## 2. Historical candlestick tools required avoidable params

`history_candlesticks_by_date` (22.4% errors) and `history_candlesticks_by_offset` (9.9%) required `period`, `forward_adjust` and `trade_sessions`, while the sibling `candlesticks` defaults all of them and errors at **1.7%**. Those fields now default the same way (day / false / all, plus 100 and false for offset's `count` / `forward`), so `symbol` alone is a valid call.

## 3. `finance_calendar` was brittle end to end

At 23.6% it was the worst tool in the panel:

- `start` / `end` were required — now optional, defaulting to today .. +7 days, with an explicit error when `end` precedes `start`.
- `category` was passed through unvalidated — now normalized case-insensitively and checked against the six accepted values, listing them back on a miss.
- Any one of its up-to-20 pages failing killed the whole call — a short walk now returns what it collected plus `partial` / `partial_reason` saying which part of the window is missing. A first-page failure still errors.
- Its description was 364 chars, past the 240-char `tools/list` limit for tools with an `outputSchema`, so the "keep the range under 2 weeks" sentence was truncated away entirely and the model never saw the constraint. Rewritten to 238.

The zh-CN / zh-HK locales are updated to match, including a `category` list that advertised a `financial` value the code never accepted.

## Testing

`cargo +nightly fmt --check` clean, `cargo clippy --all-features --all-targets` with zero warnings, 188 tests passing (16 new) covering the error-to-`isError` conversion, each hint class, the new parameter defaults, and `finance_calendar`'s category/range resolution.

## Note on the metric

Errors that are genuinely upstream (e.g. `stock_positions` at 14.5%, all permission-related) will **move** from `jsonrpc_error` to the tool-result error column rather than disappear. The volume reduction should come from 2 and 3, where the failures were avoidable.

Separately, 10 other tools with an `outputSchema` still have descriptions truncated at 240 chars — `screener_search` (-573), `grid_submit` (-462), `financial_statement` (-336), `submit_order` (-333), `grid_symbol_info` (-322), `top_movers` (-175), `financial_report` (-148), `valuation_comparison`, `screener_indicators`, `short_trades`. Left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
