### PR TITLE
chore(tools): standardize region-account terminology on US/AP accounts

### DIFF
--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -87,7 +87,7 @@
     },
     "profit_analysis_realized": {
       "title": "已实现盈亏分析（美股）",
-      "description": "获取美股账户的已实现盈亏，按类别（股票/期权/加密货币）和周期拆分。仅限美股账户；港股/沪深/新加坡账户调用会返回 DcRegionRestricted 错误",
+      "description": "获取美股账户的已实现盈亏，按类别（股票/期权/加密货币）和周期拆分。仅限美股账户；亚太账户调用会返回 DcRegionRestricted 错误",
       "properties": {
         "currency": "报告货币，例如 `\"USD\"`（默认 `\"USD\"`）。仅限美股账户",
         "category": "按类别筛选：`\"STOCK\"`、`\"OPTION\"`、`\"CRYPTO\"`，留空表示全部"
@@ -165,8 +165,8 @@
         "symbol": "按证券筛选（可选）",
         "start_at": "起始时间（RFC3339 格式）",
         "end_at": "结束时间（RFC3339 格式）",
-        "us_page": "仅限美股账户：页码（默认 1）。港股/沪深/新加坡账户忽略（区域由账户自动识别，无需传入）",
-        "us_limit": "仅限美股账户：每页数量（默认 20）。港股/沪深/新加坡账户忽略（区域由账户自动识别，无需传入）"
+        "us_page": "仅限美股账户：页码（默认 1）。亚太账户忽略（区域由账户自动识别，无需传入）",
+        "us_limit": "仅限美股账户：每页数量（默认 20）。亚太账户忽略（区域由账户自动识别，无需传入）"
       }
     },
     "order_detail": {
@@ -192,9 +192,9 @@
         "symbol": "按证券筛选，例如 `\"700.HK\"`，省略则返回当日全部委托",
         "order_id": "按委托单号筛选：母单单号，或（配合 is_attached=true）止盈/止损附加单单号。美股账户下无效",
         "is_attached": "仅在同时传入 order_id 时有效：表示该 order_id 是止盈/止损附加单单号，返回结果即为该附加单本身。单独使用无效，美股账户下同样无效",
-        "us_action": "仅限美股账户：按方向筛选，`\"Buy\"` 或 `\"Sell\"`，留空表示全部。港股/沪深/新加坡账户忽略（区域由账户自动识别，无需传入）",
-        "us_page": "仅限美股账户：页码（默认 1）。港股/沪深/新加坡账户忽略（区域由账户自动识别，无需传入）",
-        "us_limit": "仅限美股账户：每页数量（默认 20）。港股/沪深/新加坡账户忽略（区域由账户自动识别，无需传入）"
+        "us_action": "仅限美股账户：按方向筛选，`\"Buy\"` 或 `\"Sell\"`，留空表示全部。亚太账户忽略（区域由账户自动识别，无需传入）",
+        "us_page": "仅限美股账户：页码（默认 1）。亚太账户忽略（区域由账户自动识别，无需传入）",
+        "us_limit": "仅限美股账户：每页数量（默认 20）。亚太账户忽略（区域由账户自动识别，无需传入）"
       }
     },
     "cancel_order": {
@@ -490,7 +490,7 @@
     },
     "etf_docs": {
       "title": "ETF文件（美股）",
-      "description": "获取美股ETF的监管/招募说明书文件（etf-files）。仅限美股账户；港股/沪深/新加坡账户调用会返回 DcRegionRestricted 错误",
+      "description": "获取美股ETF的监管/招募说明书文件（etf-files）。仅限美股账户；亚太账户调用会返回 DcRegionRestricted 错误",
       "properties": {
         "symbol": "ETF代码，例如 `\"SPY.US\"`",
         "limit": "最多返回的文件数量，留空返回全部"
@@ -535,7 +535,7 @@
     },
     "financial_report_key_metrics": {
       "title": "关键财务指标（美股）",
-      "description": "获取美股标的的关键财务指标（fin-keyfactor）。report: af（年度，默认）、saf、qf、q1/q2/q3。仅限美股账户；港股/沪深/新加坡账户调用会返回 DcRegionRestricted 错误",
+      "description": "获取美股标的的关键财务指标（fin-keyfactor）。report: af（年度，默认）、saf、qf、q1/q2/q3。仅限美股账户；亚太账户调用会返回 DcRegionRestricted 错误",
       "properties": {
         "symbol": "证券代码，例如 `\"AAPL.US\"`",
         "report": "报告期：`\"annual\"`（默认）或 `\"quarterly\"`"

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -87,7 +87,7 @@
     },
     "profit_analysis_realized": {
       "title": "已實現盈虧分析（美股）",
-      "description": "獲取美股賬戶的已實現盈虧，按類別（股票/期權/加密貨幣）和週期拆分。僅限美股賬戶；港股/滬深/新加坡賬戶調用會返回 DcRegionRestricted 錯誤",
+      "description": "獲取美股賬戶的已實現盈虧，按類別（股票/期權/加密貨幣）和週期拆分。僅限美股賬戶；亞太賬戶調用會返回 DcRegionRestricted 錯誤",
       "properties": {
         "currency": "報告貨幣，例如 `\"USD\"`（默認 `\"USD\"`）。僅限美股賬戶",
         "category": "按類別篩選：`\"STOCK\"`、`\"OPTION\"`、`\"CRYPTO\"`，留空表示全部"
@@ -165,8 +165,8 @@
         "symbol": "按證券篩選（可選）",
         "start_at": "起始時間（RFC3339 時間格式）",
         "end_at": "結束時間（RFC3339 時間格式）",
-        "us_page": "僅限美股賬戶：頁碼（預設 1）。港股/滬深/新加坡賬戶忽略（區域由賬戶自動識別，無需傳入）",
-        "us_limit": "僅限美股賬戶：每頁數量（預設 20）。港股/滬深/新加坡賬戶忽略（區域由賬戶自動識別，無需傳入）"
+        "us_page": "僅限美股賬戶：頁碼（預設 1）。亞太賬戶忽略（區域由賬戶自動識別，無需傳入）",
+        "us_limit": "僅限美股賬戶：每頁數量（預設 20）。亞太賬戶忽略（區域由賬戶自動識別，無需傳入）"
       }
     },
     "order_detail": {
@@ -192,9 +192,9 @@
         "symbol": "按證券篩選，例如 `\"700.HK\"`，省略則返回當日全部委託",
         "order_id": "按委託單號篩選：母單單號，或（配合 is_attached=true）止盈/止損附加單單號。美股賬戶下無效",
         "is_attached": "僅在同時傳入 order_id 時有效：表示該 order_id 是止盈/止損附加單單號，返回結果即為該附加單本身。單獨使用無效，美股賬戶下同樣無效",
-        "us_action": "僅限美股賬戶：按方向篩選，`\"Buy\"` 或 `\"Sell\"`，留空表示全部。港股/滬深/新加坡賬戶忽略（區域由賬戶自動識別，無需傳入）",
-        "us_page": "僅限美股賬戶：頁碼（默認 1）。港股/滬深/新加坡賬戶忽略（區域由賬戶自動識別，無需傳入）",
-        "us_limit": "僅限美股賬戶：每頁數量（默認 20）。港股/滬深/新加坡賬戶忽略（區域由賬戶自動識別，無需傳入）"
+        "us_action": "僅限美股賬戶：按方向篩選，`\"Buy\"` 或 `\"Sell\"`，留空表示全部。亞太賬戶忽略（區域由賬戶自動識別，無需傳入）",
+        "us_page": "僅限美股賬戶：頁碼（默認 1）。亞太賬戶忽略（區域由賬戶自動識別，無需傳入）",
+        "us_limit": "僅限美股賬戶：每頁數量（默認 20）。亞太賬戶忽略（區域由賬戶自動識別，無需傳入）"
       }
     },
     "cancel_order": {
@@ -490,7 +490,7 @@
     },
     "etf_docs": {
       "title": "ETF文件（美股）",
-      "description": "獲取美股ETF的監管/招募說明書文件（etf-files）。僅限美股賬戶；港股/滬深/新加坡賬戶調用會返回 DcRegionRestricted 錯誤",
+      "description": "獲取美股ETF的監管/招募說明書文件（etf-files）。僅限美股賬戶；亞太賬戶調用會返回 DcRegionRestricted 錯誤",
       "properties": {
         "symbol": "ETF代碼，例如 `\"SPY.US\"`",
         "limit": "最多返回的文件數量，留空返回全部"
@@ -535,7 +535,7 @@
     },
     "financial_report_key_metrics": {
       "title": "關鍵財務指標（美股）",
-      "description": "獲取美股標的的關鍵財務指標（fin-keyfactor）。report: af（年度，默認）、saf、qf、q1/q2/q3。僅限美股賬戶；港股/滬深/新加坡賬戶調用會返回 DcRegionRestricted 錯誤",
+      "description": "獲取美股標的的關鍵財務指標（fin-keyfactor）。report: af（年度，默認）、saf、qf、q1/q2/q3。僅限美股賬戶；亞太賬戶調用會返回 DcRegionRestricted 錯誤",
       "properties": {
         "symbol": "證券代碼，例如 `\"AAPL.US\"`",
         "report": "報告期：`\"annual\"`（默認）或 `\"quarterly\"`"

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1648,7 +1648,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        description = "Get static info for securities. Returns per symbol: symbol, name_cn, name_en, exchange (e.g. NASDAQ), type (e.g. US_Stock), lot_size, listed_date, delisted (bool). US-data-center accounts only: .BKKT crypto symbols (e.g. BTCUSD.BKKT) are routed to a separate US crypto overview endpoint; .HAS/.OSL crypto symbols are unaffected."
+        description = "Get static info for securities. Returns per symbol: symbol, name_cn, name_en, exchange (e.g. NASDAQ), type (e.g. US_Stock), lot_size, listed_date, delisted (bool). US accounts only: .BKKT crypto symbols (e.g. BTCUSD.BKKT) are routed to a separate US crypto overview endpoint; .HAS/.OSL crypto symbols are unaffected."
     )]
     async fn static_info(
         &self,
@@ -2321,7 +2321,7 @@ impl Longbridge {
         title = "Stock Positions",
         annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::StockPositionsResponse>(),
-        description = "Get current stock positions across all channels. Returns list[].stock_info[]{symbol, symbol_name, quantity, available_quantity, currency, cost_price, market}. US-data-center accounts only: an additional us_asset_overview field {cash_list, stock_list, option_list, crypto_list, cash_buy_power, overnight_buy_power} is included alongside the existing data."
+        description = "Get current stock positions across all channels. Returns list[].stock_info[]{symbol, symbol_name, quantity, available_quantity, currency, cost_price, market}. US accounts only: an additional us_asset_overview field {cash_list, stock_list, option_list, crypto_list, cash_buy_power, overnight_buy_power} is included alongside the existing data."
     )]
     async fn stock_positions(
         &self,
@@ -2380,7 +2380,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        description = "Get orders placed today. Returns orders[]{order_id, symbol, side, order_type, status, quantity, price, submitted_at, executed_quantity, executed_price, attached_orders[]}, where attached_orders[] holds the order's take-profit/stop-loss legs. Pass symbol to filter by security, or order_id for one order. To fetch an attached leg by its own ID, pass that ID as order_id together with is_attached=true — the leg itself comes back as the order entry. is_attached does nothing without order_id, and neither has any effect for US-data-center accounts, which are served by the US order endpoint. US-data-center accounts only: us_action (Buy/Sell), us_page, us_limit filter/paginate via a separate US order endpoint."
+        description = "Get orders placed today. Returns orders[]{order_id, symbol, side, order_type, status, quantity, price, submitted_at, executed_quantity, executed_price, attached_orders[]}, where attached_orders[] holds the order's take-profit/stop-loss legs. Pass symbol to filter by security, or order_id for one order. To fetch an attached leg by its own ID, pass that ID as order_id together with is_attached=true — the leg itself comes back as the order entry. is_attached does nothing without order_id, and neither has any effect for US accounts, which are served by the US order endpoint. US accounts only: us_action (Buy/Sell), us_page, us_limit filter/paginate via a separate US order endpoint."
     )]
     async fn today_orders(
         &self,
@@ -2399,7 +2399,7 @@ impl Longbridge {
         title = "Order Detail",
         annotations(read_only_hint = true, destructive_hint = false, idempotent_hint = true, open_world_hint = true),
         output_schema = schema_for::<output::OrderDetailResponse>(),
-        description = "Get detailed information about a specific order. Returns {order_id, symbol, status, side, order_type, quantity, price, executed_quantity, executed_price, submitted_at, time_in_force, msg, attached_orders[]}, where attached_orders[] holds the order's take-profit/stop-loss legs with their own order IDs. To look up such a leg by its own ID instead, pass it as order_id with is_attached=true: the response is then that leg, with charge_detail null. US-data-center accounts get a US-specific variant served by the US order endpoint, with the order (and its attached legs) nested under `order`. The region is detected from the account automatically."
+        description = "Get detailed information about a specific order. Returns {order_id, symbol, status, side, order_type, quantity, price, executed_quantity, executed_price, submitted_at, time_in_force, msg, attached_orders[]}, where attached_orders[] holds the order's take-profit/stop-loss legs with their own order IDs. To look up such a leg by its own ID instead, pass it as order_id with is_attached=true: the response is then that leg, with charge_detail null. US accounts get a US-specific variant served by the US order endpoint, with the order (and its attached legs) nested under `order`. The region is detected from the account automatically."
     )]
     async fn order_detail(
         &self,
@@ -2468,7 +2468,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        description = "Get historical orders between dates (excludes today). Returns orders[]{order_id, symbol, side, status, quantity, price, submitted_at}. start_at/end_at in RFC3339. US-data-center accounts only: us_page, us_limit paginate via a separate US order endpoint (default page size 20 — pass us_page to see more than the first page)."
+        description = "Get historical orders between dates (excludes today). Returns orders[]{order_id, symbol, side, status, quantity, price, submitted_at}. start_at/end_at in RFC3339. US accounts only: us_page, us_limit paginate via a separate US order endpoint (default page size 20 — pass us_page to see more than the first page)."
     )]
     async fn history_orders(
         &self,
@@ -2601,7 +2601,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::us_market::FinancialReportResponse>(),
-        description = "Get financial reports (income statement, balance sheet, cash flow). kind: IS/BS/CF/ALL. report_type: af (annual), saf (semi-annual), q1/q2/q3, qf (quarterly full). US-data-center accounts querying a .US symbol without kind are routed to a US-specific overview endpoint; passing kind explicitly always uses the generic path."
+        description = "Get financial reports (income statement, balance sheet, cash flow). kind: IS/BS/CF/ALL. report_type: af (annual), saf (semi-annual), q1/q2/q3, qf (quarterly full). US accounts querying a .US symbol without kind are routed to a US-specific overview endpoint; passing kind explicitly always uses the generic path."
     )]
     async fn financial_report(
         &self,
@@ -2673,7 +2673,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::fundamental::DividendResponse>(),
-        description = "Get dividend history for the symbol. US-data-center accounts querying a .US symbol get a US-specific variant (e.g. dividend_yield_ttm is a percent value: 0.34 means 0.34%). The region is detected from the account automatically."
+        description = "Get dividend history for the symbol. US accounts querying a .US symbol get a US-specific variant (e.g. dividend_yield_ttm is a percent value: 0.34 means 0.34%). The region is detected from the account automatically."
     )]
     async fn dividend(
         &self,
@@ -2745,7 +2745,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::fundamental::ConsensusResponse>(),
-        description = "Get financial consensus estimates for upcoming periods. US-data-center accounts querying a .US symbol get a US-specific variant (ai_summary plus a details[] list per period, instead of items[]). The region is detected from the account automatically."
+        description = "Get financial consensus estimates for upcoming periods. US accounts querying a .US symbol get a US-specific variant (ai_summary plus a details[] list per period, instead of items[]). The region is detected from the account automatically."
     )]
     async fn consensus(
         &self,
@@ -2769,7 +2769,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::fundamental::ValuationResponse>(),
-        description = "Get valuation overview with peer comparison. US-data-center accounts querying a .US symbol get a US-specific variant (ai_summary plus a metrics.pe object with different sub-fields). The region is detected from the account automatically."
+        description = "Get valuation overview with peer comparison. US accounts querying a .US symbol get a US-specific variant (ai_summary plus a metrics.pe object with different sub-fields). The region is detected from the account automatically."
     )]
     async fn valuation(
         &self,
@@ -2865,7 +2865,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::fundamental::CompanyResponse>(),
-        description = "Get company overview. US-data-center accounts querying a .US symbol get a US-specific variant (intro, market_cap, top_rank_tags, sharelist, detail_url). The region is detected from the account automatically."
+        description = "Get company overview. US accounts querying a .US symbol get a US-specific variant (intro, market_cap, top_rank_tags, sharelist, detail_url). The region is detected from the account automatically."
     )]
     async fn company(
         &self,
@@ -3333,7 +3333,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::us_market::PortfolioRealizedPlResponse>(),
-        description = "Get realized P&L for a US account, broken down by category (stock/option/crypto) and period. US-data-center accounts only; errors with DcRegionRestricted for HK/CN/SG accounts."
+        description = "Get realized P&L for a US account, broken down by category (stock/option/crypto) and period. US accounts only; errors with DcRegionRestricted for AP accounts."
     )]
     async fn profit_analysis_realized(
         &self,
@@ -4483,7 +4483,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::us_market::FinancialStatementResponse>(),
-        description = "Get financial statements (income statement, balance sheet, or cash flow) for a security. kind: IS/BS/CF/ALL. report: af (annual, default), saf (semi-annual), qf (quarterly full), q1/q2/q3. US-data-center accounts querying a .US symbol are routed to a US-specific statement endpoint (same report vocabulary as the generic path); kind=ALL/default fans out to IS+BS+CF and returns {income_statement, balance_sheet, cash_flow} since the backend doesn't support a combined request; all other symbol/account combinations use the generic path."
+        description = "Get financial statements (income statement, balance sheet, or cash flow) for a security. kind: IS/BS/CF/ALL. report: af (annual, default), saf (semi-annual), qf (quarterly full), q1/q2/q3. US accounts querying a .US symbol are routed to a US-specific statement endpoint (same report vocabulary as the generic path); kind=ALL/default fans out to IS+BS+CF and returns {income_statement, balance_sheet, cash_flow} since the backend doesn't support a combined request; all other symbol/account combinations use the generic path."
     )]
     async fn financial_statement(
         &self,
@@ -4507,7 +4507,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::us_market::FinancialReportKeyMetricsResponse>(),
-        description = "Get key financial metrics (fin-keyfactor) for a US symbol. report: af (annual, default), saf, qf, q1/q2/q3. US-data-center accounts only; errors with DcRegionRestricted for HK/CN/SG accounts."
+        description = "Get key financial metrics (fin-keyfactor) for a US symbol. report: af (annual, default), saf, qf, q1/q2/q3. US accounts only; errors with DcRegionRestricted for AP accounts."
     )]
     async fn financial_report_key_metrics(
         &self,
@@ -4531,7 +4531,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::us_market::EtfDocsResponse>(),
-        description = "Get regulatory/prospectus documents (etf-files) for a US ETF. US-data-center accounts only; errors with DcRegionRestricted for HK/CN/SG accounts."
+        description = "Get regulatory/prospectus documents (etf-files) for a US ETF. US accounts only; errors with DcRegionRestricted for AP accounts."
     )]
     async fn etf_docs(
         &self,
@@ -5895,8 +5895,7 @@ mod tests {
 
     #[test]
     fn region_scoped_us_params_are_optional() {
-        // A `us_*` input is region-scoped (meaningful only for US-data-center
-        // accounts). It must never be `required` — an HK/CN/SG session cannot
+        // A `us_*` input is region-scoped (meaningful only for US accounts). It must never be `required` — an AP-account session cannot
         // satisfy it, and the region is inferred from the account rather than
         // passed by the caller. Guards against a future region-scoped param
         // being added as required.
@@ -5948,7 +5947,29 @@ mod tests {
             assert!(
                 required.is_none_or(|a| a.is_empty()),
                 "tool `{name}`: output_schema must have no required fields so both the generic \
-                 and US-data-center variants conform, got required={required:?}"
+                 and US variants conform, got required={required:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn region_account_terminology_is_standardized() {
+        // Region-account terminology is standardized on "US accounts" / "AP
+        // accounts". The earlier mixed forms ("US-data-center accounts",
+        // "HK/CN/SG accounts") must not reappear in any tool description.
+        // (A bare market list like "US/HK/CN/SG" is fine — only the
+        // *-accounts* forms are checked.)
+        for tool in crate::tools::list_tools() {
+            let desc = tool.description.as_deref().unwrap_or_default();
+            assert!(
+                !desc.contains("US-data-center accounts"),
+                "tool `{}`: use 'US accounts', not 'US-data-center accounts'",
+                tool.name
+            );
+            assert!(
+                !desc.contains("HK/CN/SG accounts"),
+                "tool `{}`: use 'AP accounts', not 'HK/CN/SG accounts'",
+                tool.name
             );
         }
     }

--- a/src/tools/trade.rs
+++ b/src/tools/trade.rs
@@ -39,22 +39,22 @@ pub struct TodayOrdersParam {
     pub symbol: Option<String>,
     /// Filter by order ID: a parent order ID, or (with is_attached=true) the ID
     /// of an attached take-profit / stop-loss leg. Has no effect for
-    /// US-data-center accounts, which are served by the US order endpoint.
+    /// US accounts, which are served by the US order endpoint.
     pub order_id: Option<String>,
     /// Only meaningful together with order_id: it says that order_id is the ID
     /// of an attached take-profit / stop-loss leg, and the response then
     /// carries that leg itself as an order entry. On its own it does nothing,
-    /// and it has no effect for US-data-center accounts either.
+    /// and it has no effect for US accounts either.
     pub is_attached: Option<bool>,
-    /// US-data-center accounts only: filter by side, "Buy" or "Sell". Omit for
-    /// all. Ignored for HK/CN/SG accounts (the region is inferred from the
+    /// US accounts only: filter by side, "Buy" or "Sell". Omit for
+    /// all. Ignored for AP accounts (the region is inferred from the
     /// account — do not pass it).
     pub us_action: Option<String>,
-    /// US-data-center accounts only: page number (default 1). Ignored for
-    /// HK/CN/SG accounts.
+    /// US accounts only: page number (default 1). Ignored for
+    /// AP accounts.
     pub us_page: Option<i32>,
-    /// US-data-center accounts only: page size (default 20). Ignored for
-    /// HK/CN/SG accounts.
+    /// US accounts only: page size (default 20). Ignored for
+    /// AP accounts.
     pub us_limit: Option<i32>,
 }
 
@@ -273,11 +273,11 @@ pub struct HistoryOrdersParam {
     pub start_at: String,
     /// End time (RFC3339)
     pub end_at: String,
-    /// US-data-center accounts only: page number (default 1). Ignored for
-    /// HK/CN/SG accounts (the region is inferred from the account — do not pass it).
+    /// US accounts only: page number (default 1). Ignored for
+    /// AP accounts (the region is inferred from the account — do not pass it).
     pub us_page: Option<i32>,
-    /// US-data-center accounts only: page size (default 20). Ignored for
-    /// HK/CN/SG accounts.
+    /// US accounts only: page size (default 20). Ignored for
+    /// AP accounts.
     pub us_limit: Option<i32>,
 }
 


### PR DESCRIPTION
## Background

Region-account terminology across tool descriptions/params was mixed: `US accounts`, `US-data-center accounts`, `HK/CN/SG accounts`, and `AP accounts` all appeared. `DcRegion` is binary (`Us`/`Ap`), so the account-facing wording should use the two region names consistently.

## Changes

- `US-data-center accounts` → **`US accounts`**
- `HK/CN/SG accounts` → **`AP accounts`** (zh-CN `港股/沪深/新加坡账户` → `亚太账户`; zh-HK → `亞太賬戶`)
- Left untouched (not account terminology): the data-center *mechanism* comment (`US-data-center tokens`, about gateway pinning) and bare market lists (`US/HK/CN/SG` in the industry-ranking description).
- Guard test `region_account_terminology_is_standardized` asserts no tool description reintroduces `US-data-center accounts` or `HK/CN/SG accounts`.

Docs/comments + test + locale only; no runtime behavior change.

## Testing

Full suite **253 passed / 0 failed**, clippy clean, nightly fmt. Locale JSON validated.