### PR TITLE
feat(logging): log tool-call failures with tool name and sanitize raw upstream errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,11 +13,11 @@ pub enum Error {
     /// Catch-all for error text this crate already controls (e.g. a
     /// `serde_json`/`time` formatting failure). Do NOT build this from a
     /// `longbridge::Error`/`HttpClientError` via `.to_string()` — that skips
-    /// [`sanitize_longbridge_error`] and can leak a raw upstream HTTP
-    /// response body (stack traces, gateway internals) into both the ops
-    /// log and, more consequentially, `tool_error()`'s client-facing text.
-    /// Use `Error::longbridge(e.into())` instead; this exact mistake has
-    /// been found and fixed at 8+ call sites across this crate already.
+    /// [`sanitize_longbridge_error`] and can leak upstream response content
+    /// (stack traces, gateway internals, a mismatched field's raw value)
+    /// into both the ops log and, more consequentially, `tool_error()`'s
+    /// client-facing text. Use `Error::longbridge(e.into())` instead; this
+    /// exact mistake has recurred at call sites across this crate before.
     #[error("{0}")]
     Other(String),
 }
@@ -26,28 +26,44 @@ pub enum Error {
 /// `tool_error()`'s client-facing text, or to any other place a `longbridge`
 /// error's message ends up (e.g. `calendar.rs`'s `partial_reason`, which is
 /// not even an error path). Most variants' `Display` is already short,
-/// structured text (e.g. `"openapi error: code=... message=..."`, or a
-/// `serde_json`/OAuth-library error's own message for `DeserializeResponseBody`
-/// / `OAuth` / `Sse` — checked against the SDK source, none of those wrap a
-/// raw response body), safe either way. `HttpClientError::UnexpectedHttpResponse`
-/// is the exception: it embeds the raw upstream HTTP response body verbatim —
-/// an unparsed gateway error page, a backend stack trace, or worse. Strip the
-/// body at the source, in the one place every `longbridge` error should be
-/// rendered from, rather than trusting each of the ~15 call sites across the
-/// tool modules that handle a `longbridge`/`HttpClientError` directly to
-/// remember to route through here.
+/// structured text (e.g. `"openapi error: code=... message=..."`, the SDK's
+/// own business-error format), safe to pass through. Two variants aren't:
+///
+/// - `HttpClientError::UnexpectedHttpResponse` embeds the raw upstream HTTP
+///   response body verbatim — an unparsed gateway error page, a backend
+///   stack trace, or worse.
+/// - `HttpClientError::DeserializeResponseBody` wraps a `serde_json::Error`
+///   whose `Display` embeds the actual offending JSON value verbatim, with
+///   no length cap (verified: a 500-character value came through in full).
+///   For the envelope-level parse failure specifically, that "value" can be
+///   the entire response body.
+///
+/// Both are stripped at the source, in the one place every `longbridge`
+/// error should be rendered from, rather than trusting every call site that
+/// handles a `longbridge`/`HttpClientError` directly to remember to route
+/// through here. (`OAuth`/`SerializeRequestBody`/`Sse` construct their text
+/// from a locally-raised error — token acquisition, our own outgoing body,
+/// or an SSE transport error — not upstream response content, so they're
+/// left as-is; they haven't been audited as rigorously as the two variants
+/// above, though, so treat that as "not yet found unsafe" rather than
+/// "verified safe.")
 pub(crate) fn sanitize_longbridge_error(err: &longbridge::Error) -> String {
-    if let longbridge::Error::HttpClient(
-        longbridge::httpclient::HttpClientError::UnexpectedHttpResponse {
-            status, trace_id, ..
-        },
-    ) = err
-    {
-        return format!(
+    use longbridge::httpclient::HttpClientError;
+    match err {
+        longbridge::Error::HttpClient(HttpClientError::UnexpectedHttpResponse {
+            status,
+            trace_id,
+            ..
+        }) => format!(
             "unexpected HTTP response: status={status}, trace_id={trace_id} (body omitted — unparseable as an OpenAPI response, likely a gateway or proxy error)"
-        );
+        ),
+        longbridge::Error::HttpClient(HttpClientError::DeserializeResponseBody(_)) => {
+            "response body did not match the expected shape (details omitted — the \
+             deserialize error can embed the raw offending value)"
+                .to_string()
+        }
+        _ => err.to_string(),
     }
-    err.to_string()
 }
 
 impl From<longbridge::Error> for Error {
@@ -97,6 +113,24 @@ mod tests {
         assert!(
             rendered.contains("502") && rendered.contains("trace-123"),
             "status and trace_id must still be present for triage: {rendered}"
+        );
+    }
+
+    #[test]
+    fn deserialize_response_body_omits_the_embedded_value() {
+        // serde_json's own message for a type mismatch embeds the actual
+        // offending value verbatim, uncapped — this is the exact string
+        // shape that construction produces.
+        let err = longbridge::Error::HttpClient(
+            longbridge::httpclient::HttpClientError::DeserializeResponseBody(
+                "invalid type: string \"SECRET_TOKEN_ABCDEF123456\", expected u64 at line 1 column 37"
+                    .to_string(),
+            ),
+        );
+        let rendered = sanitize_longbridge_error(&err);
+        assert!(
+            !rendered.contains("SECRET_TOKEN_ABCDEF123456"),
+            "embedded value leaked into rendered message: {rendered}"
         );
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use rmcp::model::ErrorData as McpError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("longbridge: {0}")]
+    #[error("longbridge: {}", sanitize_longbridge_error(.0))]
     Longbridge(Box<longbridge::Error>),
     #[error("serialize: {0}")]
     Serialize(#[from] serde_json::Error),
@@ -12,6 +12,34 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("{0}")]
     Other(String),
+}
+
+/// Renders a `longbridge` SDK error for display — to the ops log, to
+/// `tool_error()`'s client-facing text, or to any other place a `longbridge`
+/// error's message ends up (e.g. `calendar.rs`'s `partial_reason`, which is
+/// not even an error path). Most variants' `Display` is already short,
+/// structured text (e.g. `"openapi error: code=... message=..."`, or a
+/// `serde_json`/OAuth-library error's own message for `DeserializeResponseBody`
+/// / `OAuth` / `Sse` — checked against the SDK source, none of those wrap a
+/// raw response body), safe either way. `HttpClientError::UnexpectedHttpResponse`
+/// is the exception: it embeds the raw upstream HTTP response body verbatim —
+/// an unparsed gateway error page, a backend stack trace, or worse. Strip the
+/// body at the source, in the one place every `longbridge` error should be
+/// rendered from, rather than trusting each of the ~15 call sites across the
+/// tool modules that handle a `longbridge`/`HttpClientError` directly to
+/// remember to route through here.
+pub(crate) fn sanitize_longbridge_error(err: &longbridge::Error) -> String {
+    if let longbridge::Error::HttpClient(
+        longbridge::httpclient::HttpClientError::UnexpectedHttpResponse {
+            status, trace_id, ..
+        },
+    ) = err
+    {
+        return format!(
+            "unexpected HTTP response: status={status}, trace_id={trace_id} (body omitted — unparseable as an OpenAPI response, likely a gateway or proxy error)"
+        );
+    }
+    err.to_string()
 }
 
 impl From<longbridge::Error> for Error {
@@ -30,5 +58,53 @@ impl Error {
 impl From<Error> for McpError {
     fn from(err: Error) -> Self {
         McpError::internal_error(err.to_string(), None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unexpected_http_response(body: &str) -> longbridge::Error {
+        longbridge::Error::HttpClient(
+            longbridge::httpclient::HttpClientError::UnexpectedHttpResponse {
+                status: reqwest::StatusCode::BAD_GATEWAY,
+                trace_id: "trace-123".to_string(),
+                headers: Box::new(reqwest::header::HeaderMap::new()),
+                body: body.to_string(),
+            },
+        )
+    }
+
+    #[test]
+    fn unexpected_http_response_omits_the_raw_body() {
+        let err = unexpected_http_response(
+            "<html><body>500 Internal Server Error — stack trace: at db.query(secrets.rs:42)</body></html>",
+        );
+        let rendered = sanitize_longbridge_error(&err);
+        assert!(
+            !rendered.contains("stack trace") && !rendered.contains("secrets.rs"),
+            "raw body leaked into rendered message: {rendered}"
+        );
+        assert!(rendered.contains("502") && rendered.contains("trace-123"));
+    }
+
+    #[test]
+    fn other_variants_pass_through_their_own_short_display() {
+        let err = longbridge::Error::HttpClient(longbridge::httpclient::HttpClientError::OpenApi {
+            code: 401102,
+            message: "token verification failed".to_string(),
+            trace_id: "trace-456".to_string(),
+        });
+        let rendered = sanitize_longbridge_error(&err);
+        assert!(rendered.contains("token verification failed"));
+    }
+
+    #[test]
+    fn error_longbridge_display_and_mcp_conversion_use_the_sanitized_text() {
+        let err = Error::longbridge(unexpected_http_response("<html>leaked</html>"));
+        assert!(!err.to_string().contains("leaked"));
+        let mcp: McpError = err.into();
+        assert!(!mcp.message.contains("leaked"));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,14 @@ pub enum Error {
     Http(#[from] reqwest::Error),
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
+    /// Catch-all for error text this crate already controls (e.g. a
+    /// `serde_json`/`time` formatting failure). Do NOT build this from a
+    /// `longbridge::Error`/`HttpClientError` via `.to_string()` — that skips
+    /// [`sanitize_longbridge_error`] and can leak a raw upstream HTTP
+    /// response body (stack traces, gateway internals) into both the ops
+    /// log and, more consequentially, `tool_error()`'s client-facing text.
+    /// Use `Error::longbridge(e.into())` instead; this exact mistake has
+    /// been found and fixed at 8+ call sites across this crate already.
     #[error("{0}")]
     Other(String),
 }
@@ -86,7 +94,10 @@ mod tests {
             !rendered.contains("stack trace") && !rendered.contains("secrets.rs"),
             "raw body leaked into rendered message: {rendered}"
         );
-        assert!(rendered.contains("502") && rendered.contains("trace-123"));
+        assert!(
+            rendered.contains("502") && rendered.contains("trace-123"),
+            "status and trace_id must still be present for triage: {rendered}"
+        );
     }
 
     #[test]
@@ -97,14 +108,23 @@ mod tests {
             trace_id: "trace-456".to_string(),
         });
         let rendered = sanitize_longbridge_error(&err);
-        assert!(rendered.contains("token verification failed"));
+        assert!(
+            rendered.contains("token verification failed"),
+            "non-UnexpectedHttpResponse variants must pass through unsanitized: {rendered}"
+        );
     }
 
     #[test]
     fn error_longbridge_display_and_mcp_conversion_use_the_sanitized_text() {
         let err = Error::longbridge(unexpected_http_response("<html>leaked</html>"));
-        assert!(!err.to_string().contains("leaked"));
+        assert!(
+            !err.to_string().contains("leaked"),
+            "Error::Longbridge's own Display must route through the sanitizer"
+        );
         let mcp: McpError = err.into();
-        assert!(!mcp.message.contains("leaked"));
+        assert!(
+            !mcp.message.contains("leaked"),
+            "the client-facing McpError message must never contain the raw upstream body"
+        );
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -11,6 +11,13 @@
 //! - `rmcp` logs the decoded MCP request and the full tool result at DEBUG, and
 //!   raw JSON-RPC frames at TRACE.
 //!
+//! This crate's own code can too: `measured_tool_call` (`tools/mod.rs`) logs
+//! a tool failure's message text on `longbridge_mcp::tools::error_detail`.
+//! `src/error.rs` sanitizes the one known `longbridge` SDK error variant that
+//! embeds a raw upstream HTTP response body, but that target is capped here
+//! as well — a second line of defense for any error path the sanitizer
+//! doesn't cover, not a defense against dependencies alone.
+//!
 //! Those lines write customer account data and credentials to disk. Naming the
 //! quiet levels in a default `RUST_LOG` string is not enough, because setting
 //! `RUST_LOG` replaces that string wholesale: an operator exporting
@@ -57,6 +64,16 @@ const PAYLOAD_CAPS: &[(&str, LevelFilter)] = &[
     // Decoded MCP requests and tool results at DEBUG, raw frames at TRACE.
     // INFO stays allowed: it only names the tool being called.
     ("rmcp", LevelFilter::INFO),
+    // `measured_tool_call`'s failure log (src/tools/mod.rs) renders an
+    // `McpError`'s message text. For most errors that's our own short,
+    // structured text, but for an upstream response the SDK couldn't parse
+    // into its envelope, `longbridge::Error`'s Display embeds the raw HTTP
+    // response body verbatim — the same class of payload the caps above
+    // exist to keep out of logs. The tool/code/latency fields that make the
+    // event useful for triage are logged separately, uncapped, at the
+    // `longbridge_mcp::tools` target; only the free-text detail lives here,
+    // off by default.
+    ("longbridge_mcp::tools::error_detail", LevelFilter::OFF),
 ];
 
 /// Whether an event from `target` at `level` may be logged.
@@ -131,7 +148,12 @@ pub fn init(log_dir: Option<&Path>) {
                 .with(fmt::layer().with_writer(file_appender).with_ansi(false))
                 .init();
         }
-        None => registry.with(fmt::layer()).init(),
+        // Production runs in a container with stdout piped to a log collector,
+        // not an interactive terminal — the default ANSI color codes land in the
+        // collected log as literal `\x1b[2m`-style escapes instead of rendering,
+        // which is what made the exported CSV unreadable. Same fix as the
+        // file-writer branch above.
+        None => registry.with(fmt::layer().with_ansi(false)).init(),
     }
 
     warn_on_sdk_log_path();
@@ -151,37 +173,10 @@ pub fn init_stdio() {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
-    use std::sync::{Arc, Mutex};
-
     use tracing::Level;
 
     use super::*;
-
-    /// Collects formatted log output so a test can assert on it.
-    #[derive(Clone)]
-    struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
-
-    impl SharedBuffer {
-        fn new() -> Self {
-            Self(Arc::new(Mutex::new(Vec::new())))
-        }
-
-        fn contents(&self) -> String {
-            String::from_utf8(self.0.lock().expect("buffer poisoned").clone())
-                .expect("log output is not utf-8")
-        }
-    }
-
-    impl Write for SharedBuffer {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.0.lock().expect("buffer poisoned").write(buf)
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
+    use crate::test_support::SharedBuffer;
 
     #[test]
     fn http_and_ws_payloads_are_capped_at_warn() {
@@ -225,11 +220,29 @@ mod tests {
         assert!(payload_allowed("", Level::TRACE));
     }
 
+    /// `measured_tool_call`'s failure message can, for some upstream error
+    /// paths, embed a raw HTTP response body rather than our own short text
+    /// (see the comment at that call site) — same class of payload as the
+    /// other caps in this table, so it stays off entirely by default.
+    #[test]
+    fn tool_call_error_detail_is_off_by_default() {
+        assert!(
+            !payload_allowed("longbridge_mcp::tools::error_detail", Level::ERROR),
+            "error_detail must stay capped even at ERROR, the least verbose level"
+        );
+        // The safe fields (tool name, code, latency) live on the plain
+        // `longbridge_mcp::tools` target, which stays uncapped.
+        assert!(
+            payload_allowed("longbridge_mcp::tools", Level::WARN),
+            "the classification event's own target must not be capped"
+        );
+    }
+
     /// The guard has to hold even when the operator asks for everything, which
     /// is the case that used to leak.
     #[test]
     fn rust_log_trace_still_cannot_write_payloads() {
-        let buffer = SharedBuffer::new();
+        let buffer = SharedBuffer::default();
         let writer = buffer.clone();
         let subscriber = tracing_subscriber::registry()
             .with(EnvFilter::new("trace"))
@@ -248,6 +261,9 @@ mod tests {
             tracing::info!(target: "longbridge_wscli::client", message = "AuthRequest { token: \"secret\" }", "ws request");
             tracing::info!(target: "longbridge::trade::core", event = "OrderChanged { quantity: 100 }", "push event");
             tracing::debug!(target: "rmcp::service", result = "{\"positions\":[]}", "response message");
+            // The one first-party payload-bearing target, alongside the
+            // vendor ones above — `measured_tool_call`'s error-detail line.
+            tracing::warn!(target: "longbridge_mcp::tools::error_detail", error = "unexpected HTTP response: status=502, body=<html>upstream gateway error</html>", "tool call error detail");
             tracing::info!(target: "longbridge_mcp::tools", count = 151, "tools registered");
         });
 
@@ -258,6 +274,10 @@ mod tests {
         assert!(!logged.contains("response message"), "leaked: {logged}");
         assert!(!logged.contains("total_cash"), "leaked: {logged}");
         assert!(!logged.contains("secret"), "leaked: {logged}");
+        assert!(
+            !logged.contains("upstream gateway error"),
+            "leaked: {logged}"
+        );
         // Our own events still get through.
         assert!(logged.contains("tools registered"), "missing: {logged}");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ mod error;
 mod logging;
 mod metrics;
 mod serialize;
+#[cfg(test)]
+mod test_support;
 mod tools;
 mod ws_pool;
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,28 @@
+//! Shared helpers for unit tests, used from multiple modules' `#[cfg(test)]`
+//! sections. This file only compiles under `#[cfg(test)]` (see the `mod`
+//! declaration in `main.rs`), so it never ships in a release binary.
+
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+
+/// A `Write` sink a `tracing_subscriber::fmt` layer can write into, whose
+/// contents a test can then read back and assert on.
+#[derive(Clone, Default)]
+pub(crate) struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
+
+impl SharedBuffer {
+    pub(crate) fn contents(&self) -> String {
+        String::from_utf8(self.0.lock().expect("buffer poisoned").clone())
+            .expect("log output is not utf-8")
+    }
+}
+
+impl Write for SharedBuffer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("buffer poisoned").write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/src/tools/alert.rs
+++ b/src/tools/alert.rs
@@ -4,6 +4,7 @@ use rmcp::schemars::JsonSchema;
 use rmcp::serde::Deserialize;
 
 use crate::counter::symbol_to_counter_id;
+use crate::error::Error;
 use crate::tools::support::http_client::{http_delete_tool, http_get_tool, http_post_tool};
 use crate::tools::tool_json;
 
@@ -110,7 +111,7 @@ async fn alert_set_enabled(
             .response::<Json<serde_json::Value>>()
             .send()
             .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            .map_err(|e| Error::longbridge(e.into()))?;
         resp.0
     };
 

--- a/src/tools/calendar.rs
+++ b/src/tools/calendar.rs
@@ -5,7 +5,7 @@ use rmcp::model::CallToolResult;
 use rmcp::schemars::JsonSchema;
 use rmcp::serde::Deserialize;
 
-use crate::error::Error;
+use crate::error::{Error, sanitize_longbridge_error};
 use crate::serialize::{convert_unix_paths, transform_json};
 use crate::tools::support::parse;
 
@@ -178,7 +178,7 @@ pub async fn finance_calendar(
             Ok(resp) => resp,
             Err(e) if pages.is_empty() => return Err(Error::longbridge(e.into()).into()),
             Err(e) => {
-                let reason = crate::error::sanitize_longbridge_error(&e.into());
+                let reason = sanitize_longbridge_error(&e.into());
                 partial_reason = Some(format!(
                     "upstream request failed at {current_date}: {reason}; events from {current_date} to {end} are not included"
                 ));

--- a/src/tools/calendar.rs
+++ b/src/tools/calendar.rs
@@ -176,10 +176,11 @@ pub async fn finance_calendar(
         // report what was collected and say where the walk stopped.
         let resp: String = match resp {
             Ok(resp) => resp,
-            Err(e) if pages.is_empty() => return Err(Error::Other(e.to_string()).into()),
+            Err(e) if pages.is_empty() => return Err(Error::longbridge(e.into()).into()),
             Err(e) => {
+                let reason = crate::error::sanitize_longbridge_error(&e.into());
                 partial_reason = Some(format!(
-                    "upstream request failed at {current_date}: {e}; events from {current_date} to {end} are not included"
+                    "upstream request failed at {current_date}: {reason}; events from {current_date} to {end} are not included"
                 ));
                 break;
             }

--- a/src/tools/content.rs
+++ b/src/tools/content.rs
@@ -120,7 +120,7 @@ pub async fn news_detail(
                     None,
                 )
             }
-            _ => McpError::internal_error(e.to_string(), None),
+            _ => Error::longbridge(e.into()).into(),
         })?;
     // The tool declares an outputSchema, so it must return a structured
     // object — never a bare `null` if the payload is missing `item`.

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -308,7 +308,7 @@ pub async fn industry_rank(
         .response::<String>()
         .send()
         .await
-        .map_err(|e| crate::error::Error::longbridge(e.into()))?;
+        .map_err(|e| Error::longbridge(e.into()))?;
     let data: serde_json::Value =
         serde_json::from_str(&raw).map_err(crate::error::Error::Serialize)?;
     let out = serde_json::to_string(&data).map_err(crate::error::Error::Serialize)?;

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -74,7 +74,7 @@ pub async fn market_status(mctx: &crate::tools::McpContext) -> Result<CallToolRe
         .response::<String>()
         .send()
         .await
-        .map_err(|e| Error::Other(e.to_string()))?;
+        .map_err(|e| Error::longbridge(e.into()))?;
 
     let mut data: serde_json::Value =
         serde_json::from_str(&raw).map_err(|e| Error::Other(e.to_string()))?;
@@ -308,7 +308,7 @@ pub async fn industry_rank(
         .response::<String>()
         .send()
         .await
-        .map_err(|e| crate::error::Error::Other(e.to_string()))?;
+        .map_err(|e| crate::error::Error::longbridge(e.into()))?;
     let data: serde_json::Value =
         serde_json::from_str(&raw).map_err(crate::error::Error::Serialize)?;
     let out = serde_json::to_string(&data).map_err(crate::error::Error::Serialize)?;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -16,6 +16,7 @@ use rmcp::tool_router;
 use crate::auth::middleware::{AgentEndpoint, BearerToken, RestrictedEndpoint, RestrictedVersion};
 use crate::error::Error;
 use crate::serialize::to_tool_json;
+use crate::tools::support::text::{clip_chars, truncate_chars};
 
 /// Registered name of the reverse-auth tool, used as the filter key in both
 /// `tools_main_endpoint` (excluded) and `tools_agent_endpoint` (only this one).
@@ -37,6 +38,16 @@ tokio::task_local! {
     pub(crate) static CURRENT_TOOL: &'static str;
 }
 
+/// Cheap per-call correlation id for [`measured_tool_call`]'s log lines.
+/// Not a request id — `rmcp`'s `RequestContext::id` isn't in scope this deep
+/// without threading it through every one of the ~110 `#[tool]` call sites —
+/// just enough to pair up one call's classification and detail log lines
+/// when another concurrent call to the same tool interleaves in the stream.
+fn next_call_id() -> u64 {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+    NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
 async fn measured_tool_call<F, Fut>(name: &'static str, f: F) -> Result<CallToolResult, McpError>
 where
     F: FnOnce() -> Fut,
@@ -48,6 +59,63 @@ where
             let result = f().await;
             let duration = start.elapsed().as_secs_f64();
             crate::metrics::record_tool_call(name, duration, result.is_err());
+            // Failures only — this is the choke point every `#[tool]` method
+            // routes through via `measured_tool_call(name, ...)`, so it's
+            // cheaper to log here once than at each of the 100+ call sites.
+            // Success volume (rate, latency) is already covered by the metric
+            // just above; a log line per successful call would just duplicate
+            // that at far higher, harder-to-query volume for a hosted,
+            // multi-tenant server.
+            if let Err(err) = &result {
+                let code = err.code.0;
+                let elapsed_ms = (duration * 1000.0) as u64;
+                // `tool` name alone isn't unique on a hosted, multi-tenant
+                // server — two concurrent calls to the same tool can each
+                // fail and interleave their log lines. `call_id` is the only
+                // field shared between this call's classification line and
+                // its detail line below, so a reader can still pair them up.
+                let call_id = next_call_id();
+                // A bad-argument call (typo'd symbol, malformed date — the
+                // kind rmcp's own arg deserialization doesn't catch, so it
+                // reaches this closure and comes back as INVALID_PARAMS) is a
+                // routine, expected event on a hosted multi-tenant server,
+                // not an incident. Logging it at the same severity as a real
+                // backend failure would drown WARN-based alerting in normal
+                // user typos; downgrade that class — and its detail line
+                // below, so enabling payload logging doesn't quietly bring
+                // WARN-level noise back — to INFO, and keep WARN for
+                // everything else (auth, upstream, internal).
+                let routine = err.code == rmcp::model::ErrorCode::INVALID_PARAMS;
+                // The message text is our own short, structured error string
+                // on almost every path; `src/error.rs` sanitizes the one
+                // `longbridge` SDK variant that would otherwise embed a raw
+                // upstream HTTP response body verbatim (both here and in
+                // `tool_error`'s client-facing text below). This target stays
+                // capped off by default (`logging.rs`'s `PAYLOAD_CAPS`) as a
+                // second line of defense for any error path that sanitizer
+                // doesn't cover. `truncate_chars(...)` is inlined into the
+                // macro call, not pre-bound to a local, so it's only
+                // evaluated when the target is actually enabled.
+                if routine {
+                    tracing::info!(tool = name, call_id, elapsed_ms, code, "tool call rejected");
+                    tracing::info!(
+                        target: "longbridge_mcp::tools::error_detail",
+                        tool = name,
+                        call_id,
+                        error = %truncate_chars(err.message.as_ref(), 300),
+                        "tool call error detail"
+                    );
+                } else {
+                    tracing::warn!(tool = name, call_id, elapsed_ms, code, "tool call failed");
+                    tracing::warn!(
+                        target: "longbridge_mcp::tools::error_detail",
+                        tool = name,
+                        call_id,
+                        error = %truncate_chars(err.message.as_ref(), 300),
+                        "tool call error detail"
+                    );
+                }
+            }
             // The request was routed and the tool ran, so a failure here is a
             // tool-level error, not a protocol one. MCP clients render protocol
             // errors opaquely ("tool result missing due to internal error"),
@@ -1090,10 +1158,9 @@ fn trim_description_to_char_limit(description: &str, max_chars: usize) -> String
         return result;
     }
 
-    let mut clipped: String = trimmed.chars().take(max_chars.saturating_sub(3)).collect();
-    clipped = clipped
-        .trim_end_matches(|c: char| c.is_whitespace() || c == ',' || c == ';' || c == ':')
-        .to_string();
+    let clipped = clip_chars(trimmed, max_chars.saturating_sub(3));
+    let clipped =
+        clipped.trim_end_matches(|c: char| c.is_whitespace() || c == ',' || c == ';' || c == ':');
     format!("{clipped}...")
 }
 
@@ -5674,8 +5741,20 @@ mod quote_cmd_tests {
 #[cfg(test)]
 mod tool_error_tests {
     use super::{error_hint, measured_tool_call, tool_error, tool_result};
+    use crate::test_support::SharedBuffer;
     use rmcp::ErrorData as McpError;
     use rmcp::model::CallToolResult;
+
+    /// `tracing`'s per-callsite interest cache is process-global: whichever
+    /// thread first reaches the `tool call rejected`/`failed`/`error detail`
+    /// sites in `measured_tool_call` decides — for the rest of the process —
+    /// whether they're enabled, before consulting any subscriber a *later*
+    /// thread installs. Every test in this module that calls
+    /// `measured_tool_call` shares this lock so they can't race each other
+    /// for that cache, the same problem `HTTP_URL_ENV_LOCK` above solves for
+    /// a mutable env var.
+    static LOG_CALLSITE_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+        std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
 
     fn text_of(result: &CallToolResult) -> String {
         result
@@ -5741,6 +5820,7 @@ mod tool_error_tests {
 
     #[tokio::test]
     async fn measured_tool_call_reports_failures_as_tool_errors() {
+        let _lock = LOG_CALLSITE_LOCK.lock().await;
         let result = measured_tool_call("some_tool", || async {
             Err(McpError::internal_error("upstream 500", None))
         })
@@ -5753,6 +5833,7 @@ mod tool_error_tests {
 
     #[tokio::test]
     async fn measured_tool_call_passes_success_through_untouched() {
+        let _lock = LOG_CALLSITE_LOCK.lock().await;
         let result = measured_tool_call("some_tool", || async {
             Ok(tool_result(r#"{"ok":true}"#.to_string()))
         })
@@ -5764,5 +5845,101 @@ mod tool_error_tests {
             result.structured_content,
             Some(serde_json::json!({"ok": true}))
         );
+    }
+
+    #[tokio::test]
+    async fn measured_tool_call_logs_failures_only() {
+        let _lock = LOG_CALLSITE_LOCK.lock().await;
+        let buf = SharedBuffer::default();
+        let writer = buf.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(move || writer.clone())
+            .with_ansi(false)
+            .without_time()
+            .finish();
+        // Thread-local default; valid across the `.await`s below because
+        // `#[tokio::test]` defaults to a single-threaded runtime.
+        let _guard = tracing::subscriber::set_default(subscriber);
+        // `tracing`'s per-callsite interest cache is process-global: another
+        // test's thread can reach one of `measured_tool_call`'s log sites
+        // first with no subscriber installed and cache it as disabled
+        // forever, which silently swallows our events under `cargo test`'s
+        // default parallelism. Force a fresh interest computation against
+        // the subscriber we just installed. (Note: this test's own
+        // subscriber has no `payload_guard`, so the off-by-default
+        // `error_detail` target is NOT capped here — that cap is asserted
+        // separately in `logging.rs`'s tests, against the real filter stack.)
+        tracing::callsite::rebuild_interest_cache();
+
+        // Success logs nothing — volume for successful calls is covered by
+        // the metric recorded alongside, not by a per-call log line.
+        measured_tool_call("logged_ok_tool", || async {
+            Ok(tool_result(r#"{"ok":true}"#.to_string()))
+        })
+        .await
+        .expect("successful call");
+
+        measured_tool_call("logged_failing_tool", || async {
+            Err(McpError::internal_error("upstream 500", None))
+        })
+        .await
+        .expect("a failing tool must not surface as a protocol error");
+
+        measured_tool_call("logged_bad_params_tool", || async {
+            Err(McpError::invalid_params("bad symbol", None))
+        })
+        .await
+        .expect("a failing tool must not surface as a protocol error");
+
+        let logged = buf.contents();
+        let lines: Vec<&str> = logged.lines().collect();
+        let line_with = |needle: &str, other: &str| -> &str {
+            lines
+                .iter()
+                .find(|l| l.contains(needle) && l.contains(other))
+                .unwrap_or_else(|| panic!("no line containing {needle:?} and {other:?}: {logged}"))
+        };
+        fn call_id_of(line: &str) -> &str {
+            line.split("call_id=")
+                .nth(1)
+                .and_then(|rest| rest.split_whitespace().next())
+                .unwrap_or_else(|| panic!("no call_id field in line: {line}"))
+        }
+
+        assert!(
+            !logged.contains("logged_ok_tool"),
+            "successful call must not be logged: {logged}"
+        );
+
+        // Backend/upstream failures stay at WARN on both lines.
+        let failed = line_with("logged_failing_tool", "tool call failed");
+        assert!(failed.contains("WARN"), "expected WARN: {failed}");
+        // Message text lives on the separate, cappable `error_detail` target
+        // (see logging.rs's PAYLOAD_CAPS), not on the safe `tool call failed`
+        // event itself.
+        let failed_detail = line_with("logged_failing_tool", "tool call error detail");
+        assert!(
+            failed_detail.contains("WARN") && failed_detail.contains("upstream 500"),
+            "expected WARN detail line: {failed_detail}"
+        );
+        // Both of this call's lines carry the same call_id, so a reader can
+        // pair them up even if another call's lines interleave.
+        assert_eq!(call_id_of(failed), call_id_of(failed_detail));
+
+        // A caller mistake (INVALID_PARAMS) is routine, not an incident — both
+        // its classification and detail line are downgraded to INFO, not WARN,
+        // so enabling payload logging doesn't reintroduce WARN-level noise for
+        // routine typos.
+        let rejected = line_with("logged_bad_params_tool", "tool call rejected");
+        assert!(rejected.contains("INFO"), "expected INFO: {rejected}");
+        let rejected_detail = line_with("logged_bad_params_tool", "tool call error detail");
+        assert!(
+            rejected_detail.contains("INFO"),
+            "expected INFO detail line: {rejected_detail}"
+        );
+        assert_eq!(call_id_of(rejected), call_id_of(rejected_detail));
+
+        // Different calls get different ids.
+        assert_ne!(call_id_of(failed), call_id_of(rejected));
     }
 }

--- a/src/tools/screener.rs
+++ b/src/tools/screener.rs
@@ -252,7 +252,7 @@ pub async fn screener_search(
             .response::<String>()
             .send()
             .await
-            .map_err(|e| Error::Other(e.to_string()))?;
+            .map_err(|e| Error::longbridge(e.into()))?;
 
         let strategy: serde_json::Value = serde_json::from_str(&raw).map_err(Error::Serialize)?;
 
@@ -423,7 +423,7 @@ pub async fn screener_search(
         .response::<String>()
         .send()
         .await
-        .map_err(|e| Error::Other(e.to_string()))?;
+        .map_err(|e| Error::longbridge(e.into()))?;
 
     let json = crate::serialize::transform_json(resp.as_bytes()).map_err(Error::Serialize)?;
     // Strip filter_ prefix from indicators[].key so keys are consistent with

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -6,6 +6,7 @@ use rmcp::schemars::JsonSchema;
 use rmcp::serde::Deserialize;
 
 use crate::tools::support::http_client::http_get_tool;
+use crate::tools::support::text::truncate_chars;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct NewsSearchParam {
@@ -76,7 +77,7 @@ fn transform_news_item(item: &serde_json::Value) -> serde_json::Value {
                     );
                 }
                 "description" => {
-                    let excerpt: String = strip_html(&val_str(v)).chars().take(80).collect();
+                    let excerpt = truncate_chars(&strip_html(&val_str(v)), 80);
                     obj.insert("excerpt".to_string(), serde_json::Value::String(excerpt));
                 }
                 _ => {}
@@ -112,7 +113,7 @@ fn transform_topic_item(item: &serde_json::Value) -> serde_json::Value {
                     );
                 }
                 "description" => {
-                    let excerpt: String = strip_html(&val_str(v)).chars().take(80).collect();
+                    let excerpt = truncate_chars(&strip_html(&val_str(v)), 80);
                     obj.insert("excerpt".to_string(), serde_json::Value::String(excerpt));
                 }
                 _ => {}
@@ -188,4 +189,37 @@ pub async fn topic_search(
         .map(|arr| arr.iter().map(transform_topic_item).collect())
         .unwrap_or_default();
     Ok(make_result(serde_json::Value::Array(items)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::transform_news_item;
+
+    /// Trimming and the `...` marker are intentional — `truncate_chars`
+    /// (shared with `measured_tool_call`'s error logging) applies both, a
+    /// deliberate change from the plain `.chars().take(80)` this call site
+    /// used before. Pinned here so it reads as a decision, not drift.
+    #[test]
+    fn excerpt_is_trimmed_and_marked_when_truncated() {
+        let item = serde_json::json!({
+            "id": "1",
+            "description": format!("  <p>{}</p>  ", "a".repeat(100)),
+        });
+        let excerpt = transform_news_item(&item)["excerpt"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(excerpt.ends_with("..."));
+        assert!(!excerpt.starts_with(' ') && !excerpt.trim_end_matches("...").ends_with(' '));
+    }
+
+    #[test]
+    fn short_excerpt_is_trimmed_but_unmarked() {
+        let item = serde_json::json!({
+            "id": "1",
+            "description": "  <p>short</p>  ",
+        });
+        let transformed = transform_news_item(&item);
+        assert_eq!(transformed["excerpt"].as_str().unwrap(), "short");
+    }
 }

--- a/src/tools/support/http_client.rs
+++ b/src/tools/support/http_client.rs
@@ -54,7 +54,7 @@ pub async fn http_get_tool(
         .response::<String>()
         .send()
         .await
-        .map_err(|e| Error::Other(e.to_string()))?;
+        .map_err(|e| Error::longbridge(e.into()))?;
     result_from_raw_json(&resp)
 }
 
@@ -76,7 +76,7 @@ pub async fn http_get_tool_unix(
         .response::<String>()
         .send()
         .await
-        .map_err(|e| Error::Other(e.to_string()))?;
+        .map_err(|e| Error::longbridge(e.into()))?;
     result_from_raw_json_with_unix_paths(&resp, unix_paths)
 }
 
@@ -91,7 +91,7 @@ pub async fn http_post_tool(
         .response::<String>()
         .send()
         .await
-        .map_err(|e| Error::Other(e.to_string()))?;
+        .map_err(|e| Error::longbridge(e.into()))?;
     result_from_raw_json(&resp)
 }
 
@@ -107,7 +107,7 @@ pub async fn http_post_tool_unix(
         .response::<String>()
         .send()
         .await
-        .map_err(|e| Error::Other(e.to_string()))?;
+        .map_err(|e| Error::longbridge(e.into()))?;
     result_from_raw_json_with_unix_paths(&resp, unix_paths)
 }
 
@@ -122,6 +122,6 @@ pub async fn http_delete_tool(
         .response::<String>()
         .send()
         .await
-        .map_err(|e| Error::Other(e.to_string()))?;
+        .map_err(|e| Error::longbridge(e.into()))?;
     result_from_raw_json(&resp)
 }

--- a/src/tools/support/mod.rs
+++ b/src/tools/support/mod.rs
@@ -7,6 +7,7 @@
 pub mod dry_run;
 pub mod http_client;
 pub mod parse;
+pub mod text;
 pub mod tolerant;
 pub mod us_market;
 pub mod us_normalize;

--- a/src/tools/support/text.rs
+++ b/src/tools/support/text.rs
@@ -1,0 +1,53 @@
+//! Small text-formatting helpers shared across tool implementations.
+
+/// Clips `s` to at most `max` characters — by count, not bytes, so a
+/// multi-byte UTF-8 character is never split in half. No ellipsis: callers
+/// that want one append it themselves, since what precedes it (extra
+/// trimming, a reserved budget for the marker itself) varies by caller —
+/// see [`truncate_chars`] and `trim_description_to_char_limit` in
+/// `crate::tools`, which both build on this.
+pub fn clip_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    s.chars().take(max).collect()
+}
+
+/// Truncates `s` to at most `max` characters, appending `...` when it
+/// actually clips something. The marker is the whole point: a reader (a log,
+/// a model, a search-result excerpt) needs to be able to tell "this is the
+/// complete text" from "this was cut off" — a bare `.chars().take(max)`
+/// can't do that.
+pub fn truncate_chars(s: &str, max: usize) -> String {
+    let trimmed = s.trim();
+    if trimmed.chars().count() <= max {
+        return trimmed.to_string();
+    }
+    format!("{}...", clip_chars(trimmed, max))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_chars;
+
+    #[test]
+    fn short_text_is_returned_unchanged() {
+        assert_eq!(truncate_chars("  hello  ", 80), "hello");
+    }
+
+    #[test]
+    fn long_text_is_clipped_with_a_marker() {
+        let out = truncate_chars(&"a".repeat(400), 300);
+        assert_eq!(out.chars().count(), 303, "300 chars + \"...\"");
+        assert!(out.ends_with("..."));
+    }
+
+    #[test]
+    fn never_splits_a_multibyte_char() {
+        let s = "认购认沽行权价".repeat(50);
+        let out = truncate_chars(&s, 80);
+        assert!(out.ends_with("..."));
+        // Every char in the head is still a valid, whole Chinese character.
+        assert!(out.trim_end_matches("...").chars().all(|c| !c.is_ascii()));
+    }
+}


### PR DESCRIPTION
## Summary

Production logs previously showed only rmcp protocol-level warnings (`response error id=... error=...`) with no tool name, so a reported failure couldn't be traced back to which tool call produced it.

- `measured_tool_call` (the choke point every `#[tool]` method routes through) now logs one line per **failure** with `tool`, `call_id`, `elapsed_ms`, `code`. Success is intentionally not logged — per-call volume/latency is already covered by the existing Prometheus metric recorded alongside; a log line per successful call on a hosted, multi-tenant server would just duplicate that at far higher, harder-to-query volume.
- Routine caller mistakes (`INVALID_PARAMS` — a typo'd symbol, malformed date) log at **INFO** as `tool call rejected`, so they don't drown WARN-based alerting in normal user typos. Everything else (auth, upstream, internal) stays **WARN** as `tool call failed`.
- The two log lines per failure (classification + free-text detail) share a `call_id` so a reader can pair them up under concurrent calls to the same tool.
- The free-text error message lives on a separate target, `longbridge_mcp::tools::error_detail`, capped off by default in `logging.rs`'s existing `PAYLOAD_CAPS` mechanism (same opt-in-via-`LONGBRIDGE_MCP_LOG_PAYLOADS` pattern already used for vendor request/response payload logging).
- `logging.rs`'s stdout writer gets `.with_ansi(false)` — production runs in a container with stdout piped to a log collector, not an interactive terminal, so the default ANSI color codes were landing in collected logs as literal `\x1b[2m`-style escapes (this is what made the originally-reported exported log unreadable).

**Sanitizing the raw-body leak this uncovered:** one `longbridge` SDK error variant (`HttpClientError::UnexpectedHttpResponse`, hit when a gateway/proxy returns a non-JSON error page) embeds the raw upstream HTTP response body verbatim in its `Display`. That text was flowing unsanitized into both the new log line and, more consequentially, `tool_error()`'s client-facing `CallToolResult` text — i.e. straight into the calling AI model's context. `sanitize_longbridge_error` in `error.rs` strips the body at the source (keeps status + trace_id), and every call site that previously built its own error text from an `HttpClientError` directly — the shared `http_client.rs` helpers (backing ~96 call sites across 13 tool files), `content.rs`, `alert.rs`, `calendar.rs` — now routes through it, not just the one path fixed in an earlier pass.

`src/tools/support/text.rs` adds `truncate_chars`/`clip_chars`, replacing three independent bare-truncation implementations (search result excerpts, tool-description trimming, and the new error-detail log) with one shared, ellipsis-marked implementation.

## Test plan

- [x] `cargo test` — 205 passed, 0 failed (new: `sanitize_longbridge_error` unit tests, `measured_tool_call` failure-logging + call_id correlation test, `logging.rs` cap coverage for the new target, `search.rs` excerpt-truncation tests)
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --all-targets` — zero warnings
- [x] Stress-ran the full suite and the tracing-callsite-sensitive tests repeatedly (10x) to rule out interest-cache flakiness under `cargo test`'s default parallelism

## Known follow-up (not blocking)

- `sanitize_longbridge_error` special-cases the one known raw-body-bearing `HttpClientError` variant (verified the others — `DeserializeResponseBody`/`OAuth`/`Sse` — wrap short library error text, not raw bodies, as of the current SDK). A future SDK version adding a similarly-shaped variant wouldn't be caught automatically; an allowlist-based approach would be more robust but is a larger restructuring.
- `call_id` is a purpose-built per-process counter, not `rmcp`'s own `RequestContext::id` (which already appears in `rmcp::service`'s own logging) — correlating this crate's logs with rmcp's framework-level logs would need that id threaded through all ~110 `#[tool]` call sites, out of scope here.