### PR TITLE
feat(quote): return option Greeks in option_quote; fix theta normalization

### DIFF
--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -811,7 +811,7 @@
     },
     "option_quote": {
       "title": "期权报价",
-      "description": "获取期权行情（最多 500 个）。symbols 必须是期权合约代码（例如 \"AAPL230317P160000.US\"），不能用普通股票代码——请先用 option_chain_info_by_date 返回的 call.symbol/put.symbol 字段获取有效的期权代码。返回各标的：last_done（最新价）, prev_close, open, high, low, volume（成交量）, turnover（成交额）, implied_volatility（隐含波动率）, delta/gamma/theta/vega/rho（Greeks）, open_interest（未平仓量）",
+      "description": "获取期权行情（最多 500 个）。symbols 必须是期权合约代码（例如 \"AAPL230317P160000.US\"），不能用普通股票代码——请先用 option_chain_info_by_date 返回的 call.symbol/put.symbol 字段获取有效的期权代码。返回各标的：last_done（最新价）, prev_close, open, high, low, volume（成交量）, turnover（成交额）, implied_volatility（隐含波动率）, delta/gamma/theta/vega/rho（Greeks）, open_interest（未平仓量）。Greeks 已归一化：theta 为每日值（一天的时间损耗），vega 为隐含波动率每变动 1% 的价格变化，rho 为无风险利率每变动 1% 的价格变化。",
       "properties": {
         "symbols": "期权合约代码，例如 `[\"AAPL230317P160000.US\"]`。不是普通股票代码——请先用 option_chain_expiry_date_list 列出到期日，再用 option_chain_info_by_date 按行权价获取的 call.symbol/put.symbol 字段拿到有效代码"
       }

--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -373,7 +373,7 @@
     },
     "calc_indexes": {
       "title": "指标计算",
-      "description": "批量计算证券的行情/财务指标（PE、PB、股息率、最新价、换手率等），传入 symbols 和 indexes 列表，返回各标的的指标值",
+      "description": "批量计算证券的行情/财务指标（PE、PB、股息率、最新价、换手率等），传入 symbols 和 indexes 列表，返回各标的的指标值。当请求希腊字母指标（Delta、Gamma、Theta、Vega、Rho）时，返回值已归一化：theta 为每日值（一天的时间损耗），vega 为隐含波动率每变动 1% 的价格变化，rho 为无风险利率每变动 1% 的价格变化。",
       "properties": {
         "symbols": "证券代码，例如 `[\"700.HK\", \"AAPL.US\"]`",
         "indexes": "待计算指标：`LastDone`、`ChangeValue`、`ChangeRate`、`Volume`、`Turnover`、`YtdChangeRate`、`TurnoverRate`、`TotalMarketValue`、`CapitalFlow`、`Amplitude`、`VolumeRatio`、`PeTtmRatio`、`PbRatio`、`DividendRatioTtm`、`FiveDayChangeRate`、`TenDayChangeRate`、`HalfYearChangeRate`、`FiveMinutesChangeRate`、`ExpiryDate`、`StrikePrice`、`UpperStrikePrice`、`LowerStrikePrice`、`OutstandingQty`、`OutstandingRatio`、`Premium`、`ItmOtm`、`ImpliedVolatility`、`WarrantDelta`、`CallPrice`、`ToCallPrice`、`EffectiveLeverage`、`LeverageRatio`、`ConversionRatio`、`BalancePoint`、`OpenInterest`、`Delta`、`Gamma`、`Theta`、`Vega`、`Rho`"

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -373,7 +373,7 @@
     },
     "calc_indexes": {
       "title": "指標計算",
-      "description": "批量計算證券的行情/財務指標（PE、PB、股息率、最新價、換手率等），傳入 symbols 和 indexes 列表，返回各標的的指標值",
+      "description": "批量計算證券的行情/財務指標（PE、PB、股息率、最新價、換手率等），傳入 symbols 和 indexes 列表，返回各標的的指標值。當請求希臘字母指標（Delta、Gamma、Theta、Vega、Rho）時，返回值已歸一化：theta 為每日值（一天的時間損耗），vega 為隱含波動率每變動 1% 的價格變化，rho 為無風險利率每變動 1% 的價格變化。",
       "properties": {
         "symbols": "證券代碼，例如 `[\"700.HK\", \"AAPL.US\"]`",
         "indexes": "待計算指標：`LastDone`、`ChangeValue`、`ChangeRate`、`Volume`、`Turnover`、`YtdChangeRate`、`TurnoverRate`、`TotalMarketValue`、`CapitalFlow`、`Amplitude`、`VolumeRatio`、`PeTtmRatio`、`PbRatio`、`DividendRatioTtm`、`FiveDayChangeRate`、`TenDayChangeRate`、`HalfYearChangeRate`、`FiveMinutesChangeRate`、`ExpiryDate`、`StrikePrice`、`UpperStrikePrice`、`LowerStrikePrice`、`OutstandingQty`、`OutstandingRatio`、`Premium`、`ItmOtm`、`ImpliedVolatility`、`WarrantDelta`、`CallPrice`、`ToCallPrice`、`EffectiveLeverage`、`LeverageRatio`、`ConversionRatio`、`BalancePoint`、`OpenInterest`、`Delta`、`Gamma`、`Theta`、`Vega`、`Rho`"

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -811,7 +811,7 @@
     },
     "option_quote": {
       "title": "期權報價",
-      "description": "獲取期權行情（最多 500 個）。symbols 必須是期權合約代碼（例如 \"AAPL230317P160000.US\"），不能用普通股票代碼——請先用 option_chain_info_by_date 返回的 call.symbol/put.symbol 欄位獲取有效的期權代碼。返回各標的：last_done（最新價）, prev_close, open, high, low, volume（成交量）, turnover（成交額）, implied_volatility（隱含波動率）, delta/gamma/theta/vega/rho（Greeks）, open_interest（未平倉量）",
+      "description": "獲取期權行情（最多 500 個）。symbols 必須是期權合約代碼（例如 \"AAPL230317P160000.US\"），不能用普通股票代碼——請先用 option_chain_info_by_date 返回的 call.symbol/put.symbol 欄位獲取有效的期權代碼。返回各標的：last_done（最新價）, prev_close, open, high, low, volume（成交量）, turnover（成交額）, implied_volatility（隱含波動率）, delta/gamma/theta/vega/rho（Greeks）, open_interest（未平倉量）。Greeks 已歸一化：theta 為每日值（一天的時間損耗），vega 為隱含波動率每變動 1% 的價格變化，rho 為無風險利率每變動 1% 的價格變化。",
       "properties": {
         "symbols": "期權合約代碼，例如 `[\"AAPL230317P160000.US\"]`。不是普通股票代碼——請先用 option_chain_expiry_date_list 列出到期日，再用 option_chain_info_by_date 按行使價獲取的 call.symbol/put.symbol 欄位拿到有效代碼"
       }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1967,7 +1967,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        description = "Calculate financial indexes for symbols. Pass symbols, and optionally indexes (e.g. [\"PeTtmRatio\",\"PbRatio\",\"LastDone\",\"TurnoverRate\"]). When indexes is omitted or empty, defaults to [\"LastDone\",\"ChangeValue\",\"ChangeRate\",\"Volume\",\"PeTtmRatio\",\"PbRatio\",\"DividendRatioTtm\",\"TurnoverRate\",\"TotalMarketValue\"]. Returns per-symbol index values."
+        description = "Calculate financial indexes for symbols. Pass symbols, and optionally indexes (e.g. [\"PeTtmRatio\",\"PbRatio\",\"LastDone\",\"TurnoverRate\"]). When indexes is omitted or empty, defaults to [\"LastDone\",\"ChangeValue\",\"ChangeRate\",\"Volume\",\"PeTtmRatio\",\"PbRatio\",\"DividendRatioTtm\",\"TurnoverRate\",\"TotalMarketValue\"]. Returns per-symbol index values. When Greek indexes (Delta, Gamma, Theta, Vega, Rho) are requested, they are normalized: theta is the per-day value (one day's time decay), vega is the price change per 1% change in implied volatility, and rho is the price change per 1% change in the risk-free interest rate."
     )]
     async fn calc_indexes(
         &self,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1475,7 +1475,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        description = "Get option quotes (max 500 symbols). Symbols must be option contract symbols (e.g. \"AAPL230317P160000.US\"), NOT plain stock symbols — obtain valid ones from option_chain_info_by_date's call.symbol/put.symbol fields. Returns last_done, prev_close, open, high, low, volume, turnover, implied_volatility, delta, gamma, theta, vega, rho, open_interest per symbol."
+        description = "Get option quotes (max 500 symbols). Symbols must be option contract symbols (e.g. \"AAPL230317P160000.US\"), NOT plain stock symbols — obtain valid ones from option_chain_info_by_date's call.symbol/put.symbol fields. Returns last_done, prev_close, open, high, low, volume, turnover, implied_volatility, delta, gamma, theta, vega, rho, open_interest per symbol. Greeks are normalized: theta is the per-day value (one day's time decay), vega is the price change per 1% change in implied volatility, and rho is the price change per 1% change in the risk-free interest rate."
     )]
     async fn option_quote(
         &self,

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -382,11 +382,11 @@ pub async fn option_quote(
                     .get("symbol")
                     .and_then(|s| s.as_str())
                     .map(String::from);
-                if let (Some(sym), Some(obj)) = (sym, item.as_object_mut()) {
-                    if let Some(g) = by_symbol.get(&sym).and_then(|v| v.as_object()) {
-                        for (k, v) in g {
-                            obj.insert(k.clone(), v.clone());
-                        }
+                if let (Some(sym), Some(obj)) = (sym, item.as_object_mut())
+                    && let Some(g) = by_symbol.get(&sym).and_then(|v| v.as_object())
+                {
+                    for (k, v) in g {
+                        obj.insert(k.clone(), v.clone());
                     }
                 }
             }

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -1,5 +1,5 @@
 use longbridge::quote::{
-    RequestCreateWatchlistGroup, RequestUpdateWatchlistGroup, SecuritiesUpdateMode,
+    CalcIndex, RequestCreateWatchlistGroup, RequestUpdateWatchlistGroup, SecuritiesUpdateMode,
 };
 use rmcp::ErrorData as McpError;
 use rmcp::model::CallToolResult;
@@ -343,11 +343,57 @@ pub async fn option_quote(
     p: OptionSymbolsParam,
 ) -> Result<CallToolResult, McpError> {
     let ctx = mctx.get_quote_context().await;
-    let result = ctx.option_quote(p.symbols).await.map_err(|e| {
+    let result = ctx.option_quote(p.symbols.clone()).await.map_err(|e| {
         mctx.evict_quote_context();
         Error::longbridge(e)
     })?;
-    tool_json(&result)
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+
+    // The `option_quote` interface does not carry the option Greeks — they come
+    // from the Calc Index interface. Fetch them for the same symbols and merge
+    // delta/gamma/theta/vega/rho into each quote (best-effort: a Greek lookup
+    // failure leaves the quotes unchanged).
+    let greek_indexes = vec![
+        CalcIndex::Delta,
+        CalcIndex::Gamma,
+        CalcIndex::Theta,
+        CalcIndex::Vega,
+        CalcIndex::Rho,
+    ];
+    if let Ok(mut greeks) = ctx.calc_indexes(p.symbols, greek_indexes).await {
+        let mut by_symbol: std::collections::HashMap<String, serde_json::Value> =
+            std::collections::HashMap::new();
+        for g in &mut greeks {
+            normalize_greeks(g);
+            by_symbol.insert(
+                g.symbol.clone(),
+                serde_json::json!({
+                    "delta": g.delta,
+                    "gamma": g.gamma,
+                    "theta": g.theta,
+                    "vega": g.vega,
+                    "rho": g.rho,
+                }),
+            );
+        }
+        if let Some(arr) = value.as_array_mut() {
+            for item in arr {
+                let sym = item
+                    .get("symbol")
+                    .and_then(|s| s.as_str())
+                    .map(String::from);
+                if let (Some(sym), Some(obj)) = (sym, item.as_object_mut()) {
+                    if let Some(g) = by_symbol.get(&sym).and_then(|v| v.as_object()) {
+                        for (k, v) in g {
+                            obj.insert(k.clone(), v.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    tool_json(&value)
 }
 
 pub async fn warrant_quote(
@@ -804,23 +850,29 @@ pub async fn calc_indexes(
         Error::longbridge(e)
     })?;
 
-    // Normalize Greeks to match Longbridge app display values:
-    // - theta: API returns annualized value (×252), divide by 252 for per-trading-day
-    // - vega:  API returns per-1%-IV-change value scaled by 100, divide by 100
-    // - rho:   API returns per-1%-rate-change value scaled by 100, divide by 100
     for r in &mut result {
-        if let Some(v) = r.theta.as_mut() {
-            *v /= rust_decimal::Decimal::from(252u32);
-        }
-        if let Some(v) = r.vega.as_mut() {
-            *v /= rust_decimal::Decimal::ONE_HUNDRED;
-        }
-        if let Some(v) = r.rho.as_mut() {
-            *v /= rust_decimal::Decimal::ONE_HUNDRED;
-        }
+        normalize_greeks(r);
     }
 
     tool_json(&result)
+}
+
+/// Normalize the option Greeks on a calc-index row to the values the Longbridge
+/// app displays.
+///
+/// - `theta`: the API already returns a per-day value (the raw annualized value
+///   has been divided by 365 on the server), so it is used as-is.
+/// - `vega`:  the API returns the value scaled by 100 (per 1% IV change);
+///   divide by 100 for the per-unit value.
+/// - `rho`:   the API returns the value scaled by 100 (per 1% rate change);
+///   divide by 100 for the per-unit value.
+fn normalize_greeks(r: &mut longbridge::quote::SecurityCalcIndex) {
+    if let Some(v) = r.vega.as_mut() {
+        *v /= rust_decimal::Decimal::ONE_HUNDRED;
+    }
+    if let Some(v) = r.rho.as_mut() {
+        *v /= rust_decimal::Decimal::ONE_HUNDRED;
+    }
 }
 
 pub async fn create_watchlist_group(


### PR DESCRIPTION
## Changes
- **calc_indexes**: the Calc Index API's theta was fixed server-side to return a per-day value (raw annualized value divided by 365 on the server), so calc_indexes no longer divides theta by 252 — that would double-normalize. Extracted the Greek normalization into `normalize_greeks` (vega/100, rho/100; theta as-is).
- **option_quote**: the `option_quote` interface does not carry Greeks (they come from the Calc Index interface), so it previously showed the Greek fields but returned no data. It now also fetches delta/gamma/theta/vega/rho via `calc_indexes` for the same symbols and merges them into each quote (best-effort — a Greek lookup failure leaves the quotes unchanged).

Matches longbridge/openapi#586 and the CLI change. build + clippy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)