### PR TITLE
fix(tools): adopt case-insensitive parsing and partial success from #131

### DIFF
--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -60,6 +60,26 @@ pub async fn financial_report(
     http_get_tool(&client, "/v1/quote/financial-reports", &params).await
 }
 
+/// Pull one half of `institution_rating`'s response out of a sub-request,
+/// turning a failure into a JSON `null` plus a warning that names the cause.
+fn rating_part(label: &str, result: Result<CallToolResult, McpError>) -> (String, Option<String>) {
+    match result {
+        Ok(part) => {
+            let text = part
+                .content
+                .first()
+                .and_then(|c| c.as_text())
+                .map(|t| t.text.clone())
+                .unwrap_or_else(|| "null".to_string());
+            (text, None)
+        }
+        Err(e) => (
+            "null".to_string(),
+            Some(format!("{label} is unavailable: {}", e.message)),
+        ),
+    }
+}
+
 pub async fn institution_rating(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
@@ -67,39 +87,49 @@ pub async fn institution_rating(
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
     let params = [("counter_id", cid.as_str())];
-    let ratings = http_get_tool(&client, "/v1/quote/institution-rating-latest", &params).await;
-    let instratings = http_get_tool(&client, "/v1/quote/institution-ratings", &params).await;
-    match (ratings, instratings) {
-        (Ok(r), Ok(i)) => {
-            let r_text = r
-                .content
-                .first()
-                .and_then(|c| c.as_text())
-                .map(|t| t.text.as_str())
-                .unwrap_or("null");
-            let i_text = i
-                .content
-                .first()
-                .and_then(|c| c.as_text())
-                .map(|t| t.text.as_str())
-                .unwrap_or("null");
-            let combined = format!(r#"{{"analyst":{r_text},"instratings":{i_text}}}"#);
-            let mut value: serde_json::Value =
-                serde_json::from_str(&combined).map_err(crate::error::Error::Serialize)?;
-            convert_unix_paths(
-                &mut value,
-                &[
-                    "analyst.evaluate.start_date",
-                    "analyst.evaluate.end_date",
-                    "analyst.target.start_date",
-                    "analyst.target.end_date",
-                ],
-            );
-            let out = serde_json::to_string(&value).map_err(crate::error::Error::Serialize)?;
-            Ok(crate::tools::tool_result(out))
-        }
-        (Err(e), _) | (_, Err(e)) => Err(e),
+
+    // Two independent upstream calls. Run them concurrently, and let one
+    // failure degrade the response instead of discarding the half that worked.
+    let (analyst, instratings) = tokio::join!(
+        http_get_tool(&client, "/v1/quote/institution-rating-latest", &params),
+        http_get_tool(&client, "/v1/quote/institution-ratings", &params),
+    );
+
+    // Nothing to report if neither half came back — surface the first cause.
+    if let (Err(e), Err(_)) = (&analyst, &instratings) {
+        return Err(e.clone());
     }
+
+    let (analyst_text, analyst_warning) = rating_part("analyst", analyst);
+    let (instratings_text, instratings_warning) = rating_part("instratings", instratings);
+    let warnings: Vec<String> = [analyst_warning, instratings_warning]
+        .into_iter()
+        .flatten()
+        .collect();
+
+    let combined = if warnings.is_empty() {
+        format!(r#"{{"analyst":{analyst_text},"instratings":{instratings_text}}}"#)
+    } else {
+        let warnings_json =
+            serde_json::to_string(&warnings).map_err(crate::error::Error::Serialize)?;
+        format!(
+            r#"{{"analyst":{analyst_text},"instratings":{instratings_text},"warnings":{warnings_json}}}"#
+        )
+    };
+
+    let mut value: serde_json::Value =
+        serde_json::from_str(&combined).map_err(crate::error::Error::Serialize)?;
+    convert_unix_paths(
+        &mut value,
+        &[
+            "analyst.evaluate.start_date",
+            "analyst.evaluate.end_date",
+            "analyst.target.start_date",
+            "analyst.target.end_date",
+        ],
+    );
+    let out = serde_json::to_string(&value).map_err(crate::error::Error::Serialize)?;
+    Ok(crate::tools::tool_result(out))
 }
 
 pub async fn institution_rating_detail(
@@ -866,4 +896,40 @@ pub async fn valuation_comparison(
         &["list.*.history.*.date"],
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rating_part;
+    use rmcp::ErrorData as McpError;
+    use rmcp::model::Content;
+
+    #[test]
+    fn rating_part_returns_the_payload_and_no_warning_on_success() {
+        let ok = rmcp::model::CallToolResult::success(vec![Content::text(r#"{"a":1}"#)]);
+        let (text, warning) = rating_part("analyst", Ok(ok));
+        assert_eq!(text, r#"{"a":1}"#);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn rating_part_degrades_to_null_and_names_the_cause() {
+        let err = McpError::internal_error("upstream 503", None);
+        let (text, warning) = rating_part("instratings", Err(err));
+        assert_eq!(text, "null");
+        let warning = warning.expect("a failure must produce a warning");
+        assert!(
+            warning.contains("instratings") && warning.contains("upstream 503"),
+            "warning should name the part and the cause, got: {warning}"
+        );
+    }
+
+    #[test]
+    fn rating_part_treats_an_empty_body_as_json_null() {
+        let empty = rmcp::model::CallToolResult::success(vec![]);
+        let (text, warning) = rating_part("analyst", Ok(empty));
+        assert_eq!(text, "null");
+        // An empty-but-successful response is not a failure.
+        assert!(warning.is_none());
+    }
 }

--- a/src/tools/output/fundamental.rs
+++ b/src/tools/output/fundamental.rs
@@ -43,6 +43,10 @@ pub struct InstitutionRatingResponse {
     /// description; passed through as raw JSON.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instratings: Option<serde_json::Value>,
+    /// Present when one of the two upstream calls failed: the other half is
+    /// still returned, and this names what is missing and why.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<String>>,
 }
 
 /// Analyst consensus block of `institution_rating`.

--- a/src/tools/output/mod.rs
+++ b/src/tools/output/mod.rs
@@ -90,6 +90,10 @@ pub struct StockPositionsResponse {
     /// US-specific endpoint.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub us_asset_overview: Option<us_market::UsAssetOverview>,
+    /// Present when the US overview call failed: positions are still returned,
+    /// and this names what is missing and why.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/src/tools/support/parse.rs
+++ b/src/tools/support/parse.rs
@@ -13,7 +13,7 @@ const PRIMITIVE_DATETIME_FORMAT: &[time::format_description::BorrowedFormatItem<
     time::macros::format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]");
 
 pub fn parse_period(s: &str) -> Result<Period, McpError> {
-    match s {
+    match s.trim().to_lowercase().as_str() {
         "1m" => Ok(Period::OneMinute),
         "2m" => Ok(Period::TwoMinute),
         "3m" => Ok(Period::ThreeMinute),
@@ -33,18 +33,21 @@ pub fn parse_period(s: &str) -> Result<Period, McpError> {
         "quarter" => Ok(Period::Quarter),
         "year" => Ok(Period::Year),
         _ => Err(McpError::invalid_params(
-            format!("invalid period: {s}"),
+            format!(
+                "invalid period: '{s}', expected one of: 1m, 2m, 3m, 5m, 10m, 15m, 20m, 30m, \
+                 45m, 60m, 120m, 180m, 240m, day, week, month, quarter, year"
+            ),
             None,
         )),
     }
 }
 
 pub fn parse_trade_sessions(s: &str) -> Result<TradeSessions, McpError> {
-    match s {
+    match s.trim().to_lowercase().as_str() {
         "intraday" => Ok(TradeSessions::Intraday),
         "all" => Ok(TradeSessions::All),
         _ => Err(McpError::invalid_params(
-            format!("invalid trade_sessions: {s}, expected 'intraday' or 'all'"),
+            format!("invalid trade_sessions: '{s}', expected 'intraday' or 'all'"),
             None,
         )),
     }
@@ -223,5 +226,47 @@ pub fn parse_warrant_status(s: &str) -> Result<WarrantStatus, McpError> {
             format!("invalid status: {s}, expected Suspend/PrepareList/Normal"),
             None,
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn period_is_case_insensitive_and_trims() {
+        assert!(matches!(parse_period("Day").unwrap(), Period::Day));
+        assert!(matches!(
+            parse_period(" 15M ").unwrap(),
+            Period::FifteenMinute
+        ));
+        assert!(matches!(parse_period("YEAR").unwrap(), Period::Year));
+    }
+
+    #[test]
+    fn period_error_lists_the_accepted_values() {
+        let err = parse_period("daily").unwrap_err();
+        assert!(
+            err.message.contains("day") && err.message.contains("week"),
+            "error should list accepted periods, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn trade_sessions_is_case_insensitive_and_trims() {
+        assert!(matches!(
+            parse_trade_sessions("All").unwrap(),
+            TradeSessions::All
+        ));
+        assert!(matches!(
+            parse_trade_sessions(" INTRADAY ").unwrap(),
+            TradeSessions::Intraday
+        ));
+    }
+
+    #[test]
+    fn trade_sessions_rejects_anything_else() {
+        assert!(parse_trade_sessions("premarket").is_err());
     }
 }

--- a/src/tools/trade.rs
+++ b/src/tools/trade.rs
@@ -237,15 +237,29 @@ pub async fn stock_positions(mctx: &crate::tools::McpContext) -> Result<CallTool
     let (ctx, _) = TradeContext::new(mctx.create_config());
     let result = ctx.stock_positions(None).await.map_err(Error::longbridge)?;
     let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
-    if mctx.dc_region().await == longbridge::DcRegion::Us
-        && let Ok(us_overview) = ctx.us_asset_overview().await
-        && let (Some(obj), Ok(mut us_value)) = (
-            value.as_object_mut(),
-            serde_json::to_value(&us_overview).map_err(Error::Serialize),
-        )
-    {
-        crate::tools::support::us_normalize::normalize_us_stock_list(&mut us_value);
-        obj.insert("us_asset_overview".to_string(), us_value);
+    if mctx.dc_region().await == longbridge::DcRegion::Us {
+        // The US overview is supplementary: its failure should annotate the
+        // positions rather than discard them, but staying silent would let the
+        // caller read a US account as having no overview at all.
+        match ctx.us_asset_overview().await {
+            Ok(us_overview) => {
+                if let (Some(obj), Ok(mut us_value)) = (
+                    value.as_object_mut(),
+                    serde_json::to_value(&us_overview).map_err(Error::Serialize),
+                ) {
+                    crate::tools::support::us_normalize::normalize_us_stock_list(&mut us_value);
+                    obj.insert("us_asset_overview".to_string(), us_value);
+                }
+            }
+            Err(e) => {
+                if let Some(obj) = value.as_object_mut() {
+                    obj.insert(
+                        "warnings".to_string(),
+                        serde_json::json!([format!("us_asset_overview is unavailable: {e}")]),
+                    );
+                }
+            }
+        }
     }
     tool_json(&value)
 }


### PR DESCRIPTION
Picks up the parts of #131 that #130 did not already cover. #131 targets the same panel metrics from a different angle, so this takes its three independent improvements and leaves the overlapping ones alone.

## Adopted, with corrections

**`parse_trade_sessions` / `parse_period` are case-insensitive** — `"All"`, `"INTRADAY"`, `"Day"` and stray whitespace now parse. #131 did this for `trade_sessions`; extended here to `period` for consistency. The period error also lists every accepted value instead of only echoing the bad one, so a model that guessed `daily` can fix the call from the message alone:

```
history_candlesticks_by_date failed: invalid period: 'daily', expected one of:
  1m, 2m, 3m, 5m, 10m, 15m, 20m, 30m, 45m, 60m, 120m, 180m, 240m,
  day, week, month, quarter, year
```

**`institution_rating` runs concurrently and degrades to partial success** — its two upstream calls now go out under `tokio::join!`, and one failure returns the half that worked plus a `warnings` entry naming the cause.

Two corrections to #131's version:

- It decided "both failed" with `if r_text == "null" && i_text == "null"`, which misreads a *successful* upstream response whose body is literally `null` as a failure — the tool would report an error for a call that actually worked. This matches on the `Result`s instead.
- It discarded the original errors (`Err(_)`) and emitted a fixed `"analyst data temporarily unavailable"`. Keeping the upstream message matters after #130: a 403 stays recognizable, so `error_hint` still attaches the "reconnect and grant the full scopes" guidance instead of the failure being disguised as a transient outage.

**`stock_positions` surfaces a failed `us_asset_overview`** in a `warnings` field rather than dropping it silently — same reasoning on keeping the cause in the text.

`warnings` is declared on `InstitutionRatingResponse` and `StockPositionsResponse`; #131 returned the field without announcing it in either `outputSchema`.

## Not adopted (already in #130, in broader form)

- **`finance_calendar` category validation** — #130 also trims, makes `start`/`end` optional (today .. +7d), rejects an inverted window, and returns `partial` / `partial_reason` when the page walk stops short.
- **`trade_sessions` optional on the two history tools** — #130 defaults `period`, `forward_adjust`, `count` and `forward` as well, so `symbol` alone is a valid call.
- **`CHANGELOG.md`** — the repo tracks releases through `Version x.y.z` commits and has never carried one; adding it is a process decision, not part of this fix.

## Testing

`cargo +nightly fmt --check` clean, clippy zero warnings, 195 tests passing (7 new, covering case-insensitive parsing, the period candidate list, and all three `rating_part` branches including the empty-but-successful body that #131 misclassified).

Verified end to end against a local server with a deliberately scope-less token:

- `{"symbol":"700.HK","period":"Day","trade_sessions":"ALL"}` → succeeds (previously `invalid_params`)
- `period=daily` → `isError` listing all 18 accepted periods
- `institution_rating` on a live and on a nonexistent symbol → both return normally, no spurious warnings
- `stock_positions` → still reaches `error_hint`'s scope guidance on 403308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
