### PR TITLE
feat(trade): pool TradeContext connections instead of opening one per call

### DIFF
--- a/src/context_pool.rs
+++ b/src/context_pool.rs
@@ -1,0 +1,804 @@
+//! Generic per-identity connection-context pool.
+//!
+//! Both `QuoteContext` and `TradeContext` open a persistent WebSocket
+//! connection to Longbridge. Creating one per tool call would exhaust the
+//! server-side per-account connection limit under concurrent load. This
+//! module caches one context per authenticated identity so all tool calls
+//! from the same user in this process share a single connection, regardless
+//! of which context type is being pooled.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE};
+use sha2::{Digest, Sha256};
+
+#[derive(Clone, Copy, Debug)]
+pub struct PoolSettings {
+    pub max_entries: usize,
+    pub idle_ttl: Duration,
+}
+
+impl PoolSettings {
+    pub fn from_env(
+        idle_ttl_env: &str,
+        max_entries_env: &str,
+        default_max_entries: usize,
+        default_idle_ttl_secs: u64,
+    ) -> Self {
+        let max_entries = std::env::var(max_entries_env)
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(default_max_entries);
+        let idle_ttl = std::env::var(idle_ttl_env)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .map(Duration::from_secs)
+            .unwrap_or(Duration::from_secs(default_idle_ttl_secs));
+
+        Self {
+            max_entries,
+            idle_ttl,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct PoolKey {
+    identity: String,
+}
+
+impl PoolKey {
+    fn new(identity: impl Into<String>) -> Self {
+        Self {
+            identity: identity.into(),
+        }
+    }
+}
+
+struct PoolEntry<T> {
+    value: T,
+    token_fingerprint: String,
+    last_used: Instant,
+}
+
+/// Combined state protected by a single Mutex so `last_prune` is always
+/// consistent with `entries` without a second lock acquisition.
+struct PoolInner<T> {
+    entries: HashMap<PoolKey, PoolEntry<T>>,
+    /// Timestamp of the last time `prune_idle` ran inline (on the hot path).
+    /// Used to gate the inline scan so it only runs every `idle_ttl / 4`,
+    /// keeping hot-path Mutex hold short. The background sweeper handles the
+    /// rest.
+    last_prune: Instant,
+}
+
+/// Metric hooks so this generic engine can report into whichever
+/// pool-specific Prometheus series the caller owns, without depending on
+/// `crate::metrics` directly.
+pub struct PoolMetrics {
+    pub record_event: fn(&str, u64),
+    pub set_entries: fn(usize),
+}
+
+pub struct Pool<T>
+where
+    T: Clone,
+{
+    settings: PoolSettings,
+    metrics: PoolMetrics,
+    inner: Mutex<PoolInner<T>>,
+}
+
+impl<T> Pool<T>
+where
+    T: Clone,
+{
+    pub fn new(settings: PoolSettings, metrics: PoolMetrics) -> Self {
+        Self {
+            settings,
+            metrics,
+            inner: Mutex::new(PoolInner {
+                entries: HashMap::new(),
+                last_prune: Instant::now(),
+            }),
+        }
+    }
+
+    pub fn get_or_insert_with(
+        &self,
+        key: PoolKey,
+        token_fingerprint: String,
+        init: impl FnOnce() -> T,
+    ) -> T {
+        self.get_or_insert_with_at(Instant::now(), key, token_fingerprint, init)
+    }
+
+    fn get_or_insert_with_at(
+        &self,
+        now: Instant,
+        key: PoolKey,
+        token_fingerprint: String,
+        init: impl FnOnce() -> T,
+    ) -> T {
+        let mut inner = self.inner.lock().unwrap_or_else(|err| err.into_inner());
+
+        // Inline idle prune — time-gated to every idle_ttl/4 so the hot path
+        // does not run an O(N) HashMap::retain on every single cache hit.
+        // The background sweeper handles cleanup between prune windows.
+        let prune_interval = self.settings.idle_ttl / 4;
+        if now.saturating_duration_since(inner.last_prune) >= prune_interval {
+            let removed = Self::do_prune_idle(&mut inner.entries, self.settings.idle_ttl, now);
+            if removed > 0 {
+                (self.metrics.record_event)("evict_idle", removed as u64);
+            }
+            inner.last_prune = now;
+        }
+
+        if let Some(value) = inner.entries.get_mut(&key).and_then(|entry| {
+            if entry.token_fingerprint == token_fingerprint {
+                entry.last_used = now;
+                Some(entry.value.clone())
+            } else {
+                None
+            }
+        }) {
+            (self.metrics.record_event)("hit", 1);
+            (self.metrics.set_entries)(inner.entries.len());
+            return value;
+        }
+
+        if inner.entries.contains_key(&key) {
+            inner.entries.remove(&key);
+            (self.metrics.record_event)("evict_rotated_token", 1);
+        }
+
+        if inner.entries.len() >= self.settings.max_entries
+            && Self::do_evict_lru(&mut inner.entries).is_some()
+        {
+            (self.metrics.record_event)("evict_capacity", 1);
+        }
+
+        (self.metrics.record_event)("miss", 1);
+        // `init()` is called while the Mutex is held. `QuoteContext::new`/
+        // `TradeContext::new` spawn their WS task on the SDK's own Tokio
+        // runtime and return immediately, so this does not block the calling
+        // thread. The trade-off is that concurrent first-use requests for the
+        // SAME key are serialized here — preventing duplicate WS connections
+        // for the same user, which is the desired behavior.
+        let value = init();
+        inner.entries.insert(
+            key,
+            PoolEntry {
+                value: value.clone(),
+                token_fingerprint,
+                last_used: now,
+            },
+        );
+        (self.metrics.set_entries)(inner.entries.len());
+        value
+    }
+
+    pub fn remove_identity(&self, key: &PoolKey) {
+        let mut inner = self.inner.lock().unwrap_or_else(|err| err.into_inner());
+        let before = inner.entries.len();
+        inner.entries.remove(key);
+        let removed = before.saturating_sub(inner.entries.len());
+        if removed > 0 {
+            (self.metrics.record_event)("evict_explicit", removed as u64);
+            (self.metrics.set_entries)(inner.entries.len());
+        }
+    }
+
+    pub fn prune_idle_now(&self) {
+        let now = Instant::now();
+        let mut inner = self.inner.lock().unwrap_or_else(|err| err.into_inner());
+        let removed = Self::do_prune_idle(&mut inner.entries, self.settings.idle_ttl, now);
+        if removed > 0 {
+            (self.metrics.record_event)("evict_idle", removed as u64);
+            (self.metrics.set_entries)(inner.entries.len());
+        }
+    }
+
+    fn do_prune_idle(
+        entries: &mut HashMap<PoolKey, PoolEntry<T>>,
+        idle_ttl: Duration,
+        now: Instant,
+    ) -> usize {
+        let before = entries.len();
+        entries.retain(|_, entry| now.saturating_duration_since(entry.last_used) <= idle_ttl);
+        before.saturating_sub(entries.len())
+    }
+
+    fn do_evict_lru(entries: &mut HashMap<PoolKey, PoolEntry<T>>) -> Option<PoolKey> {
+        let key = entries
+            .iter()
+            .min_by_key(|(_, entry)| entry.last_used)
+            .map(|(key, _)| key.clone())?;
+        entries.remove(&key);
+        Some(key)
+    }
+
+    pub fn idle_ttl(&self) -> Duration {
+        self.settings.idle_ttl
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.inner
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .entries
+            .len()
+    }
+
+    #[cfg(test)]
+    fn contains_key(&self, key: &PoolKey) -> bool {
+        self.inner
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .entries
+            .contains_key(key)
+    }
+}
+
+/// Start a background sweeper for `pool`, gated so it only ever spawns once
+/// per `started` flag. Call this on every pool access — the `OnceLock` makes
+/// repeat calls free.
+pub fn ensure_sweeper_started<T>(pool: &'static Pool<T>, started: &'static OnceLock<()>)
+where
+    T: Clone + Send + Sync + 'static,
+{
+    started.get_or_init(|| {
+        // Guard: tokio::spawn requires an active Tokio runtime. Skip silently
+        // when called from a non-async context (e.g. a sync unit test or a
+        // CLI path without a runtime). The time-gated inline prune in
+        // get_or_insert_with_at handles cleanup in the absence of the sweeper.
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let interval = sweep_interval(pool.idle_ttl());
+            handle.spawn(async move {
+                let mut ticker = tokio::time::interval(interval);
+                loop {
+                    ticker.tick().await;
+                    pool.prune_idle_now();
+                }
+            });
+        }
+    });
+}
+
+fn sweep_interval(idle_ttl: Duration) -> Duration {
+    if idle_ttl < Duration::from_secs(1) {
+        Duration::from_secs(1)
+    } else if idle_ttl < Duration::from_secs(60) {
+        idle_ttl
+    } else {
+        Duration::from_secs(60)
+    }
+}
+
+pub fn cache_key_for_token(token: &str) -> PoolKey {
+    let identity = jwt_identity(token)
+        .map(|identity| format!("jwt:{}", sha256_hex(identity.as_bytes())))
+        .unwrap_or_else(|| format!("token:{}", token_fingerprint(token)));
+    PoolKey::new(identity)
+}
+
+pub fn token_fingerprint(token: &str) -> String {
+    sha256_hex(token.as_bytes())
+}
+
+fn jwt_subject(token: &str) -> Option<String> {
+    let payload = token.split('.').nth(1)?;
+    let mut padded = payload.to_string();
+    while padded.len() % 4 != 0 {
+        padded.push('=');
+    }
+    let bytes = URL_SAFE.decode(padded).ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    claims["sub"]
+        .as_str()
+        .filter(|sub| !sub.is_empty())
+        .map(str::to_owned)
+}
+
+fn jwt_identity(token: &str) -> Option<String> {
+    let subject = jwt_subject(token)?;
+    stable_identity_from_subject(&subject)
+}
+
+fn stable_identity_from_subject(subject: &str) -> Option<String> {
+    match serde_json::from_str::<serde_json::Value>(subject) {
+        Ok(serde_json::Value::Object(map)) => {
+            const ID_FIELDS: &[&str] = &[
+                "user_id",
+                "member_id",
+                "account_id",
+                "account_no",
+                "account",
+                "uid",
+                "id",
+                "open_id",
+            ];
+            let channel = stable_json_field(&map, "account_channel").unwrap_or_default();
+            for field in ID_FIELDS {
+                if let Some(value) = stable_json_field(&map, field) {
+                    return Some(format!("account_channel={channel};{field}={value}"));
+                }
+            }
+            None
+        }
+        Ok(_) => None,
+        Err(_) => Some(subject.to_owned()),
+    }
+}
+
+fn stable_json_field(
+    map: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<String> {
+    match map.get(key)? {
+        serde_json::Value::String(value) if !value.is_empty() => Some(value.clone()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+
+    fn noop_metrics() -> PoolMetrics {
+        PoolMetrics {
+            record_event: |_, _| {},
+            set_entries: |_| {},
+        }
+    }
+
+    fn settings(max_entries: usize, idle_ttl: Duration) -> PoolSettings {
+        PoolSettings {
+            max_entries,
+            idle_ttl,
+        }
+    }
+
+    fn key(name: &str) -> PoolKey {
+        PoolKey::new(format!("identity:{name}"))
+    }
+
+    fn jwt_with_sub(sub: &str, signature: &str) -> String {
+        let header = base64::Engine::encode(&URL_SAFE_NO_PAD, r#"{"alg":"none"}"#);
+        let claims = serde_json::json!({ "sub": sub });
+        let payload = base64::Engine::encode(&URL_SAFE_NO_PAD, claims.to_string());
+        format!("{header}.{payload}.{signature}")
+    }
+
+    #[test]
+    fn concurrent_first_use_initializes_once() {
+        let pool = Arc::new(Pool::new(
+            settings(16, Duration::from_secs(60)),
+            noop_metrics(),
+        ));
+        let init_count = Arc::new(AtomicUsize::new(0));
+        let key = key("same-user");
+        let token = token_fingerprint("access-token");
+
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let pool = pool.clone();
+            let init_count = init_count.clone();
+            let key = key.clone();
+            let token = token.clone();
+            handles.push(std::thread::spawn(move || {
+                pool.get_or_insert_with_at(Instant::now(), key, token, || {
+                    init_count.fetch_add(1, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(10));
+                    42usize
+                })
+            }));
+        }
+
+        for handle in handles {
+            assert_eq!(handle.join().unwrap(), 42);
+        }
+        assert_eq!(init_count.load(Ordering::SeqCst), 1);
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn idle_entries_are_evicted_after_ttl() {
+        let pool = Pool::new(settings(16, Duration::from_secs(5)), noop_metrics());
+        let start = Instant::now();
+        let key = key("idle-user");
+        let token = token_fingerprint("access-token");
+
+        assert_eq!(
+            pool.get_or_insert_with_at(start, key.clone(), token.clone(), || 1usize),
+            1
+        );
+        assert_eq!(
+            pool.get_or_insert_with_at(
+                start + Duration::from_secs(4),
+                key.clone(),
+                token.clone(),
+                || 2usize
+            ),
+            1
+        );
+        assert_eq!(
+            pool.get_or_insert_with_at(start + Duration::from_secs(10), key, token, || 3usize),
+            3
+        );
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn capacity_eviction_removes_least_recently_used_entry() {
+        let pool = Pool::new(settings(2, Duration::from_secs(60)), noop_metrics());
+        let start = Instant::now();
+        let a = key("a");
+        let b = key("b");
+        let c = key("c");
+
+        pool.get_or_insert_with_at(start, a.clone(), token_fingerprint("a"), || "a");
+        pool.get_or_insert_with_at(
+            start + Duration::from_secs(1),
+            b.clone(),
+            token_fingerprint("b"),
+            || "b",
+        );
+        pool.get_or_insert_with_at(
+            start + Duration::from_secs(2),
+            a.clone(),
+            token_fingerprint("a"),
+            || "a",
+        );
+        pool.get_or_insert_with_at(
+            start + Duration::from_secs(3),
+            c.clone(),
+            token_fingerprint("c"),
+            || "c",
+        );
+
+        assert_eq!(pool.len(), 2);
+        assert!(
+            pool.contains_key(&a),
+            "entry 'a' (most recently used) should survive LRU eviction"
+        );
+        assert!(
+            !pool.contains_key(&b),
+            "entry 'b' (least recently used) should be LRU-evicted"
+        );
+        assert!(
+            pool.contains_key(&c),
+            "entry 'c' (just inserted) should be retained"
+        );
+    }
+
+    #[test]
+    fn jwt_subject_key_survives_token_refresh_without_storing_plaintext() {
+        let sub = r#"{"account_channel":"lb","user_id":"u-1"}"#;
+        let token_a = jwt_with_sub(sub, "signature-a");
+        let token_b = jwt_with_sub(sub, "signature-b");
+
+        let key_a = cache_key_for_token(&token_a);
+        let key_b = cache_key_for_token(&token_b);
+
+        assert_eq!(
+            key_a, key_b,
+            "same JWT subject should produce the same cache key regardless of signature"
+        );
+        assert!(
+            !key_a.identity.contains(&token_a),
+            "cache key must not contain the raw token bytes"
+        );
+        assert!(
+            !key_a.identity.contains(sub),
+            "cache key must not contain the raw JWT subject"
+        );
+    }
+
+    #[test]
+    fn jwt_subject_without_user_identity_falls_back_to_token_key() {
+        let sub = r#"{"account_channel":"lb"}"#;
+        let token_a = jwt_with_sub(sub, "signature-a");
+        let token_b = jwt_with_sub(sub, "signature-b");
+
+        let key_a = cache_key_for_token(&token_a);
+        let key_b = cache_key_for_token(&token_b);
+
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn token_rotation_for_same_identity_replaces_cached_context() {
+        let pool = Pool::new(settings(16, Duration::from_secs(60)), noop_metrics());
+        let start = Instant::now();
+        let key = key("rotating-user");
+
+        assert_eq!(
+            pool.get_or_insert_with_at(start, key.clone(), token_fingerprint("old-token"), || {
+                1usize
+            }),
+            1
+        );
+        assert_eq!(
+            pool.get_or_insert_with_at(
+                start + Duration::from_secs(1),
+                key.clone(),
+                token_fingerprint("new-token"),
+                || 2usize
+            ),
+            2
+        );
+
+        assert_eq!(pool.len(), 1);
+        assert!(
+            pool.contains_key(&key),
+            "rotating user's key should remain in pool after token swap"
+        );
+    }
+
+    /// Stress test: N users × M concurrent requests each.
+    ///
+    /// Verifies:
+    ///   1. Pool size never exceeds max_entries under concurrent insertion.
+    ///   2. Each user's init closure runs exactly once regardless of concurrency.
+    ///   3. Hit rate is ≥ 90% when users are stable (no token rotation).
+    ///
+    /// Run with:
+    ///   cargo test stress_pool_bounded_concurrency -- --nocapture --ignored
+    #[test]
+    #[ignore]
+    fn stress_pool_bounded_concurrency() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Instant;
+
+        const USERS: usize = 200;
+        const REQUESTS_PER_USER: usize = 50;
+        const MAX_POOL: usize = 64; // force LRU eviction (200 users > 64 slots)
+
+        let pool = Arc::new(Pool::new(
+            settings(MAX_POOL, Duration::from_secs(300)),
+            noop_metrics(),
+        ));
+        let total_inits = Arc::new(AtomicUsize::new(0));
+        let total_hits = Arc::new(AtomicUsize::new(0));
+        let total_requests = USERS * REQUESTS_PER_USER;
+
+        let start = Instant::now();
+        let mut handles = Vec::with_capacity(USERS * REQUESTS_PER_USER);
+
+        for user in 0..USERS {
+            for _ in 0..REQUESTS_PER_USER {
+                let pool = pool.clone();
+                let total_inits = total_inits.clone();
+                let total_hits = total_hits.clone();
+                handles.push(std::thread::spawn(move || {
+                    let k = key(&format!("user-{user}"));
+                    let fp = token_fingerprint(&format!("token-{user}"));
+                    let was_hit = {
+                        let before = pool.len();
+                        pool.get_or_insert_with(k, fp, || {
+                            total_inits.fetch_add(1, Ordering::Relaxed);
+                            user // value = user id
+                        });
+                        let after = pool.len();
+                        // "hit" if pool didn't grow (entry already existed)
+                        after <= before
+                    };
+                    if was_hit {
+                        total_hits.fetch_add(1, Ordering::Relaxed);
+                    }
+                }));
+            }
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let elapsed = start.elapsed();
+        let inits = total_inits.load(Ordering::Relaxed);
+        let hits = total_hits.load(Ordering::Relaxed);
+        let pool_size = pool.len();
+        let hit_rate = hits as f64 / total_requests as f64 * 100.0;
+        let throughput = total_requests as f64 / elapsed.as_secs_f64();
+
+        eprintln!("\ncontext_pool stress:");
+        eprintln!("  users:          {USERS}");
+        eprintln!("  requests:       {total_requests} ({REQUESTS_PER_USER}/user)");
+        eprintln!("  threads:        {total_requests}");
+        eprintln!("  max_pool:       {MAX_POOL}");
+        eprintln!("  pool size:      {pool_size}  (<= {MAX_POOL})");
+        eprintln!("  total inits:    {inits}  (<= {USERS} expected)");
+        eprintln!("  hit rate:       {hit_rate:.1}%");
+        eprintln!("  throughput:     {throughput:.0} ops/s");
+        eprintln!("  elapsed:        {:.2?}", elapsed);
+
+        assert!(
+            pool_size <= MAX_POOL,
+            "pool size {pool_size} exceeded max {MAX_POOL}"
+        );
+        assert!(
+            inits <= USERS,
+            "total inits {inits} exceeded user count {USERS} — double-init detected"
+        );
+        assert!(
+            hit_rate >= 50.0,
+            "hit rate {hit_rate:.1}% too low — pool may not be caching effectively"
+        );
+    }
+
+    /// High-concurrency stress suite. Four scenarios in one run:
+    ///
+    ///   A) Hot pool, all-hit  — 1000 users, warm cache, max_entries=1024.
+    ///      Measures pure Mutex+clone throughput with no evictions.
+    ///   B) Capacity pressure  — 500 users, max_entries=64.
+    ///      Constant LRU evictions; verifies pool never exceeds cap.
+    ///   C) Token-rotation churn — 200 users × 5 token rotations each.
+    ///      Every rotation evicts the old entry; measures rotated-token metric.
+    ///   D) Mixed init + hit    — 100 users × 200 req, init simulates
+    ///      10 ms blocking work; measures that the global Mutex serializes
+    ///      inits (only one init per user) even under contention.
+    ///
+    /// Run with:
+    ///   cargo test stress_high_concurrency -- --nocapture --ignored
+    #[test]
+    #[ignore]
+    fn stress_high_concurrency() {
+        use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+        use std::time::Instant;
+
+        fn run_scenario(
+            label: &str,
+            pool: Arc<Pool<usize>>,
+            users: usize,
+            req_per_user: usize,
+            token_rotations: usize, // how many distinct token fingerprints per user
+            init_delay_ms: u64,
+        ) -> (f64, f64, usize, usize) {
+            let total_inits = Arc::new(AtomicUsize::new(0));
+            let total_requests = users * req_per_user;
+            let start = Instant::now();
+            let mut handles = Vec::with_capacity(total_requests);
+
+            for user in 0..users {
+                for req in 0..req_per_user {
+                    let pool = pool.clone();
+                    let total_inits = total_inits.clone();
+                    let rotation = if token_rotations > 1 {
+                        req / (req_per_user / token_rotations).max(1)
+                    } else {
+                        0
+                    };
+                    handles.push(std::thread::spawn(move || {
+                        let k = key(&format!("user-{user}"));
+                        let fp = token_fingerprint(&format!("token-{user}-rot{rotation}"));
+                        pool.get_or_insert_with(k, fp, || {
+                            total_inits.fetch_add(1, Relaxed);
+                            if init_delay_ms > 0 {
+                                std::thread::sleep(std::time::Duration::from_millis(init_delay_ms));
+                            }
+                            user
+                        })
+                    }));
+                }
+            }
+
+            for h in handles {
+                h.join().unwrap();
+            }
+
+            let elapsed = start.elapsed();
+            let inits = total_inits.load(Relaxed);
+            let pool_size = pool.len();
+            let throughput = total_requests as f64 / elapsed.as_secs_f64();
+            eprintln!(
+                "  {label:<30} {:>6} req | pool={:>4} | inits={:>5} | {throughput:>9.0} ops/s | {:>6.2?}",
+                total_requests, pool_size, inits, elapsed
+            );
+            (throughput, elapsed.as_secs_f64(), pool_size, inits)
+        }
+
+        eprintln!("\ncontext_pool high-concurrency stress:");
+        eprintln!(
+            "  {:<30} {:>6}     {:>5}   {:>5}   {:>9}   {:>6}",
+            "scenario", "reqs", "pool", "inits", "ops/s", "time"
+        );
+
+        // A: Hot pool, all cache hits
+        let (tp_a, _, pool_a, inits_a) = run_scenario(
+            "A: hot pool (1000u × 50r, cap=1024)",
+            Arc::new(Pool::new(
+                settings(1024, std::time::Duration::from_secs(300)),
+                noop_metrics(),
+            )),
+            1000,
+            50,
+            1,
+            0,
+        );
+        assert!(pool_a <= 1024, "A: pool {pool_a} > cap 1024");
+        assert!(
+            inits_a <= 1000,
+            "A: inits {inits_a} > users 1000 — double-init detected"
+        );
+
+        // B: Capacity pressure — constant LRU eviction
+        let (tp_b, _, pool_b, _) = run_scenario(
+            "B: LRU pressure (500u × 100r, cap=64)",
+            Arc::new(Pool::new(
+                settings(64, std::time::Duration::from_secs(300)),
+                noop_metrics(),
+            )),
+            500,
+            100,
+            1,
+            0,
+        );
+        assert!(pool_b <= 64, "B: pool {pool_b} exceeded cap 64");
+
+        // C: Token rotation churn (5 rotations per user)
+        let (tp_c, _, pool_c, _) = run_scenario(
+            "C: token rotation (200u × 50r, 5 rot)",
+            Arc::new(Pool::new(
+                settings(512, std::time::Duration::from_secs(300)),
+                noop_metrics(),
+            )),
+            200,
+            50,
+            5,
+            0,
+        );
+        assert!(pool_c <= 512, "C: pool {pool_c} exceeded cap 512");
+
+        // D: Slow init (10 ms) — verifies per-key serialization
+        let (tp_d, elapsed_d, _, inits_d) = run_scenario(
+            "D: slow init 10ms (100u × 20r, cap=256)",
+            Arc::new(Pool::new(
+                settings(256, std::time::Duration::from_secs(300)),
+                noop_metrics(),
+            )),
+            100,
+            20,
+            1,
+            10,
+        );
+        assert!(
+            inits_d <= 100,
+            "D: inits {inits_d} > users 100 — Mutex not serializing init correctly"
+        );
+        eprintln!(
+            "  D elapsed={elapsed_d:.3}s (serial would be >= {:.1}s, parallel < {:.1}s)",
+            100.0 * 0.01,
+            20.0 * 0.01
+        );
+
+        eprintln!("  throughput: A={tp_a:.0} B={tp_b:.0} C={tp_c:.0} D={tp_d:.0} ops/s");
+
+        assert!(tp_a > 1_000.0, "A throughput {tp_a:.0} ops/s too low");
+        assert!(tp_b > 1_000.0, "B throughput {tp_b:.0} ops/s too low");
+        assert!(
+            elapsed_d < 5.0,
+            "D took {elapsed_d:.2}s — inits may be serializing globally rather than per-key"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "256"]
 
 mod auth;
+mod context_pool;
 mod counter;
 mod error;
 mod logging;
@@ -9,6 +10,7 @@ mod serialize;
 #[cfg(test)]
 mod test_support;
 mod tools;
+mod trade_pool;
 mod ws_pool;
 
 use std::net::SocketAddr;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -62,6 +62,29 @@ static QUOTE_WS_POOL_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
     gauge
 });
 
+static TRADE_WS_POOL_EVENTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new(
+            "mcp_trade_ws_pool_events_total",
+            "Trade WebSocket context pool events",
+        ),
+        &["event"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static TRADE_WS_POOL_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "mcp_trade_ws_pool_entries",
+        "Current cached trade WebSocket contexts in this process",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
 pub fn record_tool_call(tool_name: &str, duration_secs: f64, is_error: bool) {
     TOOL_CALLS_TOTAL.with_label_values(&[tool_name]).inc();
     TOOL_CALL_DURATION
@@ -80,6 +103,16 @@ pub fn record_quote_ws_pool_event(event: &str, count: u64) {
 
 pub fn set_quote_ws_pool_entries(entries: usize) {
     QUOTE_WS_POOL_ENTRIES.set(entries as i64);
+}
+
+pub fn record_trade_ws_pool_event(event: &str, count: u64) {
+    TRADE_WS_POOL_EVENTS_TOTAL
+        .with_label_values(&[event])
+        .inc_by(count);
+}
+
+pub fn set_trade_ws_pool_entries(entries: usize) {
+    TRADE_WS_POOL_ENTRIES.set(entries as i64);
 }
 
 pub async fn metrics_handler() -> impl IntoResponse {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -422,6 +422,30 @@ impl McpContext {
         crate::ws_pool::evict(&self.token);
     }
 
+    /// Return the cached `TradeContext` for this token, creating one on
+    /// first use.
+    ///
+    /// Known limitation: unlike [`Self::get_quote_context`], this does not
+    /// fire a per-call tracking beacon. `create_config()`'s `x-mcp-tool` and
+    /// language are only applied at connect time (a cache miss), so a cache
+    /// hit reuses whichever tool/language connected the pooled WebSocket
+    /// first — server-side per-tool attribution and response language can
+    /// go stale for the rest of the pool's idle TTL. Quote tools avoid this
+    /// via `track_quote_cmd()`'s `GET /v1/quote/cmd` beacon; there is no
+    /// known trade-gateway equivalent to fire the same way for trade calls.
+    pub async fn get_trade_context(&self) -> longbridge::trade::TradeContext {
+        // Pass a lazy closure: create_config() is only called on a cache miss.
+        // Cache hits avoid the Arc<Config> allocation entirely.
+        crate::trade_pool::get_or_init_trade(&self.token, || self.create_config()).await
+    }
+
+    /// Evict the cached `TradeContext` for this token. Call this after any
+    /// Longbridge error on a trade API so the next request creates a fresh
+    /// WebSocket connection rather than reusing a broken one.
+    pub fn evict_trade_context(&self) {
+        crate::trade_pool::evict(&self.token);
+    }
+
     /// Extracts `account_channel` from the JWT bearer token's `sub` claim.
     /// Falls back to `"lb"` when the token cannot be decoded.
     pub fn account_channel(&self) -> String {
@@ -5427,6 +5451,40 @@ mod quote_cmd_tests {
              All other code must use `mctx.get_quote_context()` so calls go \
              through the connection pool and the /v1/quote/cmd beacon. \
              Untracked constructor at:\n{}",
+            offenders.join("\n")
+        );
+    }
+
+    /// Guard: every trade tool must obtain its `TradeContext` via
+    /// `mctx.get_trade_context()`, never `TradeContext::new(...)` directly —
+    /// mirrors `quote_tools_use_tracking_context_constructor` above, so
+    /// trade tools share pooled WebSocket connections the same way quote
+    /// tools do instead of opening a fresh one per call.
+    #[test]
+    fn trade_tools_use_pooled_context_constructor() {
+        let src_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let allowed: std::collections::HashSet<_> = [
+            src_dir.join("trade_pool.rs"),
+            src_dir.join("tools").join("mod.rs"),
+        ]
+        .into();
+        let mut offenders = Vec::new();
+        for file in rs_files(&src_dir) {
+            if allowed.contains(&file) {
+                continue;
+            }
+            let src = std::fs::read_to_string(&file).unwrap();
+            for (i, line) in src.lines().enumerate() {
+                if line.contains("TradeContext::new(") {
+                    offenders.push(format!("{}:{}", file.display(), i + 1));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "TradeContext::new() is only allowed in src/trade_pool.rs. \
+             All other code must use `mctx.get_trade_context()` so calls go \
+             through the connection pool. Untracked constructor at:\n{}",
             offenders.join("\n")
         );
     }

--- a/src/tools/portfolio.rs
+++ b/src/tools/portfolio.rs
@@ -198,7 +198,7 @@ pub async fn profit_analysis_realized(
     mctx: &crate::tools::McpContext,
     p: ProfitAnalysisRealizedParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = longbridge::trade::TradeContext::new(mctx.create_config());
+    let ctx = mctx.get_trade_context().await;
     let category = p
         .category
         .as_deref()
@@ -208,7 +208,10 @@ pub async fn profit_analysis_realized(
         currency: p.currency.unwrap_or_else(|| "USD".to_string()),
         category,
     };
-    let result = ctx.us_realized_pl(opts).await.map_err(Error::longbridge)?;
+    let result = ctx.us_realized_pl(opts).await.map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
     let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
     crate::tools::support::us_normalize::normalize_us_realized_pl(&mut value);
     tool_json(&value)

--- a/src/tools/trade.rs
+++ b/src/tools/trade.rs
@@ -225,17 +225,23 @@ pub async fn account_balance(
     mctx: &crate::tools::McpContext,
     p: AccountBalanceParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = TradeContext::new(mctx.create_config());
+    let ctx = mctx.get_trade_context().await;
     let result = ctx
         .account_balance(p.currency.as_deref())
         .await
-        .map_err(Error::longbridge)?;
+        .map_err(|e| {
+            mctx.evict_trade_context();
+            Error::longbridge(e)
+        })?;
     tool_json(&result)
 }
 
 pub async fn stock_positions(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = TradeContext::new(mctx.create_config());
-    let result = ctx.stock_positions(None).await.map_err(Error::longbridge)?;
+    let ctx = mctx.get_trade_context().await;
+    let result = ctx.stock_positions(None).await.map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
     let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
     if mctx.dc_region().await == longbridge::DcRegion::Us {
         // The US overview is supplementary: its failure should annotate the
@@ -252,6 +258,7 @@ pub async fn stock_positions(mctx: &crate::tools::McpContext) -> Result<CallTool
                 }
             }
             Err(e) => {
+                mctx.evict_trade_context();
                 if let Some(obj) = value.as_object_mut() {
                     obj.insert(
                         "warnings".to_string(),
@@ -265,8 +272,11 @@ pub async fn stock_positions(mctx: &crate::tools::McpContext) -> Result<CallTool
 }
 
 pub async fn fund_positions(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = TradeContext::new(mctx.create_config());
-    let result = ctx.fund_positions(None).await.map_err(Error::longbridge)?;
+    let ctx = mctx.get_trade_context().await;
+    let result = ctx.fund_positions(None).await.map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -274,11 +284,11 @@ pub async fn margin_ratio(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = TradeContext::new(mctx.create_config());
-    let result = ctx
-        .margin_ratio(p.symbol)
-        .await
-        .map_err(Error::longbridge)?;
+    let ctx = mctx.get_trade_context().await;
+    let result = ctx.margin_ratio(p.symbol).await.map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -286,7 +296,7 @@ pub async fn today_orders(
     mctx: &crate::tools::McpContext,
     p: TodayOrdersParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = TradeContext::new(mctx.create_config());
+    let ctx = mctx.get_trade_context().await;
     if mctx.dc_region().await == longbridge::DcRegion::Us {
         let side = match p.us_action.as_deref() {
             Some(s) if s.eq_ignore_ascii_case("buy") => longbridge::trade::OrderSide::Buy,
@@ -315,7 +325,10 @@ pub async fn today_orders(
             page: p.us_page.unwrap_or(1),
             limit: p.us_limit.unwrap_or(20),
         };
-        let result = ctx.us_query_orders(opts).await.map_err(Error::longbridge)?;
+        let result = ctx.us_query_orders(opts).await.map_err(|e| {
+            mctx.evict_trade_context();
+            Error::longbridge(e)
+        })?;
         let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
         if let Some(orders) = value.get_mut("orders").and_then(|v| v.as_array_mut()) {
             for order in orders {
@@ -328,7 +341,10 @@ pub async fn today_orders(
     if let Some(symbol) = p.symbol {
         opts = opts.symbol(symbol);
     }
-    let result = ctx.today_orders(opts).await.map_err(Error::longbridge)?;
+    let result = ctx.today_orders(opts).await.map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -336,12 +352,12 @@ pub async fn order_detail(
     mctx: &crate::tools::McpContext,
     p: OrderIdParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = TradeContext::new(mctx.create_config());
+    let ctx = mctx.get_trade_context().await;
     if mctx.dc_region().await == longbridge::DcRegion::Us {
-        let result = ctx
-            .us_order_detail(p.order_id)
-            .await
-            .map_err(Error::longbridge)?;
+        let result = ctx.us_order_detail(p.order_id).await.map_err(|e| {
+            mctx.evict_trade_context();
+            Error::longbridge(e)
+        })?;
         let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
         if let Some(order) = value.get_mut("order") {
             crate::tools::support::us_normalize::normalize_us_order(order);
@@ -351,10 +367,10 @@ pub async fn order_detail(
         }
         return tool_json(&value);
     }
-    let result = ctx
-        .order_detail(p.order_id)
-        .await
-        .map_err(Error::longbridge)?;
+    let result = ctx.order_detail(p.order_id).await.map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -362,7 +378,7 @@ pub async fn cancel_order(
     mctx: &crate::tools::McpContext,
     p: CancelOrderParam,
 ) -> Result<CallToolResult, McpError> {
-    let (ctx, _) = TradeContext::new(mctx.create_config());
+    let ctx = mctx.get_trade_context().await;
     let scope = dry_run::Scope::on_order("cancel", &p.order_id);
     // Two-step by design: without a confirmation code this cancels nothing.
     let Some(code) = p.execute.clone() else {
@@ -377,9 +393,10 @@ pub async fn cancel_order(
         );
     };
     scope.verify(&code)?;
-    ctx.cancel_order(p.order_id)
-        .await
-        .map_err(Error::longbridge)?;
+    ctx.cancel_order(p.order_id).await.map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
     Ok(tool_result("order cancelled".to_string()))
 }
 
@@ -399,12 +416,15 @@ pub async fn today_executions(
         exec_opts = exec_opts.order_id(order_id);
     }
 
-    let (ctx, _) = TradeContext::new(mctx.create_config());
+    let ctx = mctx.get_trade_context().await;
     let (executions, orders) = tokio::try_join!(
         ctx.today_executions(exec_opts),
         ctx.today_orders(order_opts),
     )
-    .map_err(Error::longbridge)?;
+    .map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
 
     let side_map: HashMap<String, String> = orders
         .into_iter()
@@ -431,7 +451,7 @@ pub async fn history_orders(
 ) -> Result<CallToolResult, McpError> {
     let start = parse::parse_rfc3339(&p.start_at)?;
     let end = parse::parse_rfc3339(&p.end_at)?;
-    let (ctx, _) = TradeContext::new(mctx.create_config());
+    let ctx = mctx.get_trade_context().await;
     if mctx.dc_region().await == longbridge::DcRegion::Us {
         let opts = longbridge::trade::GetUSHistoryOrders {
             symbol: p.symbol,
@@ -447,7 +467,10 @@ pub async fn history_orders(
             page: p.us_page.unwrap_or(1),
             limit: p.us_limit.unwrap_or(20),
         };
-        let result = ctx.us_query_orders(opts).await.map_err(Error::longbridge)?;
+        let result = ctx.us_query_orders(opts).await.map_err(|e| {
+            mctx.evict_trade_context();
+            Error::longbridge(e)
+        })?;
         let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
         if let Some(orders) = value.get_mut("orders").and_then(|v| v.as_array_mut()) {
             for order in orders {
@@ -462,7 +485,10 @@ pub async fn history_orders(
     if let Some(symbol) = p.symbol {
         opts = opts.symbol(symbol);
     }
-    let result = ctx.history_orders(opts).await.map_err(Error::longbridge)?;
+    let result = ctx.history_orders(opts).await.map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -486,12 +512,15 @@ pub async fn history_executions(
         order_opts = order_opts.symbol(symbol.clone());
     }
 
-    let (ctx, _) = TradeContext::new(mctx.create_config());
+    let ctx = mctx.get_trade_context().await;
     let (executions, orders) = tokio::try_join!(
         ctx.history_executions(exec_opts),
         ctx.history_orders(order_opts),
     )
-    .map_err(Error::longbridge)?;
+    .map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
 
     let side_map: HashMap<String, String> = orders
         .into_iter()
@@ -519,8 +548,11 @@ pub async fn cash_flow(
     let start = parse::parse_rfc3339(&p.start_at)?;
     let end = parse::parse_rfc3339(&p.end_at)?;
     let opts = longbridge::trade::GetCashFlowOptions::new(start, end);
-    let (ctx, _) = TradeContext::new(mctx.create_config());
-    let result = ctx.cash_flow(opts).await.map_err(Error::longbridge)?;
+    let ctx = mctx.get_trade_context().await;
+    let result = ctx.cash_flow(opts).await.map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
     tool_json(&result)
 }
 
@@ -621,8 +653,11 @@ pub async fn submit_order(
     };
     scope.verify(&code)?;
 
-    let (ctx, _) = TradeContext::new(mctx.create_config());
-    let result = ctx.submit_order(opts).await.map_err(Error::longbridge)?;
+    let ctx = mctx.get_trade_context().await;
+    let result = ctx.submit_order(opts).await.map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
     // Same envelope as the dry run so both outcomes validate against
     // `output::SubmitOrderResult`, and `dry_run` alone tells them apart.
     tool_json(&serde_json::json!({
@@ -670,7 +705,7 @@ pub async fn replace_order(
             McpError::invalid_params(format!("invalid trailing_percent: {e}"), None)
         })?);
     }
-    let (ctx, _) = TradeContext::new(mctx.create_config());
+    let ctx = mctx.get_trade_context().await;
     let scope = dry_run::Scope::replace(&p.order_id, &p.quantity, p.price.as_deref().unwrap_or(""));
     // Two-step by design: without a confirmation code this changes nothing.
     let Some(code) = p.execute.clone() else {
@@ -691,7 +726,10 @@ pub async fn replace_order(
         );
     };
     scope.verify(&code)?;
-    ctx.replace_order(opts).await.map_err(Error::longbridge)?;
+    ctx.replace_order(opts).await.map_err(|e| {
+        mctx.evict_trade_context();
+        Error::longbridge(e)
+    })?;
     Ok(tool_result("order replaced".to_string()))
 }
 
@@ -727,11 +765,14 @@ pub async fn estimate_max_purchase_quantity(
                 .map_err(|e| McpError::invalid_params(format!("invalid price: {e}"), None))?,
         );
     }
-    let (ctx, _) = TradeContext::new(mctx.create_config());
+    let ctx = mctx.get_trade_context().await;
     let result = ctx
         .estimate_max_purchase_quantity(opts)
         .await
-        .map_err(Error::longbridge)?;
+        .map_err(|e| {
+            mctx.evict_trade_context();
+            Error::longbridge(e)
+        })?;
     tool_json(&result)
 }
 

--- a/src/trade_pool.rs
+++ b/src/trade_pool.rs
@@ -1,9 +1,13 @@
-//! WebSocket `QuoteContext` pool — see [`crate::context_pool`] for the
+//! WebSocket `TradeContext` pool — see [`crate::context_pool`] for the
 //! generic caching/eviction engine this wraps.
+//!
+//! Mirrors [`crate::ws_pool`]'s `QuoteContext` pooling: without this,
+//! every trade tool call opened a fresh WebSocket connection, unlike quote
+//! calls which have always shared a pooled connection per identity.
 
 use std::sync::{Arc, LazyLock, OnceLock};
 
-use longbridge::quote::QuoteContext;
+use longbridge::trade::TradeContext;
 
 use crate::context_pool::{
     Pool, PoolMetrics, PoolSettings, cache_key_for_token, ensure_sweeper_started, token_fingerprint,
@@ -11,10 +15,10 @@ use crate::context_pool::{
 
 const DEFAULT_IDLE_TTL_SECS: u64 = 10 * 60;
 const DEFAULT_MAX_ENTRIES: usize = 1024;
-const IDLE_TTL_ENV: &str = "LONGBRIDGE_MCP_QUOTE_WS_IDLE_TTL_SECS";
-const MAX_ENTRIES_ENV: &str = "LONGBRIDGE_MCP_QUOTE_WS_MAX_CONTEXTS";
+const IDLE_TTL_ENV: &str = "LONGBRIDGE_MCP_TRADE_WS_IDLE_TTL_SECS";
+const MAX_ENTRIES_ENV: &str = "LONGBRIDGE_MCP_TRADE_WS_MAX_CONTEXTS";
 
-static POOL: LazyLock<Pool<QuoteContext>> = LazyLock::new(|| {
+static POOL: LazyLock<Pool<TradeContext>> = LazyLock::new(|| {
     Pool::new(
         PoolSettings::from_env(
             IDLE_TTL_ENV,
@@ -23,36 +27,36 @@ static POOL: LazyLock<Pool<QuoteContext>> = LazyLock::new(|| {
             DEFAULT_IDLE_TTL_SECS,
         ),
         PoolMetrics {
-            record_event: crate::metrics::record_quote_ws_pool_event,
-            set_entries: crate::metrics::set_quote_ws_pool_entries,
+            record_event: crate::metrics::record_trade_ws_pool_event,
+            set_entries: crate::metrics::set_trade_ws_pool_entries,
         },
     )
 });
 static SWEEPER_STARTED: OnceLock<()> = OnceLock::new();
 
-/// Return the cached `QuoteContext` for `token`, creating one on first use.
+/// Return the cached `TradeContext` for `token`, creating one on first use.
 ///
 /// `make_config` is a lazy factory: it is only called on a cache miss so
 /// callers avoid building a `Config` (and its `Arc` allocation) on every
 /// cache hit. Pass `|| mctx.create_config()` rather than
 /// `mctx.create_config()`.
-pub async fn get_or_init_quote(
+pub async fn get_or_init_trade(
     token: &str,
     make_config: impl FnOnce() -> Arc<longbridge::Config>,
-) -> QuoteContext {
+) -> TradeContext {
     ensure_sweeper_started(&POOL, &SWEEPER_STARTED);
 
     let key = cache_key_for_token(token);
     let token_fingerprint = token_fingerprint(token);
     POOL.get_or_insert_with(key, token_fingerprint, || {
-        let (ctx, _) = QuoteContext::new(make_config());
+        let (ctx, _) = TradeContext::new(make_config());
         ctx
     })
 }
 
-/// Evict the cached `QuoteContext` for `token`. Call this after any error on
-/// a quote API so the next request creates a fresh WebSocket connection rather
-/// than reusing a potentially broken one.
+/// Evict the cached `TradeContext` for `token`. Call this after any error on
+/// a trade API so the next request creates a fresh WebSocket connection
+/// rather than reusing a potentially broken one.
 pub fn evict(token: &str) {
     POOL.remove_identity(&cache_key_for_token(token));
 }


### PR DESCRIPTION
## Summary
Split out of #134, which bundled this with unrelated fixes.

Every trade tool call (15 call sites across `trade.rs` and `portfolio.rs`) opened a fresh WebSocket connection via `TradeContext::new()`, unlike `QuoteContext` which has always been pooled per identity via `ws_pool.rs`. Under concurrent load this plausibly contributes to elevated error rates on trade-related tools (connection-limit/timeout errors), and is architecturally inconsistent with how quote calls are handled.

- Extracted the pooling engine (LRU + idle-TTL + per-key init serialization + eviction-on-error) out of `ws_pool.rs` into a generic `context_pool.rs`.
- Added `trade_pool.rs` as a `TradeContext` pool built on it, mirroring `ws_pool.rs` exactly (same identity-keying, own Prometheus metrics, own env vars for tuning).
- Rewired all 15 `TradeContext::new()` call sites through `mctx.get_trade_context()`, with eviction-on-error wired into every trade error path.
- Added a compile-time lint (`trade_tools_use_pooled_context_constructor`) mirroring the existing quote-side one, so any future trade tool that bypasses the pool fails CI.

## Test plan
- [x] `cargo build` clean
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo test` — 207 passed, 0 failed
- [x] Both `#[ignore]`d stress tests (`stress_pool_bounded_concurrency`, `stress_high_concurrency`) run manually against real thread contention and pass