### PR TITLE
docs(tools): unify DC-region wording across region-branching tools (+ schema guard, locale sync)

### DIFF
--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../tools.schema.json",
-  "server_instructions": "长桥 MCP 服务 —— 提供市场数据、交易与金融分析工具。委托执行需要两步确认：submit_order、cancel_order、replace_order 以及全部网格写操作（grid_submit、grid_replace、grid_cancel、grid_suspend、grid_restart）在未回填确认码时均为 DRY RUN（试运行），并会返回一个一次性 confirmation_code。请务必先不带 execute 调用一次，把预览展示给用户，只有在用户明确确认之后，才可再次调用并把该确认码传入 execute。",
+  "server_instructions": "长桥 MCP 服务 —— 提供市场数据、交易与金融分析工具。委托执行需要两步确认：submit_order、cancel_order、replace_order 以及全部网格写操作（grid_submit、grid_replace、grid_cancel、grid_suspend、grid_restart）在未回填确认码时均为 DRY RUN（试运行），并会返回一个一次性 confirmation_code。请务必先不带 execute 调用一次，把预览展示给用户，只有在用户明确确认之后，才可再次调用并把该确认码传入 execute。 调用失败时，工具会在结果内容里返回带 error_code 和 recoverable 字段的 JSON 信封：reauth（重新鉴权后重试）、backoff（等待后重试）、fix_params（修正参数后重试）、none（不要重试，告知用户）。",
   "tools": {
     "create_watchlist_group": {
       "title": "新建自选分组",

--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -165,8 +165,8 @@
         "symbol": "按证券筛选（可选）",
         "start_at": "起始时间（RFC3339 格式）",
         "end_at": "结束时间（RFC3339 格式）",
-        "us_page": "仅限美股账户：页码（默认 1）",
-        "us_limit": "仅限美股账户：每页数量（默认 20）"
+        "us_page": "仅限美股账户：页码（默认 1）。港股/沪深/新加坡账户忽略（区域由账户自动识别，无需传入）",
+        "us_limit": "仅限美股账户：每页数量（默认 20）。港股/沪深/新加坡账户忽略（区域由账户自动识别，无需传入）"
       }
     },
     "order_detail": {
@@ -189,9 +189,9 @@
       "description": "查询当日委托，返回 orders[]{order_id, symbol, side, order_type, status, quantity, price, submitted_at, executed_quantity, executed_price}。仅限美股账户：us_action（Buy/Sell）、us_page、us_limit 通过独立的美股委托接口筛选/分页",
       "properties": {
         "symbol": "按证券筛选，例如 `\"700.HK\"`，省略则返回当日全部委托",
-        "us_action": "仅限美股账户：按方向筛选，`\"Buy\"` 或 `\"Sell\"`，留空表示全部",
-        "us_page": "仅限美股账户：页码（默认 1）",
-        "us_limit": "仅限美股账户：每页数量（默认 20）"
+        "us_action": "仅限美股账户：按方向筛选，`\"Buy\"` 或 `\"Sell\"`，留空表示全部。港股/沪深/新加坡账户忽略（区域由账户自动识别，无需传入）",
+        "us_page": "仅限美股账户：页码（默认 1）。港股/沪深/新加坡账户忽略（区域由账户自动识别，无需传入）",
+        "us_limit": "仅限美股账户：每页数量（默认 20）。港股/沪深/新加坡账户忽略（区域由账户自动识别，无需传入）"
       }
     },
     "cancel_order": {

--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -171,7 +171,7 @@
     },
     "order_detail": {
       "title": "委托详情",
-      "description": "查询单个委托详情，返回 {order_id, symbol, status, side, order_type, quantity, price, executed_quantity, executed_price, submitted_at, time_in_force, msg}",
+      "description": "查询单个委托详情，返回 {order_id, symbol, status, side, order_type, quantity, price, executed_quantity, executed_price, submitted_at, time_in_force, msg}。美股账户查询会得到美股专属变体：委托嵌套在 `order` 字段下而非根级。区域由账户自动识别",
       "properties": {
         "order_id": "委托单号"
       }

--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -406,14 +406,14 @@
     },
     "company": {
       "title": "公司概况",
-      "description": "获取公司概况，返回 name、description、employees、CEO、founded_year、website、exchange、industry、market_cap 等信息。美股账户查询 `.US` 标的时会路由到专属美股接口，返回结构不同（intro、market_cap、top_rank_tags、sharelist、detail_url），与 output_schema 不符；其余组合走通用接口，符合 output_schema",
+      "description": "获取公司概况，返回 name、description、employees、CEO、founded_year、website、exchange、industry、market_cap 等信息。美股账户查询 `.US` 标的会得到美股专属变体（intro、market_cap、top_rank_tags、sharelist、detail_url）。区域由账户自动识别",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
     },
     "consensus": {
       "title": "一致预期",
-      "description": "获取分析师一致预期，返回 items[]{period, revenue_estimate, eps_estimate, net_income_estimate, analyst_count, last_updated}。美股账户查询 `.US` 标的时会路由到专属美股一致预期接口，返回结构不同（ai_summary + 按期间的 details[] 列表），与 output_schema 不符；其余组合走通用接口，符合 output_schema",
+      "description": "获取分析师一致预期，返回 items[]{period, revenue_estimate, eps_estimate, net_income_estimate, analyst_count, last_updated}。美股账户查询 `.US` 标的会得到美股专属变体（ai_summary + 按期间的 details[] 列表，替代 items[]）。区域由账户自动识别",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
@@ -448,7 +448,7 @@
     },
     "dividend": {
       "title": "派息历史",
-      "description": "获取证券的派息历史，返回 items[]{ex_date（除权日）, pay_date（派发日）, record_date, dividend_type, amount, currency, status}。美股账户查询 `.US` 标的时会按 ETF/个股路由到对应的专属美股派息接口，返回结构不同，与 output_schema 不符（dividend_yield/dividend_yield_ttm 是百分比数值，例如 0.34 代表 0.34%，不是 0-1 的小数）；其余组合走通用接口，符合 output_schema",
+      "description": "获取证券的派息历史，返回 items[]{ex_date（除权日）, pay_date（派发日）, record_date, dividend_type, amount, currency, status}。美股账户查询 `.US` 标的会按 ETF/个股得到美股专属变体（dividend_yield/dividend_yield_ttm 是百分比数值，例如 0.34 代表 0.34%，不是 0-1 的小数）。区域由账户自动识别",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }
@@ -996,7 +996,7 @@
     },
     "valuation": {
       "title": "估值",
-      "description": "获取估值概览及同业对比，返回 metrics.pe/pb/ps/dividend_yield{current, industry_avg, 5yr_avg, percentile} 及同业对比列表。美股账户查询 `.US` 标的时会路由到专属美股估值接口，返回结构不同（ai_summary + 字段不同的 metrics.pe），与 output_schema 不符；其余组合走通用接口，符合 output_schema",
+      "description": "获取估值概览及同业对比，返回 metrics.pe/pb/ps/dividend_yield{current, industry_avg, 5yr_avg, percentile} 及同业对比列表。美股账户查询 `.US` 标的会得到美股专属变体（ai_summary + 字段不同的 metrics.pe）。区域由账户自动识别",
       "properties": {
         "symbol": "证券代码，例如 `\"700.HK\"`"
       }

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../tools.schema.json",
-  "server_instructions": "長橋 MCP 服務 —— 提供市場數據、交易與金融分析工具。委託執行需要兩步確認：submit_order、cancel_order、replace_order 以及全部網格寫操作（grid_submit、grid_replace、grid_cancel、grid_suspend、grid_restart）在未回填確認碼時均為 DRY RUN（試執行），並會返回一個一次性 confirmation_code。請務必先不帶 execute 呼叫一次，把預覽展示給用戶，只有在用戶明確確認之後，才可再次呼叫並把該確認碼傳入 execute。",
+  "server_instructions": "長橋 MCP 服務 —— 提供市場數據、交易與金融分析工具。委託執行需要兩步確認：submit_order、cancel_order、replace_order 以及全部網格寫操作（grid_submit、grid_replace、grid_cancel、grid_suspend、grid_restart）在未回填確認碼時均為 DRY RUN（試執行），並會返回一個一次性 confirmation_code。請務必先不帶 execute 呼叫一次，把預覽展示給用戶，只有在用戶明確確認之後，才可再次呼叫並把該確認碼傳入 execute。 調用失敗時，工具會在結果內容裡返回帶 error_code 和 recoverable 欄位的 JSON 信封：reauth（重新鑑權後重試）、backoff（等待後重試）、fix_params（修正參數後重試）、none（不要重試，告知用戶）。",
   "tools": {
     "create_watchlist_group": {
       "title": "新建自選分組",

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -165,8 +165,8 @@
         "symbol": "按證券篩選（可選）",
         "start_at": "起始時間（RFC3339 時間格式）",
         "end_at": "結束時間（RFC3339 時間格式）",
-        "us_page": "僅限美股賬戶：頁碼（預設 1）",
-        "us_limit": "僅限美股賬戶：每頁數量（預設 20）"
+        "us_page": "僅限美股賬戶：頁碼（預設 1）。港股/滬深/新加坡賬戶忽略（區域由賬戶自動識別，無需傳入）",
+        "us_limit": "僅限美股賬戶：每頁數量（預設 20）。港股/滬深/新加坡賬戶忽略（區域由賬戶自動識別，無需傳入）"
       }
     },
     "order_detail": {
@@ -189,9 +189,9 @@
       "description": "查詢當日委託，返回 orders[]{order_id, symbol, side, order_type, status, quantity, price, submitted_at, executed_quantity, executed_price}。僅限美股賬戶：us_action（Buy/Sell）、us_page、us_limit 通過獨立的美股委託接口篩選/分頁",
       "properties": {
         "symbol": "按證券篩選，例如 `\"700.HK\"`，省略則返回當日全部委託",
-        "us_action": "僅限美股賬戶：按方向篩選，`\"Buy\"` 或 `\"Sell\"`，留空表示全部",
-        "us_page": "僅限美股賬戶：頁碼（默認 1）",
-        "us_limit": "僅限美股賬戶：每頁數量（默認 20）"
+        "us_action": "僅限美股賬戶：按方向篩選，`\"Buy\"` 或 `\"Sell\"`，留空表示全部。港股/滬深/新加坡賬戶忽略（區域由賬戶自動識別，無需傳入）",
+        "us_page": "僅限美股賬戶：頁碼（默認 1）。港股/滬深/新加坡賬戶忽略（區域由賬戶自動識別，無需傳入）",
+        "us_limit": "僅限美股賬戶：每頁數量（默認 20）。港股/滬深/新加坡賬戶忽略（區域由賬戶自動識別，無需傳入）"
       }
     },
     "cancel_order": {

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -171,7 +171,7 @@
     },
     "order_detail": {
       "title": "委託詳情",
-      "description": "查詢單個委託詳情，返回 {order_id, symbol, status, side, order_type, quantity, price, executed_quantity, executed_price, submitted_at, time_in_force, msg}",
+      "description": "查詢單個委託詳情，返回 {order_id, symbol, status, side, order_type, quantity, price, executed_quantity, executed_price, submitted_at, time_in_force, msg}。美股賬戶查詢會得到美股專屬變體：委託嵌套在 `order` 欄位下而非根級。區域由賬戶自動識別",
       "properties": {
         "order_id": "委託單號"
       }

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -406,14 +406,14 @@
     },
     "company": {
       "title": "公司概況",
-      "description": "獲取公司概況，返回 name、description、employees、CEO、founded_year、website、exchange、industry、market_cap 等信息。美股賬戶查詢 `.US` 標的時會路由到專屬美股接口，返回結構不同（intro、market_cap、top_rank_tags、sharelist、detail_url），與 output_schema 不符；其餘組合走通用接口，符合 output_schema",
+      "description": "獲取公司概況，返回 name、description、employees、CEO、founded_year、website、exchange、industry、market_cap 等信息。美股賬戶查詢 `.US` 標的會得到美股專屬變體（intro、market_cap、top_rank_tags、sharelist、detail_url）。區域由賬戶自動識別",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
     },
     "consensus": {
       "title": "一致預期",
-      "description": "獲取分析師一致預期，返回 items[]{period, revenue_estimate, eps_estimate, net_income_estimate, analyst_count, last_updated}。美股賬戶查詢 `.US` 標的時會路由到專屬美股一致預期接口，返回結構不同（ai_summary + 按期間的 details[] 列表），與 output_schema 不符；其餘組合走通用接口，符合 output_schema",
+      "description": "獲取分析師一致預期，返回 items[]{period, revenue_estimate, eps_estimate, net_income_estimate, analyst_count, last_updated}。美股賬戶查詢 `.US` 標的會得到美股專屬變體（ai_summary + 按期間的 details[] 列表，替代 items[]）。區域由賬戶自動識別",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
@@ -448,7 +448,7 @@
     },
     "dividend": {
       "title": "派息歷史",
-      "description": "獲取證券的派息歷史，返回 items[]{ex_date（除權日）, pay_date（派發日）, record_date, dividend_type, amount, currency, status}。美股賬戶查詢 `.US` 標的時會按 ETF/個股路由到對應的專屬美股派息接口，返回結構不同，與 output_schema 不符（dividend_yield/dividend_yield_ttm 是百分比數值，例如 0.34 代表 0.34%，不是 0-1 的小數）；其餘組合走通用接口，符合 output_schema",
+      "description": "獲取證券的派息歷史，返回 items[]{ex_date（除權日）, pay_date（派發日）, record_date, dividend_type, amount, currency, status}。美股賬戶查詢 `.US` 標的會按 ETF/個股得到美股專屬變體（dividend_yield/dividend_yield_ttm 是百分比數值，例如 0.34 代表 0.34%，不是 0-1 的小數）。區域由賬戶自動識別",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }
@@ -996,7 +996,7 @@
     },
     "valuation": {
       "title": "估值",
-      "description": "獲取估值概覽及同業對比，返回 metrics.pe/pb/ps/dividend_yield{current, industry_avg, 5yr_avg, percentile} 及同業對比列表。美股賬戶查詢 `.US` 標的時會路由到專屬美股估值接口，返回結構不同（ai_summary + 字段不同的 metrics.pe），與 output_schema 不符；其餘組合走通用接口，符合 output_schema",
+      "description": "獲取估值概覽及同業對比，返回 metrics.pe/pb/ps/dividend_yield{current, industry_avg, 5yr_avg, percentile} 及同業對比列表。美股賬戶查詢 `.US` 標的會得到美股專屬變體（ai_summary + 字段不同的 metrics.pe）。區域由賬戶自動識別",
       "properties": {
         "symbol": "證券代碼，例如 `\"700.HK\"`"
       }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2601,7 +2601,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::us_market::FinancialReportResponse>(),
-        description = "Get financial reports (income statement, balance sheet, cash flow). kind: IS/BS/CF/ALL. report_type: af (annual), saf (semi-annual), q1/q2/q3, qf (quarterly full). US accounts querying a .US symbol without kind are routed to a US-specific overview endpoint; passing kind explicitly always uses the generic path."
+        description = "Get financial reports (income statement, balance sheet, cash flow). kind: IS/BS/CF/ALL. report_type: af (annual), saf (semi-annual), q1/q2/q3, qf (quarterly full). US-data-center accounts querying a .US symbol without kind are routed to a US-specific overview endpoint; passing kind explicitly always uses the generic path."
     )]
     async fn financial_report(
         &self,
@@ -2673,7 +2673,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::fundamental::DividendResponse>(),
-        description = "Get dividend history for the symbol. US accounts querying a .US symbol get a differently-shaped response not matching output_schema (dividend_yield_ttm etc. are percent values, e.g. 0.34 means 0.34%); other combinations match output_schema."
+        description = "Get dividend history for the symbol. US-data-center accounts querying a .US symbol get a US-specific variant (e.g. dividend_yield_ttm is a percent value: 0.34 means 0.34%). The region is detected from the account automatically."
     )]
     async fn dividend(
         &self,
@@ -2745,7 +2745,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::fundamental::ConsensusResponse>(),
-        description = "Get financial consensus estimates for upcoming periods. US accounts querying a .US symbol get a differently-shaped response not matching output_schema (ai_summary plus a details[] list per period); other combinations match output_schema."
+        description = "Get financial consensus estimates for upcoming periods. US-data-center accounts querying a .US symbol get a US-specific variant (ai_summary plus a details[] list per period, instead of items[]). The region is detected from the account automatically."
     )]
     async fn consensus(
         &self,
@@ -2769,7 +2769,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::fundamental::ValuationResponse>(),
-        description = "Get valuation overview with peer comparison. US accounts querying a .US symbol get a differently-shaped response not matching output_schema (ai_summary plus a metrics.pe object with different sub-fields); other combos match output_schema."
+        description = "Get valuation overview with peer comparison. US-data-center accounts querying a .US symbol get a US-specific variant (ai_summary plus a metrics.pe object with different sub-fields). The region is detected from the account automatically."
     )]
     async fn valuation(
         &self,
@@ -2865,7 +2865,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::fundamental::CompanyResponse>(),
-        description = "Get company overview. US accounts querying a .US symbol get a differently-shaped response not matching output_schema (intro, market_cap, top_rank_tags, sharelist, detail_url); other combinations match output_schema."
+        description = "Get company overview. US-data-center accounts querying a .US symbol get a US-specific variant (intro, market_cap, top_rank_tags, sharelist, detail_url). The region is detected from the account automatically."
     )]
     async fn company(
         &self,
@@ -4483,7 +4483,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::us_market::FinancialStatementResponse>(),
-        description = "Get financial statements (income statement, balance sheet, or cash flow) for a security. kind: IS/BS/CF/ALL. report: af (annual, default), saf (semi-annual), qf (quarterly full), q1/q2/q3. US accounts querying a .US symbol are routed to a US-specific statement endpoint (same report vocabulary as the generic path); kind=ALL/default fans out to IS+BS+CF and returns {income_statement, balance_sheet, cash_flow} since the backend doesn't support a combined request; all other symbol/account combinations use the generic path."
+        description = "Get financial statements (income statement, balance sheet, or cash flow) for a security. kind: IS/BS/CF/ALL. report: af (annual, default), saf (semi-annual), qf (quarterly full), q1/q2/q3. US-data-center accounts querying a .US symbol are routed to a US-specific statement endpoint (same report vocabulary as the generic path); kind=ALL/default fans out to IS+BS+CF and returns {income_statement, balance_sheet, cash_flow} since the backend doesn't support a combined request; all other symbol/account combinations use the generic path."
     )]
     async fn financial_statement(
         &self,
@@ -5924,6 +5924,32 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    #[test]
+    fn region_branching_fundamental_output_schemas_have_no_required_fields() {
+        // dividend/consensus/valuation/company branch by DC region and return a
+        // US-specific field set (ai_summary, details[], intro, …). Their output
+        // schema must impose no required fields — every field optional and no
+        // `deny_unknown_fields` — so BOTH the generic and the US variant conform.
+        // Otherwise the US structuredContent would violate the declared schema.
+        let tools = crate::tools::list_tools();
+        for name in ["dividend", "consensus", "valuation", "company"] {
+            let tool = tools
+                .iter()
+                .find(|t| t.name == name)
+                .unwrap_or_else(|| panic!("tool `{name}` not found"));
+            let schema = tool
+                .output_schema
+                .as_ref()
+                .unwrap_or_else(|| panic!("tool `{name}` must declare an output_schema"));
+            let required = schema.get("required").and_then(|r| r.as_array());
+            assert!(
+                required.is_none_or(|a| a.is_empty()),
+                "tool `{name}`: output_schema must have no required fields so both the generic \
+                 and US-data-center variants conform, got required={required:?}"
+            );
         }
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2399,7 +2399,7 @@ impl Longbridge {
         title = "Order Detail",
         annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::OrderDetailResponse>(),
-        description = "Get detailed information about a specific order. Returns {order_id, symbol, status, side, order_type, quantity, price, executed_quantity, executed_price, submitted_at, time_in_force, msg}."
+        description = "Get detailed information about a specific order. Returns {order_id, symbol, status, side, order_type, quantity, price, executed_quantity, executed_price, submitted_at, time_in_force, msg}. US-data-center accounts get a US-specific variant with the order nested under `order` instead of at the root. The region is detected from the account automatically."
     )]
     async fn order_detail(
         &self,
@@ -3333,7 +3333,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::us_market::PortfolioRealizedPlResponse>(),
-        description = "Get realized P&L for a US account, broken down by category (stock/option/crypto) and period. US accounts only; errors with DcRegionRestricted for HK/CN/SG accounts."
+        description = "Get realized P&L for a US account, broken down by category (stock/option/crypto) and period. US-data-center accounts only; errors with DcRegionRestricted for HK/CN/SG accounts."
     )]
     async fn profit_analysis_realized(
         &self,
@@ -4507,7 +4507,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::us_market::FinancialReportKeyMetricsResponse>(),
-        description = "Get key financial metrics (fin-keyfactor) for a US symbol. report: af (annual, default), saf, qf, q1/q2/q3. US accounts only; errors with DcRegionRestricted for HK/CN/SG accounts."
+        description = "Get key financial metrics (fin-keyfactor) for a US symbol. report: af (annual, default), saf, qf, q1/q2/q3. US-data-center accounts only; errors with DcRegionRestricted for HK/CN/SG accounts."
     )]
     async fn financial_report_key_metrics(
         &self,
@@ -4531,7 +4531,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::us_market::EtfDocsResponse>(),
-        description = "Get regulatory/prospectus documents (etf-files) for a US ETF. US accounts only; errors with DcRegionRestricted for HK/CN/SG accounts."
+        description = "Get regulatory/prospectus documents (etf-files) for a US ETF. US-data-center accounts only; errors with DcRegionRestricted for HK/CN/SG accounts."
     )]
     async fn etf_docs(
         &self,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1648,7 +1648,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        description = "Get static info for securities. Returns per symbol: symbol, name_cn, name_en, exchange (e.g. NASDAQ), type (e.g. US_Stock), lot_size, listed_date, delisted (bool). US accounts only: .BKKT crypto symbols (e.g. BTCUSD.BKKT) are routed to a separate US crypto overview endpoint; .HAS/.OSL crypto symbols are unaffected."
+        description = "Get static info for securities. Returns per symbol: symbol, name_cn, name_en, exchange (e.g. NASDAQ), type (e.g. US_Stock), lot_size, listed_date, delisted (bool). US-data-center accounts only: .BKKT crypto symbols (e.g. BTCUSD.BKKT) are routed to a separate US crypto overview endpoint; .HAS/.OSL crypto symbols are unaffected."
     )]
     async fn static_info(
         &self,
@@ -2321,7 +2321,7 @@ impl Longbridge {
         title = "Stock Positions",
         annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::StockPositionsResponse>(),
-        description = "Get current stock positions across all channels. Returns list[].stock_info[]{symbol, symbol_name, quantity, available_quantity, currency, cost_price, market}. US accounts only: an additional us_asset_overview field {cash_list, stock_list, option_list, crypto_list, cash_buy_power, overnight_buy_power} is included alongside the existing data."
+        description = "Get current stock positions across all channels. Returns list[].stock_info[]{symbol, symbol_name, quantity, available_quantity, currency, cost_price, market}. US-data-center accounts only: an additional us_asset_overview field {cash_list, stock_list, option_list, crypto_list, cash_buy_power, overnight_buy_power} is included alongside the existing data."
     )]
     async fn stock_positions(
         &self,
@@ -2380,7 +2380,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        description = "Get orders placed today. Returns orders[]{order_id, symbol, side, order_type, status, quantity, price, submitted_at, executed_quantity, executed_price}. Pass symbol to filter. US accounts only: us_action (Buy/Sell), us_page, us_limit filter/paginate via a separate US order endpoint."
+        description = "Get orders placed today. Returns orders[]{order_id, symbol, side, order_type, status, quantity, price, submitted_at, executed_quantity, executed_price}. Pass symbol to filter. US-data-center accounts only: us_action (Buy/Sell), us_page, us_limit filter/paginate via a separate US order endpoint."
     )]
     async fn today_orders(
         &self,
@@ -2468,7 +2468,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        description = "Get historical orders between dates (excludes today). Returns orders[]{order_id, symbol, side, status, quantity, price, submitted_at}. start_at/end_at in RFC3339. US accounts only: us_page, us_limit paginate via a separate US order endpoint (default page size 20 — pass us_page to see more than the first page)."
+        description = "Get historical orders between dates (excludes today). Returns orders[]{order_id, symbol, side, status, quantity, price, submitted_at}. start_at/end_at in RFC3339. US-data-center accounts only: us_page, us_limit paginate via a separate US order endpoint (default page size 20 — pass us_page to see more than the first page)."
     )]
     async fn history_orders(
         &self,
@@ -5891,6 +5891,40 @@ mod tests {
                 .all(|n| !super::AP_ONLY_TOOLS.contains(n)),
             "US_ONLY_TOOLS and AP_ONLY_TOOLS must be disjoint"
         );
+    }
+
+    #[test]
+    fn region_scoped_us_params_are_optional() {
+        // A `us_*` input is region-scoped (meaningful only for US-data-center
+        // accounts). It must never be `required` — an HK/CN/SG session cannot
+        // satisfy it, and the region is inferred from the account rather than
+        // passed by the caller. Guards against a future region-scoped param
+        // being added as required.
+        for tool in crate::tools::list_tools() {
+            let required: std::collections::HashSet<&str> = tool
+                .input_schema
+                .get("required")
+                .and_then(|r| r.as_array())
+                .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+                .unwrap_or_default();
+            let Some(props) = tool
+                .input_schema
+                .get("properties")
+                .and_then(|p| p.as_object())
+            else {
+                continue;
+            };
+            for name in props.keys() {
+                if name.starts_with("us_") {
+                    assert!(
+                        !required.contains(name.as_str()),
+                        "tool `{}`: region-scoped param `{}` must be optional, not required",
+                        tool.name,
+                        name
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/src/tools/trade.rs
+++ b/src/tools/trade.rs
@@ -28,11 +28,15 @@ pub struct AccountBalanceParam {
 pub struct TodayOrdersParam {
     /// Filter by symbol, e.g. "700.HK". Omit to return all today's orders.
     pub symbol: Option<String>,
-    /// US accounts only: filter by side, "Buy" or "Sell". Omit for all.
+    /// US-data-center accounts only: filter by side, "Buy" or "Sell". Omit for
+    /// all. Ignored for HK/CN/SG accounts (the region is inferred from the
+    /// account — do not pass it).
     pub us_action: Option<String>,
-    /// US accounts only: page number (default 1).
+    /// US-data-center accounts only: page number (default 1). Ignored for
+    /// HK/CN/SG accounts.
     pub us_page: Option<i32>,
-    /// US accounts only: page size (default 20).
+    /// US-data-center accounts only: page size (default 20). Ignored for
+    /// HK/CN/SG accounts.
     pub us_limit: Option<i32>,
 }
 
@@ -159,9 +163,11 @@ pub struct HistoryOrdersParam {
     pub start_at: String,
     /// End time (RFC3339)
     pub end_at: String,
-    /// US accounts only, history_orders tool only: page number (default 1).
+    /// US-data-center accounts only: page number (default 1). Ignored for
+    /// HK/CN/SG accounts (the region is inferred from the account — do not pass it).
     pub us_page: Option<i32>,
-    /// US accounts only, history_orders tool only: page size (default 20).
+    /// US-data-center accounts only: page size (default 20). Ignored for
+    /// HK/CN/SG accounts.
     pub us_limit: Option<i32>,
 }
 


### PR DESCRIPTION
## Background

Several tools share one name but branch internally on the account's **DC region** and normalize the two upstreams, so the AI should never need to know or pass a region. The wording of their descriptions and params was inconsistent, and some descriptions were stale/misleading.

Two categories, handled oppositely from **region-exclusive** tools (`US_ONLY`/`AP_ONLY`, which are hidden per region): these keep region **invisible** to the AI.

## Changes

### Orders / positions branch tools
- Region-scoped `us_*` params (only ones in the codebase: `today_orders`, `history_orders`) reworded to `US-data-center accounts only … Ignored for HK/CN/SG accounts (the region is inferred from the account — do not pass it)`.
- Unified `US accounts only:` → `US-data-center accounts only:` on the 4 branch tools.
- Regression test `region_scoped_us_params_are_optional`: every `us_*` input must be optional.

### Fundamental region-routing tools (`dividend`, `consensus`, `valuation`, `company`, `financial_report`, `financial_statement`)
- These route `.US` symbols to a US-specific interface. Their output structs are **already a conforming union** (every field optional, US-only fields modeled, no `deny_unknown_fields`), so the US `structuredContent` already matches `output_schema` — but 4 descriptions still claimed the US shape *"does not match output_schema"*. **Corrected those stale/false claims** to describe the US variant's field set accurately and note the region is auto-detected.
- Unified `US accounts querying` → `US-data-center accounts querying` across all 6.
- Guard test `region_branching_fundamental_output_schemas_have_no_required_fields`: locks that these schemas impose no required fields, so both the generic and US variants conform (no struct change was needed — B was already implemented).

### Locales (`/mcp/tools.json` manifest; live MCP `initialize`/`tools/list` stay English)
- Synced zh-CN/zh-HK for the `us_*` params and the 4 rewritten fundamental descriptions.
- Synced zh-CN/zh-HK `server_instructions` with the recoverable-envelope convention (`reauth`/`backoff`/`fix_params`/`none`) that was added to the English instructions in #141 but never mirrored.

Docs/annotations + tests only; no runtime behavior change.

## Testing

Full suite **244 passed / 0 failed**, clippy clean, nightly fmt. Both locale JSON files validated.