### PR TITLE
fix(locales): sync zh-CN/zh-HK descriptions for option_quote and candlestick count fixes

### DIFF
--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -381,7 +381,7 @@
     },
     "candlesticks": {
       "title": "K 线数据",
-      "description": "获取 K 线数据（OHLCV）。period：1m/5m/15m/30m/60m/day/week/month/year；trade_sessions：intraday（默认，仅正常时段）或 all（含盘前盘后）",
+      "description": "获取 K 线数据（OHLCV）。period：1m/5m/15m/30m/60m/day/week/month/year；trade_sessions：intraday（默认，仅正常时段）或 all（含盘前盘后）。若账号权限上限低于请求的 count，会返回权限允许范围内尽量多的数据而不报错——如果需要精确数量，请检查返回数组的长度。",
       "properties": {
         "symbol": "证券代码",
         "period": "K 线周期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`",
@@ -674,7 +674,7 @@
     },
     "history_candlesticks_by_offset": {
       "title": "历史 K 线（按偏移）",
-      "description": "以参考时间为锚点按偏移量获取历史 K 线（OHLCV）数据。仅 symbol 必填，period 默认 day、count 默认 100、forward_adjust 与 forward 默认 false、trade_sessions 默认 all。",
+      "description": "以参考时间为锚点按偏移量获取历史 K 线（OHLCV）数据。仅 symbol 必填，period 默认 day、count 默认 100、forward_adjust 与 forward 默认 false、trade_sessions 默认 all。若账号权限上限低于请求的 count，会返回权限允许范围内尽量多的数据而不报错——如果需要精确数量，请检查返回数组的长度。",
       "properties": {
         "symbol": "证券代码",
         "period": "K 线周期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`（默认 `day`）",
@@ -811,9 +811,9 @@
     },
     "option_quote": {
       "title": "期权报价",
-      "description": "获取期权行情（最多 500 个），返回各标的：last_done（最新价）, prev_close, open, high, low, volume（成交量）, turnover（成交额）, implied_volatility（隐含波动率）, delta/gamma/theta/vega/rho（Greeks）, open_interest（未平仓量）",
+      "description": "获取期权行情（最多 500 个）。symbols 必须是期权合约代码（例如 \"AAPL230317P160000.US\"），不能用普通股票代码——请先用 option_chain_info_by_date 返回的 call.symbol/put.symbol 字段获取有效的期权代码。返回各标的：last_done（最新价）, prev_close, open, high, low, volume（成交量）, turnover（成交额）, implied_volatility（隐含波动率）, delta/gamma/theta/vega/rho（Greeks）, open_interest（未平仓量）",
       "properties": {
-        "symbols": "证券代码，例如 `[\"700.HK\", \"AAPL.US\"]`"
+        "symbols": "期权合约代码，例如 `[\"AAPL230317P160000.US\"]`。不是普通股票代码——请先用 option_chain_expiry_date_list 列出到期日，再用 option_chain_info_by_date 按行权价获取的 call.symbol/put.symbol 字段拿到有效代码"
       }
     },
     "option_volume": {

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -381,7 +381,7 @@
     },
     "candlesticks": {
       "title": "K 線數據",
-      "description": "獲取 K 線數據（OHLCV）。period：1m/5m/15m/30m/60m/day/week/month/year；trade_sessions：intraday（預設，僅正常時段）或 all（含盤前盤後）",
+      "description": "獲取 K 線數據（OHLCV）。period：1m/5m/15m/30m/60m/day/week/month/year；trade_sessions：intraday（預設，僅正常時段）或 all（含盤前盤後）。若賬戶權限上限低於請求的 count，會返回權限允許範圍內盡量多的數據而不報錯——如果需要精確數量，請檢查返回數組的長度。",
       "properties": {
         "symbol": "證券代碼",
         "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`",
@@ -674,7 +674,7 @@
     },
     "history_candlesticks_by_offset": {
       "title": "歷史 K 線（按偏移）",
-      "description": "以參考時間為錨點按偏移量獲取歷史 K 線（OHLCV）數據。僅 symbol 必填，period 預設 day、count 預設 100、forward_adjust 與 forward 預設 false、trade_sessions 預設 all。",
+      "description": "以參考時間為錨點按偏移量獲取歷史 K 線（OHLCV）數據。僅 symbol 必填，period 預設 day、count 預設 100、forward_adjust 與 forward 預設 false、trade_sessions 預設 all。若賬戶權限上限低於請求的 count，會返回權限允許範圍內盡量多的數據而不報錯——如果需要精確數量，請檢查返回數組的長度。",
       "properties": {
         "symbol": "證券代碼",
         "period": "K 線週期：`1m`、`5m`、`15m`、`30m`、`60m`、`day`、`week`、`month`、`year`（預設 `day`）",
@@ -811,9 +811,9 @@
     },
     "option_quote": {
       "title": "期權報價",
-      "description": "獲取期權行情（最多 500 個），返回各標的：last_done（最新價）, prev_close, open, high, low, volume（成交量）, turnover（成交額）, implied_volatility（隱含波動率）, delta/gamma/theta/vega/rho（Greeks）, open_interest（未平倉量）",
+      "description": "獲取期權行情（最多 500 個）。symbols 必須是期權合約代碼（例如 \"AAPL230317P160000.US\"），不能用普通股票代碼——請先用 option_chain_info_by_date 返回的 call.symbol/put.symbol 欄位獲取有效的期權代碼。返回各標的：last_done（最新價）, prev_close, open, high, low, volume（成交量）, turnover（成交額）, implied_volatility（隱含波動率）, delta/gamma/theta/vega/rho（Greeks）, open_interest（未平倉量）",
       "properties": {
-        "symbols": "證券代碼，例如 `[\"700.HK\", \"AAPL.US\"]`"
+        "symbols": "期權合約代碼，例如 `[\"AAPL230317P160000.US\"]`。不是普通股票代碼——請先用 option_chain_expiry_date_list 列出到期日，再用 option_chain_info_by_date 按行使價獲取的 call.symbol/put.symbol 欄位拿到有效代碼"
       }
     },
     "option_volume": {


### PR DESCRIPTION
## Summary
PR #134 rewrote `option_quote`'s `symbols` example (was the plain-stock-symbol example that caused models to pass the wrong format) and added a count-shortfall note to `candlesticks`/`history_candlesticks_by_offset`, but only in English — `locales/zh-CN/tools.json` and `locales/zh-HK/tools.json` were never updated, so Chinese-language clients still saw the pre-fix wording (`option_quote`'s zh `symbols` example still literally said `["700.HK", "AAPL.US"]`).

The existing `locales_match_live_tool_schema` test only checks tool/param *key* presence, not translated *content* drift, so this slipped through CI silently.

## Test plan
- [x] Both locale files still valid JSON
- [x] `cargo test locales_match_live_tool_schema` passes
- [x] `cargo build` / `cargo +nightly fmt --check` / `cargo clippy --all-features --all-targets -- -D warnings` / `cargo test` all clean