### PR TITLE
Version 0.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-mcp"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longbridge-mcp"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 
 [dependencies]

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.longbridge/mcp",
   "description": "US/HK markets — 163 tools: quotes, options, orders, fundamentals, screener, IPO, alerts, DCA & grid",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "repository": {
     "url": "https://github.com/longbridge/longbridge-mcp",
     "source": "github"
@@ -25,7 +25,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.10.3",
+      "identifier": "ghcr.io/longbridge/longbridge-mcp:0.10.4",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8000/mcp",


### PR DESCRIPTION
Bumps the version for PR #138 (input-params-on-failure logging, capital_distribution index handling), matching the repo's convention of a standalone version-bump commit/PR ahead of a release tag.