### PR TITLE
feat(endpoints): pin upstream endpoints, add --canary, environment-aware scopes

### DIFF
--- a/LAUNCHGUIDE.md
+++ b/LAUNCHGUIDE.md
@@ -11,10 +11,7 @@ The server is hosted at `https://mcp.longbridge.com` (streamable-http), stateles
 ## Setup Requirements
 No environment variables or API keys required for the hosted endpoint. Authentication is handled by an OAuth 2.1 flow that the MCP client kicks off automatically the first time a tool is invoked — the user logs in to their Longbridge account in the browser and grants access. No tokens to copy/paste, no secrets to configure.
 
-For **self-hosting** (optional):
-- `LONGBRIDGE_HTTP_URL` (optional, default `https://openapi.longbridge.com`): Longbridge OpenAPI base URL — used for OAuth metadata discovery.
-- `LONGBRIDGE_QUOTE_WS_URL` (optional, default `wss://openapi-quote.longbridge.com/v2`): quote WebSocket endpoint.
-- `LONGBRIDGE_TRADE_WS_URL` (optional, default `wss://openapi-trade.longbridge.com/v2`): trade WebSocket endpoint.
+For **self-hosting**: no environment variables are needed. Upstream endpoints are fixed in the binary — `https://openapi.longbridge.com` plus the `openapi-quote` / `openapi-trade` WebSocket endpoints — and cannot be overridden by environment variables. The `--canary` flag switches them to Longbridge's canary environment (`*.longbridge.xyz`), which is internal and not usable with production credentials.
 
 ## Category
 Finance

--- a/README.md
+++ b/README.md
@@ -137,17 +137,25 @@ Config lives at `~/.longbridge/mcp/config.json` (override the directory with `LO
 | Log directory | `log_dir` | `--log-dir` | *(stderr)* | Directory for rolling log files |
 | TLS certificate | `tls_cert` | `--tls-cert` | *(none)* | PEM certificate file for HTTPS |
 | TLS private key | `tls_key` | `--tls-key` | *(none)* | PEM private key file for HTTPS |
+| Canary upstream | `canary` | `--canary` | `false` | Talk to the Longbridge canary environment (`*.longbridge.xyz`) instead of production. `--canary=false` forces production even when the config file enables it |
 
-Advanced environment variables — most deployments never touch these; they exist for non-production Longbridge environments and SDK debugging.
+**Upstream endpoints** are fixed by the mode, not by the environment:
+
+| | Production (default) | Canary (`--canary`) |
+|---|---|---|
+| OpenAPI | `https://openapi.longbridge.com` | `https://openapi.longbridge.xyz` |
+| Quote WebSocket | `wss://openapi-quote.longbridge.com/v2` | `wss://openapi-quote.longbridge.xyz/v2` |
+| Trade WebSocket | `wss://openapi-trade.longbridge.com/v2` | `wss://openapi-trade.longbridge.xyz/v2` |
+
+All three are set explicitly on the SDK, so `LONGBRIDGE_HTTP_URL`, `LONGBRIDGE_QUOTE_WS_URL`, `LONGBRIDGE_TRADE_WS_URL`, their `LONGPORT_*` aliases, `LONGBRIDGE_REGION`, and a `.env` file are all inert — as is the SDK's geolocation probe, which means the `openapi.longbridge.cn` access point is never selected. Which data center serves a request is unaffected: that is decided by the `x-dc-region` header the SDK derives from the credential's `us_` / `ap_` prefix.
+
+Advanced environment variables — most deployments never touch these; they exist for SDK debugging and edge/global-entry deployments.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `LONGBRIDGE_MCP_CONFIG_DIR` | `~/.longbridge/mcp` | Config file directory |
-| `LONGBRIDGE_HTTP_URL` | `https://openapi.longbridge.com` | Longbridge API base URL (also used for OAuth metadata) |
 | `LONGBRIDGE_PUBLIC_HOSTS` | *(none)* | Comma-separated hostnames accepted from the edge-injected `X-Host` header; matching requests echo that host in the 401 challenge / RFC 9728 metadata. Unset = `X-Host` ignored |
-| `LONGBRIDGE_GLOBAL_OAUTH_URL` | *(none)* | Authorization-server URL advertised to requests arriving via an allowlisted `X-Host` (global single-domain entry). Unset = fall back to `LONGBRIDGE_HTTP_URL` |
-| `LONGBRIDGE_QUOTE_WS_URL` | `wss://openapi-quote.longbridge.com/v2` | Quote WebSocket endpoint |
-| `LONGBRIDGE_TRADE_WS_URL` | `wss://openapi-trade.longbridge.com/v2` | Trade WebSocket endpoint |
+| `LONGBRIDGE_GLOBAL_OAUTH_URL` | *(none)* | Authorization-server URL advertised to requests arriving via an allowlisted `X-Host` (global single-domain entry). Unset = fall back to the mode's OpenAPI base URL |
 | `LONGBRIDGE_MCP_QUOTE_WS_IDLE_TTL_SECS` | `600` | Idle seconds before a cached quote WebSocket context is evicted |
 | `LONGBRIDGE_MCP_QUOTE_WS_MAX_CONTEXTS` | `1024` | Maximum cached quote WebSocket contexts per server process |
 | `LONGBRIDGE_MCP_LOG_PAYLOADS` | *(unset)* | `1` lifts the payload log caps (see below). Never set this in production |

--- a/README.md
+++ b/README.md
@@ -143,9 +143,12 @@ Config lives at `~/.longbridge/mcp/config.json` (override the directory with `LO
 
 | | Production (default) | Canary (`--canary`) |
 |---|---|---|
-| OpenAPI | `https://openapi.longbridge.com` | `https://openapi.longbridge.xyz` |
-| Quote WebSocket | `wss://openapi-quote.longbridge.com/v2` | `wss://openapi-quote.longbridge.xyz/v2` |
-| Trade WebSocket | `wss://openapi-trade.longbridge.com/v2` | `wss://openapi-trade.longbridge.xyz/v2` |
+| OpenAPI | `https://openapi.longbridge.com` | `https://openapi-global.longbridge.xyz` |
+| Quote WebSocket | `wss://openapi-quote.longbridge.com/v2` | `wss://openapi-global-quote.longbridge.xyz/v2` |
+| Trade WebSocket | `wss://openapi-trade.longbridge.com/v2` | `wss://openapi-global-trade.longbridge.xyz/v2` |
+| OAuth / connect page | `openapi.longbridge.com` / `open.longbridge.com` | `openapi-global.longbridge.xyz` / `open.longbridge.xyz` |
+
+Canary uses the `-global` gateway, not `openapi.longbridge.xyz`: only the former is CloudFront-fronted and performs `x-dc-region` data-center routing, which this server depends on to serve `us_`- and `ap_`-prefixed credentials from one process.
 
 All three are set explicitly on the SDK, so `LONGBRIDGE_HTTP_URL`, `LONGBRIDGE_QUOTE_WS_URL`, `LONGBRIDGE_TRADE_WS_URL`, their `LONGPORT_*` aliases, `LONGBRIDGE_REGION`, and a `.env` file are all inert — as is the SDK's geolocation probe, which means the `openapi.longbridge.cn` access point is never selected. Which data center serves a request is unaffected: that is decided by the `x-dc-region` header the SDK derives from the credential's `us_` / `ap_` prefix.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,7 @@ Longbridge MCP Server is a Rust service with no durable session state that expos
 
 4. Tool handler:
    a. Extracts McpContext (token + Accept-Language) from request
-   b. Creates Config via OAuth::from_token(token)
+   b. Creates Config via OAuth::from_token(token), with the HTTP and both WebSocket URLs pinned from `endpoints`
    c. Reuses or creates a cached QuoteContext, or creates TradeContext / HttpClient as needed
    d. Calls the Longbridge SDK or HTTP API
    e. Serializes the response through TransformSerializer
@@ -59,6 +59,7 @@ src/
 ├── counter.rs              Symbol ↔ counter_id bidirectional conversion
 ├── metrics.rs              Prometheus metrics and /metrics handler
 ├── ws_pool.rs              Cached QuoteContext pool (idle TTL, capacity eviction)
+├── endpoints.rs            Upstream endpoint selection (production / canary)
 │
 ├── auth/
 │   ├── mod.rs              Router composition, AppState, MCP service wiring
@@ -239,14 +240,14 @@ Every tool call is wrapped with `measured_tool_call()` which records timing and 
 
 ## Configuration
 
-The server reads configuration from CLI arguments (highest priority), a JSON config file (`~/.longbridge/mcp/config.json`), and environment variables. Key settings:
+The server reads configuration from CLI arguments (highest priority), a JSON config file (`~/.longbridge/mcp/config.json`), and environment variables. Upstream endpoints are the exception: they are fixed at startup by the `canary` setting and set explicitly on the SDK, so no environment variable influences them and the SDK never geolocates an access point (`geotest.lbkrs.com` is not probed and `openapi.longbridge.cn` is never selected). Key settings:
 
 | Setting | Purpose |
 |---------|---------|
 | `bind` | Listen address (default: `127.0.0.1:8000`) |
 | `base_url` | Public URL for OAuth metadata (**required for public deployments**) |
 | `tls_cert` / `tls_key` | Enable HTTPS with PEM certificate and key |
-| `LONGBRIDGE_HTTP_URL` | Override Longbridge API endpoint (env var) |
+| `canary` | Talk to the Longbridge canary environment (`*.longbridge.xyz`) instead of production (CLI flag `--canary`) |
 | `LONGBRIDGE_MCP_QUOTE_WS_IDLE_TTL_SECS` | Idle TTL for cached quote WebSocket contexts (default: 600) |
 | `LONGBRIDGE_MCP_QUOTE_WS_MAX_CONTEXTS` | Maximum cached quote WebSocket contexts per process (default: 1024) |
 
@@ -296,6 +297,12 @@ trace or exceed the trace-chain limit. ALB then returns HTTP 463 before the
 request reaches the OpenAPI application. `collect_headers` therefore treats
 `ALICLOUD-ALB-TRACE` as hop-specific and removes it at the MCP-to-OpenAPI
 boundary.
+
+Since endpoint selection was pinned (see Configuration), the server's upstream
+calls always go to `openapi.longbridge.com` or `openapi.longbridge.xyz`, so the
+second traversal described above no longer originates here. The
+`ALICLOUD-ALB-TRACE` filter is kept regardless: it is a one-line allowlist entry
+and the 463 failure mode would return the moment a CN upstream is reintroduced.
 
 The failure mode was verified against
 `openapi.longbridge.cn/v1/quote/market-status`: changing only an

--- a/server.json
+++ b/server.json
@@ -52,26 +52,14 @@
           "description": "Externally reachable URL of the server. Required for public deployments; returned via OAuth protected resource metadata.",
           "isRequired": false,
           "default": "http://localhost:8000"
-        }
-      ],
-      "environmentVariables": [
-        {
-          "name": "LONGBRIDGE_HTTP_URL",
-          "description": "Longbridge OpenAPI base URL. Used for OAuth metadata discovery.",
-          "isRequired": false,
-          "default": "https://openapi.longbridge.com"
         },
         {
-          "name": "LONGBRIDGE_QUOTE_WS_URL",
-          "description": "Quote WebSocket endpoint used by the embedded Longbridge SDK.",
+          "type": "named",
+          "name": "--canary",
+          "description": "Talk to Longbridge's canary environment (*.longbridge.xyz) instead of production. Longbridge-internal; not usable with production credentials.",
           "isRequired": false,
-          "default": "wss://openapi-quote.longbridge.com/v2"
-        },
-        {
-          "name": "LONGBRIDGE_TRADE_WS_URL",
-          "description": "Trade WebSocket endpoint used by the embedded Longbridge SDK.",
-          "isRequired": false,
-          "default": "wss://openapi-trade.longbridge.com/v2"
+          "choices": ["true", "false"],
+          "default": "false"
         }
       ]
     }

--- a/src/auth/metadata.rs
+++ b/src/auth/metadata.rs
@@ -7,19 +7,15 @@ use serde::Serialize;
 
 use crate::auth::AppState;
 
-fn longbridge_oauth_url() -> String {
-    std::env::var("LONGBRIDGE_HTTP_URL")
-        .unwrap_or_else(|_| "https://openapi.longbridge.com".to_string())
-}
-
 /// Authorization-server URL advertised to clients that reached us through the
 /// global single-domain entry (allowlisted `X-Host`, see [`public_hosts`]).
-/// Unset/empty = such requests keep advertising [`longbridge_oauth_url`].
+/// Unset/empty = such requests keep advertising the running environment's OAuth
+/// base URL (see [`crate::endpoints`]).
 ///
-/// Deliberately separate from `LONGBRIDGE_HTTP_URL`: that variable is also the
-/// longbridge SDK upstream base and the `/agent` reverse-auth base, so pointing
-/// it at the global edge domain would reroute this server's own upstream calls
-/// through the public edge.
+/// Deliberately kept out of [`crate::endpoints`]: this is the public edge
+/// domain, whereas the environment's OAuth base is also this server's own
+/// upstream, so conflating them would reroute our upstream calls through the
+/// public edge.
 fn global_oauth_url() -> Option<String> {
     std::env::var("LONGBRIDGE_GLOBAL_OAUTH_URL")
         .ok()
@@ -146,7 +142,7 @@ const V2_SCOPES_SUPPORTED: &[&str] = &["4", "6", "10"];
 /// Picks the authorization server to advertise: requests that came through the
 /// global single-domain entry get [`global_oauth_url`] (when configured) so the
 /// whole OAuth bootstrap stays on the global domains; everything else keeps the
-/// per-DC [`longbridge_oauth_url`].
+/// running environment's OAuth base URL.
 pub(crate) fn select_authorization_server(
     via_global_entry: bool,
     global: Option<String>,
@@ -207,7 +203,11 @@ pub async fn protected_resource_metadata_v2(
 
 /// Longbridge OAuth upstream selected for this public entry point.
 pub(crate) fn oauth_upstream_url(via_global_entry: bool) -> String {
-    select_authorization_server(via_global_entry, global_oauth_url(), longbridge_oauth_url())
+    select_authorization_server(
+        via_global_entry,
+        global_oauth_url(),
+        crate::endpoints::oauth_url(),
+    )
 }
 
 /// RFC 8414 metadata for the minimal OAuth facade hosted by this MCP server.
@@ -424,7 +424,11 @@ mod tests {
     #[test]
     fn authorization_server_selection_matrix() {
         let global = || Some("https://openapi-global.longbridge.xyz".to_string());
-        let fallback = || "https://openapi.longbridge.xyz".to_string();
+        let fallback = || {
+            crate::endpoints::Environment::Canary
+                .oauth_url()
+                .to_string()
+        };
 
         // Global entry + configured → advertise the global AS.
         assert_eq!(

--- a/src/auth/metadata.rs
+++ b/src/auth/metadata.rs
@@ -6,6 +6,7 @@ use axum::response::Json;
 use serde::Serialize;
 
 use crate::auth::AppState;
+use crate::endpoints::Scope;
 
 /// Authorization-server URL advertised to clients that reached us through the
 /// global single-domain entry (allowlisted `X-Host`, see [`public_hosts`]).
@@ -126,18 +127,11 @@ pub(crate) struct ProtectedResourceMetadata {
     scopes_supported: Vec<String>,
 }
 
-/// OAuth scope ids advertised by the Longbridge authorization server.
-///
-/// - 4: Watchlist management, including creating, updating, and deleting user
-///   watchlists.
-/// - 6: Account assets and cash details, including fund/stock positions, cash
-///   balances, and cash-flow history for portfolio overview and reconciliation.
-/// - 10: Trade order lookup, covering read-only order lifecycle and execution
-///   reports, plus pre-order buying-power estimates.
-/// - 11: Trade execution, including submit/replace/cancel orders and recurring
-///   investment operations.
-const SCOPES_SUPPORTED: &[&str] = &["4", "6", "10", "11"];
-const V2_SCOPES_SUPPORTED: &[&str] = &["4", "6", "10"];
+/// OAuth scopes advertised by this server. The concepts live in
+/// [`crate::endpoints::Scope`]; the numeric ids the authorization server
+/// expects are environment-specific and resolved there.
+const SCOPES_SUPPORTED: &[Scope] = crate::endpoints::SCOPES;
+const V2_SCOPES_SUPPORTED: &[Scope] = crate::endpoints::V2_SCOPES;
 
 /// Picks the authorization server to advertise: requests that came through the
 /// global single-domain entry get [`global_oauth_url`] (when configured) so the
@@ -157,15 +151,12 @@ pub(crate) fn select_authorization_server(
 fn build_resource_metadata(
     authorization_server: String,
     resource: String,
-    scopes_supported: &[&str],
+    scopes_supported: &[Scope],
 ) -> ProtectedResourceMetadata {
     ProtectedResourceMetadata {
         resource,
         authorization_servers: vec![authorization_server],
-        scopes_supported: scopes_supported
-            .iter()
-            .map(|scope| scope.to_string())
-            .collect(),
+        scopes_supported: crate::endpoints::scope_ids(scopes_supported),
     }
 }
 
@@ -242,7 +233,7 @@ fn build_authorization_server_metadata(
         revocation_endpoint: format!("{issuer}/oauth2/revoke"),
         registration_endpoint: format!("{upstream}/oauth2/register"),
         jwks_uri: format!("{upstream}/.well-known/jwks.json"),
-        scopes_supported: SCOPES_SUPPORTED.iter().map(|s| s.to_string()).collect(),
+        scopes_supported: crate::endpoints::scope_ids(SCOPES_SUPPORTED),
         response_types_supported: vec!["code"],
         grant_types_supported: vec!["authorization_code", "refresh_token"],
         token_endpoint_auth_methods_supported: vec!["none"],

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -30,8 +30,15 @@ fn build_locales_node(sources: &[&[(&str, &str)]]) -> serde_json::Value {
     let mut locales = serde_json::Map::new();
     for src in sources {
         for (code, raw) in src.iter() {
+            // Translations name the production connect page too; retarget it the
+            // same way the live descriptions are (see
+            // `crate::tools::all_tools_full_cached`). A no-op in production.
+            let raw = raw.replace(
+                crate::endpoints::STATIC_CONNECT_PAGE,
+                crate::endpoints::connect_page_url(),
+            );
             let parsed: serde_json::Value =
-                serde_json::from_str(raw).expect("locale file must be valid JSON");
+                serde_json::from_str(&raw).expect("locale file must be valid JSON");
             let entry = locales
                 .entry((*code).to_string())
                 .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
@@ -329,6 +336,49 @@ pub fn create_router(state: Arc<AppState>) -> Router {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+
+    /// Guard: in static tool metadata — descriptions, input schemas, and the
+    /// translations — the connect page may only appear as
+    /// `endpoints::STATIC_CONNECT_PAGE`, optionally with a path suffix such as
+    /// `/done`. That exact prefix is what both retarget passes
+    /// (`tools::all_tools_full_cached` and `build_locales_node`) replace, so any
+    /// other spelling would survive into a canary process and send users to the
+    /// production page — whose code then fails the exchange with an opaque
+    /// `invalid_grant`.
+    #[test]
+    fn static_connect_page_urls_all_start_with_the_placeholder() {
+        let placeholder = crate::endpoints::STATIC_CONNECT_PAGE;
+        let mut sources: Vec<(String, String)> = super::TOOL_LOCALES
+            .iter()
+            .map(|(code, raw)| (format!("locales/{code}/tools.json"), (*raw).to_string()))
+            .collect();
+        for tool in crate::tools::list_tools() {
+            sources.push((
+                format!("tool `{}`", tool.name),
+                format!(
+                    "{} {}",
+                    tool.description.as_deref().unwrap_or_default(),
+                    serde_json::to_string(&tool.input_schema).expect("schema must serialize")
+                ),
+            ));
+        }
+
+        let mut offenders = Vec::new();
+        for (origin, text) in &sources {
+            for (at, _) in text.match_indices("https://open.longbridge") {
+                if !text[at..].starts_with(placeholder) {
+                    let end = (at + placeholder.len() + 8).min(text.len());
+                    offenders.push(format!("{origin}: {}…", &text[at..end]));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "static tool metadata must spell the connect page as `{placeholder}` \
+             so it can be retargeted for canary. Offending occurrences:\n{}",
+            offenders.join("\n")
+        );
+    }
 
     /// Every locale file must cover every registered tool, and every locale
     /// param key must exist in the live JSON Schema. Catches drift when a

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -54,6 +54,33 @@ fn build_locales_node(sources: &[&[(&str, &str)]]) -> serde_json::Value {
     serde_json::Value::Object(locales)
 }
 
+/// Rewrite each scope catalogue entry's `id` to the current environment's id.
+///
+/// `data/scopes.json` records production ids, but the authorization server
+/// numbers the same concepts differently on canary (see
+/// [`crate::endpoints::Scope`]). The `key` field is stable across environments,
+/// so it drives the rewrite. A no-op in production, and entries with no
+/// matching [`crate::endpoints::Scope`] (e.g. the `General` bucket) are left
+/// untouched.
+fn retarget_scope_ids(scopes: &mut serde_json::Value) {
+    let Some(entries) = scopes.as_array_mut() else {
+        return;
+    };
+    let environment = crate::endpoints::current();
+    for entry in entries {
+        let Some(key) = entry.get("key").and_then(|k| k.as_str()) else {
+            continue;
+        };
+        let Some(scope) = crate::endpoints::SCOPES.iter().find(|s| s.key() == key) else {
+            continue;
+        };
+        let id = scope.id(environment).to_string();
+        if let Some(slot) = entry.get_mut("id") {
+            *slot = serde_json::Value::String(id);
+        }
+    }
+}
+
 /// Build the `/mcp/tools.json` (and `/v1/tools.json`, `/v2/tools.json`) body.
 ///
 /// Order: tools → scopes → locales (relies on serde_json's `preserve_order`).
@@ -89,6 +116,7 @@ fn build_tools_json(allow: Option<&std::collections::HashSet<&'static str>>) -> 
                     !tools_arr.is_empty()
                 });
             }
+            retarget_scope_ids(&mut v);
             // Live tool list always wins over any `tools` in scopes.json.
             out.entry(k).or_insert(v);
         }
@@ -125,6 +153,9 @@ async fn scopes_json() -> axum::Json<&'static serde_json::Value> {
                 Ok(serde_json::Value::Object(m)) => m,
                 _ => panic!("scopes.json must be a JSON object"),
             };
+        if let Some(scopes) = out.get_mut("scopes") {
+            retarget_scope_ids(scopes);
+        }
         // Only the scope-specific locale files — no tool translations here.
         out.insert("locales".to_string(), build_locales_node(&[SCOPE_LOCALES]));
         serde_json::Value::Object(out)

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -1,0 +1,348 @@
+//! Longbridge upstream endpoints, fixed once at process start.
+//!
+//! # Why the endpoints are pinned
+//!
+//! The SDK, left to itself, derives its base URLs at request time: it reads
+//! `LONGBRIDGE_HTTP_URL` / `LONGBRIDGE_QUOTE_WS_URL` / `LONGBRIDGE_TRADE_WS_URL`
+//! (plus the `LONGPORT_` aliases, and a `.env` file via `dotenv`), and when
+//! none are set it probes `geotest.lbkrs.com` to choose between the
+//! `*.longbridge.cn` and `*.longbridge.com` access points. The same binary then
+//! talks to different hosts depending on where it runs and what happens to be
+//! in the environment.
+//!
+//! This module removes that ambiguity: the environment is chosen once at
+//! startup ([`init`], from `--canary` / the config file) and every upstream URL
+//! is set explicitly on the SDK afterwards, so no environment variable and no
+//! geolocation probe can influence it.
+//!
+//! # `.cn` is deliberately absent
+//!
+//! Mainland acceleration through `openapi.longbridge.cn` is not used. `.cn` has
+//! no path to the US data center, so a `us_`-prefixed credential sent there
+//! authenticates but fails every market-data request with
+//! `301604 no quote access` — a failure that reads like a missing permission
+//! and is not one. `.com` serves both data centers, so it is the only host.
+//!
+//! Host selection and data-center routing are two independent things: which
+//! data center serves a request is decided by the `x-dc-region` header, which
+//! the SDK derives from the credential's `us_` / `ap_` prefix. That is
+//! unaffected by anything here.
+//!
+//! # Scope
+//!
+//! Everything this server sends upstream, plus the OAuth URLs it advertises and
+//! the connect page it points users at, follows [`current`]. Static tool
+//! metadata cannot: it is made of literals. Those name
+//! [`STATIC_CONNECT_PAGE`] and are retargeted once at startup — which is why
+//! [`init`] must run before the first `tools/list`.
+
+use std::sync::OnceLock;
+
+#[cfg(test)]
+tokio::task_local! {
+    /// Test-only override for the upstream HTTP and OAuth base URL, scoped
+    /// around the code under test so it can be pointed at a local mock server.
+    /// Replaces the process-wide env-var mutation this module exists to
+    /// eliminate; being task-scoped, it needs no cross-test locking.
+    ///
+    /// Use `scope` when the override must survive `.await` points inside the
+    /// code under test, `sync_scope` when only synchronous client construction
+    /// happens inside it. Task-locals are **not** inherited by `tokio::spawn`,
+    /// so a client must be built inside the scope, never in a task spawned
+    /// from it.
+    pub(crate) static UPSTREAM_OVERRIDE: String;
+}
+
+/// The Longbridge environment this process talks to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Environment {
+    /// Production (`*.longbridge.com`).
+    #[default]
+    Production,
+    /// Canary (`*.longbridge.xyz`).
+    Canary,
+}
+
+impl Environment {
+    /// OpenAPI REST base URL.
+    pub fn http_url(self) -> &'static str {
+        match self {
+            Environment::Production => "https://openapi.longbridge.com",
+            Environment::Canary => "https://openapi.longbridge.xyz",
+        }
+    }
+
+    /// Quote WebSocket endpoint.
+    pub fn quote_ws_url(self) -> &'static str {
+        match self {
+            Environment::Production => "wss://openapi-quote.longbridge.com/v2",
+            Environment::Canary => "wss://openapi-quote.longbridge.xyz/v2",
+        }
+    }
+
+    /// Trade WebSocket endpoint.
+    pub fn trade_ws_url(self) -> &'static str {
+        match self {
+            Environment::Production => "wss://openapi-trade.longbridge.com/v2",
+            Environment::Canary => "wss://openapi-trade.longbridge.xyz/v2",
+        }
+    }
+
+    /// OAuth base URL: the authorization server advertised in the RFC 8414 /
+    /// RFC 9728 metadata and the host the `authenticate` tool exchanges codes
+    /// against. Currently the same host as [`Environment::http_url`], kept
+    /// separate so the two can diverge without touching callers.
+    pub fn oauth_url(self) -> &'static str {
+        match self {
+            Environment::Production => "https://openapi.longbridge.com",
+            Environment::Canary => "https://openapi.longbridge.xyz",
+        }
+    }
+
+    /// Page where a user generates a one-time authorization code.
+    pub fn connect_page_url(self) -> &'static str {
+        match self {
+            Environment::Production => STATIC_CONNECT_PAGE,
+            Environment::Canary => "https://open.longbridge.xyz/connect",
+        }
+    }
+
+    /// `redirect_uri` the connect page binds authorization codes to. The token
+    /// exchange must send this exact value; keep it in sync with the web
+    /// `getAgentRedirectUri()` and the CLI.
+    pub fn agent_redirect_uri(self) -> &'static str {
+        match self {
+            Environment::Production => "https://open.longbridge.com/connect/done",
+            Environment::Canary => "https://open.longbridge.xyz/connect/done",
+        }
+    }
+
+    /// Short label for logs and the startup banner.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Environment::Production => "production",
+            Environment::Canary => "canary",
+        }
+    }
+}
+
+/// The connect page baked into static tool metadata: the `#[tool]` description
+/// and `auth_code` schema doc, which need literals, and the locale files.
+///
+/// It is the production URL and doubles as the placeholder those surfaces are
+/// retargeted from when the process runs against canary — the same idiom as
+/// `crate::auth::LANDING_PAGE_URL_PLACEHOLDER`. Retargeting them matters: left
+/// alone, canary would send users to the production page while exchanging the
+/// resulting code against canary, and the `redirect_uri` mismatch surfaces as
+/// an opaque `invalid_grant`.
+pub const STATIC_CONNECT_PAGE: &str = "https://open.longbridge.com/connect";
+
+static ENVIRONMENT: OnceLock<Environment> = OnceLock::new();
+
+/// Fix the environment for this process. Called once during startup, before any
+/// upstream client is built.
+///
+/// # Panics
+///
+/// Panics if called more than once — the endpoints must not change under a
+/// running server.
+pub fn init(environment: Environment) {
+    ENVIRONMENT
+        .set(environment)
+        .expect("endpoints::init called more than once");
+    // Logged here rather than by the caller so stdio mode — which prints no
+    // startup banner — still records which environment it is talking to.
+    tracing::info!(
+        environment = environment.as_str(),
+        http_url = environment.http_url(),
+        quote_ws_url = environment.quote_ws_url(),
+        trade_ws_url = environment.trade_ws_url(),
+        "upstream endpoints fixed"
+    );
+}
+
+/// The environment fixed by [`init`], or [`Environment::Production`] when
+/// nothing set it (unit tests, and any path that skips startup configuration).
+pub fn current() -> Environment {
+    ENVIRONMENT.get().copied().unwrap_or_default()
+}
+
+#[cfg(test)]
+fn override_url() -> Option<String> {
+    UPSTREAM_OVERRIDE.try_with(Clone::clone).ok()
+}
+
+#[cfg(not(test))]
+fn override_url() -> Option<String> {
+    None
+}
+
+/// Resolve a base URL, honoring the test override, without a trailing slash so
+/// callers can append a leading-slash path.
+fn base_url(default: &'static str) -> String {
+    let url = override_url().unwrap_or_else(|| default.to_string());
+    url.trim_end_matches('/').to_string()
+}
+
+/// OpenAPI REST base URL for the current environment.
+pub fn http_url() -> String {
+    base_url(current().http_url())
+}
+
+/// OAuth base URL for the current environment.
+pub fn oauth_url() -> String {
+    base_url(current().oauth_url())
+}
+
+/// Quote WebSocket endpoint for the current environment.
+pub fn quote_ws_url() -> &'static str {
+    current().quote_ws_url()
+}
+
+/// Trade WebSocket endpoint for the current environment.
+pub fn trade_ws_url() -> &'static str {
+    current().trade_ws_url()
+}
+
+/// Connect-page URL for the current environment.
+pub fn connect_page_url() -> &'static str {
+    current().connect_page_url()
+}
+
+/// Agent `redirect_uri` for the current environment.
+pub fn agent_redirect_uri() -> &'static str {
+    current().agent_redirect_uri()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every host is spelled out here so a typo in a TLD fails the build rather
+    /// than silently pointing production at canary or vice versa.
+    #[test]
+    fn endpoint_table() {
+        let cases = [
+            (
+                Environment::Production,
+                "https://openapi.longbridge.com",
+                "wss://openapi-quote.longbridge.com/v2",
+                "wss://openapi-trade.longbridge.com/v2",
+                "https://openapi.longbridge.com",
+                "https://open.longbridge.com/connect",
+                "https://open.longbridge.com/connect/done",
+            ),
+            (
+                Environment::Canary,
+                "https://openapi.longbridge.xyz",
+                "wss://openapi-quote.longbridge.xyz/v2",
+                "wss://openapi-trade.longbridge.xyz/v2",
+                "https://openapi.longbridge.xyz",
+                "https://open.longbridge.xyz/connect",
+                "https://open.longbridge.xyz/connect/done",
+            ),
+        ];
+
+        for (env, http, quote_ws, trade_ws, oauth, connect, redirect) in cases {
+            assert_eq!(env.http_url(), http, "http_url for {env:?}");
+            assert_eq!(env.quote_ws_url(), quote_ws, "quote_ws_url for {env:?}");
+            assert_eq!(env.trade_ws_url(), trade_ws, "trade_ws_url for {env:?}");
+            assert_eq!(env.oauth_url(), oauth, "oauth_url for {env:?}");
+            assert_eq!(
+                env.connect_page_url(),
+                connect,
+                "connect_page_url for {env:?}"
+            );
+            assert_eq!(
+                env.agent_redirect_uri(),
+                redirect,
+                "agent_redirect_uri for {env:?}"
+            );
+        }
+    }
+
+    /// Catches the realistic slip: a `.com` const copy-pasted into the canary
+    /// arm, or vice versa.
+    #[test]
+    fn every_url_matches_its_environment_domain() {
+        for env in [Environment::Production, Environment::Canary] {
+            let expected = match env {
+                Environment::Production => "longbridge.com",
+                Environment::Canary => "longbridge.xyz",
+            };
+            for url in [
+                env.http_url(),
+                env.quote_ws_url(),
+                env.trade_ws_url(),
+                env.oauth_url(),
+                env.connect_page_url(),
+                env.agent_redirect_uri(),
+            ] {
+                assert!(
+                    url.contains(expected),
+                    "{env:?} URL {url} must be on {expected}"
+                );
+            }
+        }
+    }
+
+    /// Callers append leading-slash paths (`{base}/oauth2/token`), so a
+    /// trailing slash here would produce a double slash upstream.
+    #[test]
+    fn base_urls_have_no_trailing_slash() {
+        for env in [Environment::Production, Environment::Canary] {
+            assert!(!env.http_url().ends_with('/'), "http_url for {env:?}");
+            assert!(!env.oauth_url().ends_with('/'), "oauth_url for {env:?}");
+        }
+    }
+
+    #[test]
+    fn defaults_to_production_without_init() {
+        assert_eq!(
+            current(),
+            Environment::Production,
+            "an uninitialized process must talk to production"
+        );
+    }
+
+    /// The whole point of the module: the resolved base URL comes from the
+    /// environment enum alone. No `LONGBRIDGE_HTTP_URL` read is involved, so no
+    /// value of that variable can change the outcome — asserted here rather
+    /// than by mutating the process environment, which would race the other
+    /// tests' `getenv` calls.
+    #[test]
+    fn base_url_comes_from_the_environment_enum() {
+        assert_eq!(
+            http_url(),
+            current().http_url(),
+            "http_url must be exactly the current environment's host"
+        );
+        assert_eq!(
+            oauth_url(),
+            current().oauth_url(),
+            "oauth_url must be exactly the current environment's host"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_override_replaces_http_and_oauth_base() {
+        let scoped = UPSTREAM_OVERRIDE
+            .scope("http://127.0.0.1:9/".to_string(), async {
+                (http_url(), oauth_url())
+            })
+            .await;
+        assert_eq!(
+            scoped,
+            (
+                "http://127.0.0.1:9".to_string(),
+                "http://127.0.0.1:9".to_string()
+            ),
+            "the override must cover both bases and drop the trailing slash"
+        );
+        assert_eq!(
+            http_url(),
+            Environment::Production.http_url(),
+            "the override must not leak outside its scope"
+        );
+    }
+}

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -68,7 +68,7 @@ impl Environment {
     pub fn http_url(self) -> &'static str {
         match self {
             Environment::Production => "https://openapi.longbridge.com",
-            Environment::Canary => "https://openapi.longbridge.xyz",
+            Environment::Canary => CANARY_GLOBAL_GATEWAY,
         }
     }
 
@@ -76,7 +76,7 @@ impl Environment {
     pub fn quote_ws_url(self) -> &'static str {
         match self {
             Environment::Production => "wss://openapi-quote.longbridge.com/v2",
-            Environment::Canary => "wss://openapi-quote.longbridge.xyz/v2",
+            Environment::Canary => "wss://openapi-global-quote.longbridge.xyz/v2",
         }
     }
 
@@ -84,18 +84,19 @@ impl Environment {
     pub fn trade_ws_url(self) -> &'static str {
         match self {
             Environment::Production => "wss://openapi-trade.longbridge.com/v2",
-            Environment::Canary => "wss://openapi-trade.longbridge.xyz/v2",
+            Environment::Canary => "wss://openapi-global-trade.longbridge.xyz/v2",
         }
     }
 
     /// OAuth base URL: the authorization server advertised in the RFC 8414 /
     /// RFC 9728 metadata and the host the `authenticate` tool exchanges codes
-    /// against. Currently the same host as [`Environment::http_url`], kept
-    /// separate so the two can diverge without touching callers.
+    /// against. The same host as [`Environment::http_url`] in both
+    /// environments, kept as its own method so the two can diverge without
+    /// touching callers.
     pub fn oauth_url(self) -> &'static str {
         match self {
             Environment::Production => "https://openapi.longbridge.com",
-            Environment::Canary => "https://openapi.longbridge.xyz",
+            Environment::Canary => CANARY_GLOBAL_GATEWAY,
         }
     }
 
@@ -126,6 +127,19 @@ impl Environment {
     }
 }
 
+/// Canary's global gateway — the counterpart of production's
+/// `openapi.longbridge.com`.
+///
+/// Canary fronts the same backend with two gateways: this one, which is
+/// CloudFront-fronted and performs `x-dc-region` data-center routing exactly
+/// like production, and `openapi.longbridge.xyz`, which resolves to regional
+/// (ap-east-1) addresses. This server serves `us_`- and `ap_`-prefixed
+/// credentials from one process and depends on that routing, so the regional
+/// endpoint would reproduce the `301604 no quote access` failure described
+/// above. `longbridge-terminal` (`src/region.rs`) and the SDK's staging OAuth
+/// base point at the same host.
+const CANARY_GLOBAL_GATEWAY: &str = "https://openapi-global.longbridge.xyz";
+
 /// The connect page baked into static tool metadata: the `#[tool]` description
 /// and `auth_code` schema doc, which need literals, and the locale files.
 ///
@@ -136,6 +150,76 @@ impl Environment {
 /// resulting code against canary, and the `redirect_uri` mismatch surfaces as
 /// an opaque `invalid_grant`.
 pub const STATIC_CONNECT_PAGE: &str = "https://open.longbridge.com/connect";
+
+/// An OAuth scope this server advertises in its RFC 8414 / RFC 9728 metadata.
+///
+/// The authorization server identifies scopes by *numeric id* in the `scope`
+/// request parameter, and those ids are environment-specific: production uses
+/// `4/6/10/11` while canary uses `18/20/21/24` for the same four concepts
+/// (observed from dynamic client registration, which reports each
+/// environment's available set — `4 6 10 11 12` vs `18 20 21 24 25`). The
+/// stable identifier is the `key`, which is what the token endpoint echoes back
+/// and what `data/scopes.json` records; the numeric id is resolved per
+/// environment by [`Scope::id`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+    /// Watchlist group management.
+    Watchlist,
+    /// Account assets, positions, and cash flow (read-only).
+    AccountRead,
+    /// Order and execution lookup (read-only).
+    TradeRead,
+    /// Order placement, DCA, and grid writes.
+    TradeWrite,
+}
+
+impl Scope {
+    /// Stable scope key, matching the `key` field in `data/scopes.json` and the
+    /// `scope` value the token endpoint returns.
+    pub fn key(self) -> &'static str {
+        match self {
+            Scope::Watchlist => "watchlist",
+            Scope::AccountRead => "account.read",
+            Scope::TradeRead => "trade.read",
+            Scope::TradeWrite => "trade.write",
+        }
+    }
+
+    /// Numeric id the given environment's authorization server expects.
+    pub fn id(self, environment: Environment) -> &'static str {
+        match (self, environment) {
+            (Scope::Watchlist, Environment::Production) => "4",
+            (Scope::AccountRead, Environment::Production) => "6",
+            (Scope::TradeRead, Environment::Production) => "10",
+            (Scope::TradeWrite, Environment::Production) => "11",
+            (Scope::Watchlist, Environment::Canary) => "18",
+            (Scope::AccountRead, Environment::Canary) => "20",
+            (Scope::TradeRead, Environment::Canary) => "21",
+            (Scope::TradeWrite, Environment::Canary) => "24",
+        }
+    }
+}
+
+/// Scopes advertised on the full endpoints (`/mcp`, `/agent`, root).
+pub const SCOPES: &[Scope] = &[
+    Scope::Watchlist,
+    Scope::AccountRead,
+    Scope::TradeRead,
+    Scope::TradeWrite,
+];
+
+/// Scopes advertised on the restricted `/v2` endpoint: the read-only subset,
+/// deliberately without [`Scope::TradeWrite`].
+pub const V2_SCOPES: &[Scope] = &[Scope::Watchlist, Scope::AccountRead, Scope::TradeRead];
+
+/// Scope ids to advertise for the current environment.
+pub fn scope_ids(scopes: &[Scope]) -> Vec<String> {
+    let environment = current();
+    scopes
+        .iter()
+        .map(|scope| scope.id(environment).to_string())
+        .collect()
+}
 
 static ENVIRONMENT: OnceLock<Environment> = OnceLock::new();
 
@@ -157,6 +241,7 @@ pub fn init(environment: Environment) {
         http_url = environment.http_url(),
         quote_ws_url = environment.quote_ws_url(),
         trade_ws_url = environment.trade_ws_url(),
+        oauth_url = environment.oauth_url(),
         "upstream endpoints fixed"
     );
 }
@@ -234,10 +319,10 @@ mod tests {
             ),
             (
                 Environment::Canary,
-                "https://openapi.longbridge.xyz",
-                "wss://openapi-quote.longbridge.xyz/v2",
-                "wss://openapi-trade.longbridge.xyz/v2",
-                "https://openapi.longbridge.xyz",
+                "https://openapi-global.longbridge.xyz",
+                "wss://openapi-global-quote.longbridge.xyz/v2",
+                "wss://openapi-global-trade.longbridge.xyz/v2",
+                "https://openapi-global.longbridge.xyz",
                 "https://open.longbridge.xyz/connect",
                 "https://open.longbridge.xyz/connect/done",
             ),
@@ -294,6 +379,58 @@ mod tests {
             assert!(!env.http_url().ends_with('/'), "http_url for {env:?}");
             assert!(!env.oauth_url().ends_with('/'), "oauth_url for {env:?}");
         }
+    }
+
+    /// Guard: the production ids in [`Scope::id`] must match `data/scopes.json`,
+    /// which is the catalogue the public `/mcp/scopes.json` manifest and the
+    /// translations are built from. Keys are the stable identifier, so this
+    /// pins the id-to-concept mapping against the only other place that
+    /// records it.
+    #[test]
+    fn production_scope_ids_match_the_catalogue() {
+        let catalogue: serde_json::Value =
+            serde_json::from_str(include_str!("../data/scopes.json"))
+                .expect("data/scopes.json must be valid JSON");
+        let entries = catalogue["scopes"]
+            .as_array()
+            .expect("scopes.json must hold a `scopes` array");
+        for scope in SCOPES {
+            let entry = entries
+                .iter()
+                .find(|e| e["key"].as_str() == Some(scope.key()))
+                .unwrap_or_else(|| panic!("no `{}` entry in data/scopes.json", scope.key()));
+            assert_eq!(
+                entry["id"].as_str(),
+                Some(scope.id(Environment::Production)),
+                "production id for `{}` disagrees with data/scopes.json",
+                scope.key()
+            );
+        }
+    }
+
+    /// Every environment must map the four concepts onto four distinct ids, and
+    /// the `/v2` set must never carry trade execution.
+    #[test]
+    fn scope_sets_are_well_formed() {
+        for env in [Environment::Production, Environment::Canary] {
+            let ids: Vec<&str> = SCOPES.iter().map(|s| s.id(env)).collect();
+            let mut unique = ids.clone();
+            unique.sort_unstable();
+            unique.dedup();
+            assert_eq!(
+                unique.len(),
+                ids.len(),
+                "duplicate scope id for {env:?}: {ids:?}"
+            );
+        }
+        assert!(
+            !V2_SCOPES.contains(&Scope::TradeWrite),
+            "/v2 is the read-only surface and must not advertise trade execution"
+        );
+        assert!(
+            V2_SCOPES.iter().all(|s| SCOPES.contains(s)),
+            "/v2 scopes must be a subset of the full set"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,12 @@
 #![recursion_limit = "256"]
+// Nothing in this crate needs `unsafe`. It is forbidden mainly to keep tests
+// from reaching for `std::env::set_var` to redirect upstream URLs — see
+// `crate::endpoints::UPSTREAM_OVERRIDE` for the supported way to do that.
+#![forbid(unsafe_code)]
 
 mod auth;
 mod counter;
+mod endpoints;
 mod error;
 mod logging;
 mod metrics;
@@ -19,6 +24,8 @@ use clap::Parser;
 use serde::Deserialize;
 use tokio::net::TcpListener;
 
+use crate::endpoints::Environment;
+
 fn default_bind() -> SocketAddr {
     "127.0.0.1:8000".parse().unwrap()
 }
@@ -30,6 +37,7 @@ struct FileConfig {
     log_dir: Option<PathBuf>,
     tls_cert: Option<PathBuf>,
     tls_key: Option<PathBuf>,
+    canary: Option<bool>,
 }
 
 #[derive(Debug, Parser)]
@@ -55,6 +63,12 @@ struct Cli {
     #[arg(long)]
     tls_key: Option<PathBuf>,
 
+    /// Talk to the canary Longbridge environment (`*.longbridge.xyz`) instead
+    /// of production (`*.longbridge.com`). `--canary=false` forces production
+    /// even when the config file enables canary.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    canary: Option<bool>,
+
     /// Run as a stdio MCP server instead of HTTP.
     /// Exposes tools/list without authentication for directory scanners
     /// (e.g. Glama).  tools/call will return auth errors for upstream
@@ -70,6 +84,8 @@ pub struct AppConfig {
     pub log_dir: Option<PathBuf>,
     pub tls_cert: Option<PathBuf>,
     pub tls_key: Option<PathBuf>,
+    pub environment: Environment,
+    pub stdio: bool,
 }
 
 fn config_path() -> PathBuf {
@@ -113,6 +129,19 @@ fn load_config() -> AppConfig {
         log_dir: cli.log_dir.or(file_config.log_dir),
         tls_cert,
         tls_key,
+        environment: resolve_environment(cli.canary, file_config.canary),
+        stdio: cli.stdio,
+    }
+}
+
+/// Pick the upstream environment from the CLI flag and the config file, CLI
+/// first. Both are `Option<bool>` so `--canary=false` can force production on a
+/// host whose config file enables canary.
+fn resolve_environment(cli: Option<bool>, file: Option<bool>) -> Environment {
+    if cli.or(file).unwrap_or(false) {
+        Environment::Canary
+    } else {
+        Environment::Production
     }
 }
 
@@ -126,10 +155,10 @@ fn print_startup_banner(config: &AppConfig, tools: usize, v2_tools: usize) {
     use std::io::IsTerminal;
 
     let color = std::io::stderr().is_terminal();
-    let (b, d, c, r) = if color {
-        ("\x1b[1m", "\x1b[2m", "\x1b[36m", "\x1b[0m")
+    let (b, d, c, y, r) = if color {
+        ("\x1b[1m", "\x1b[2m", "\x1b[36m", "\x1b[33m", "\x1b[0m")
     } else {
-        ("", "", "", "")
+        ("", "", "", "", "")
     };
 
     let base = &config.base_url;
@@ -152,6 +181,16 @@ fn print_startup_banner(config: &AppConfig, tools: usize, v2_tools: usize) {
     eprintln!("  {d}Listening{r}  {scheme}://{}", config.bind);
     eprintln!("  {d}Base URL{r}   {base}");
     eprintln!("  {d}Logs{r}       {logs}");
+    eprintln!(
+        "  {d}Upstream{r}   {}  {d}{}{r}",
+        crate::endpoints::http_url(),
+        crate::endpoints::quote_ws_url()
+    );
+    if config.environment == Environment::Canary {
+        eprintln!(
+            "  {d}Mode{r}       {y}CANARY{r} {d}— upstream is the Longbridge canary environment, not production{r}"
+        );
+    }
     eprintln!();
     eprintln!("  {b}Endpoints{r}");
     eprintln!(
@@ -188,11 +227,21 @@ async fn main() -> anyhow::Result<()> {
         .install_default()
         .expect("failed to install rustls crypto provider");
 
-    // stdio mode: serve via stdin/stdout for directory scanners like Glama.
-    // tools/list works without credentials; tools/call returns auth errors.
-    if std::env::args().any(|a| a == "--stdio") {
+    // Configuration is resolved before the transport branch so `--canary` and
+    // the config file apply to stdio mode too, and so the upstream endpoints
+    // are fixed before the first `list_tools()` bakes the tool descriptors.
+    let config = load_config();
+    if config.stdio {
         // In stdio mode stdout is the MCP transport; send all logs to stderr.
         crate::logging::init_stdio();
+    } else {
+        crate::logging::init(config.log_dir.as_deref());
+    }
+    crate::endpoints::init(config.environment);
+
+    // stdio mode: serve via stdin/stdout for directory scanners like Glama.
+    // tools/list works without credentials; tools/call returns auth errors.
+    if config.stdio {
         let tools = crate::tools::list_tools();
         // count includes all registered tools; authenticated clients on /mcp see one fewer
         // (the `authenticate` tool is only surfaced on the unauthenticated /agent endpoint).
@@ -207,9 +256,6 @@ async fn main() -> anyhow::Result<()> {
         }
         return Ok(());
     }
-
-    let config = load_config();
-    crate::logging::init(config.log_dir.as_deref());
 
     let app_state = Arc::new(crate::auth::AppState {
         base_url: config.base_url.clone(),
@@ -247,4 +293,32 @@ async fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canary_precedence_matrix() {
+        let cases = [
+            (None, None, Environment::Production),
+            (Some(true), None, Environment::Canary),
+            (None, Some(true), Environment::Canary),
+            (None, Some(false), Environment::Production),
+            // The CLI wins in both directions, which is why both sides are
+            // `Option<bool>`: `--canary=false` must be able to force production
+            // on a host whose config file enables canary.
+            (Some(false), Some(true), Environment::Production),
+            (Some(true), Some(false), Environment::Canary),
+        ];
+
+        for (cli, file, expected) in cases {
+            assert_eq!(
+                resolve_environment(cli, file),
+                expected,
+                "cli={cli:?} file={file:?}"
+            );
+        }
+    }
 }

--- a/src/tools/authenticate.rs
+++ b/src/tools/authenticate.rs
@@ -37,30 +37,16 @@ use crate::tools::tool_result;
 /// The page where a user generates a one-time authorization code to paste to
 /// the AI. Referenced in the tool description and in error hints so the AI can
 /// self-heal by directing the user here.
-pub const CONNECT_PAGE_URL: &str = "https://open.longbridge.com/connect";
-
-/// `/connect` page URL matching the deployment region: a `.cn` deployment
-/// (detected via `LONGBRIDGE_HTTP_URL` pointing at openapi.longbridge.cn)
-/// should send users to open.longbridge.cn instead of the global site.
 pub fn connect_page_url() -> &'static str {
-    if oauth_base_url().contains("longbridge.cn") {
-        "https://open.longbridge.cn/connect"
-    } else {
-        CONNECT_PAGE_URL
-    }
+    crate::endpoints::connect_page_url()
 }
 
 /// `redirect_uri` the authorization code is bound to. The connect page issues
 /// the code against `{open_url}/connect/done`, so the token exchange must send
-/// the exact same value. Region-aware (mirrors `connect_page_url`): a `.cn`
-/// deployment binds to open.longbridge.cn, everything else to open.longbridge.com.
-/// Must stay in sync with the web `getAgentRedirectUri()` and the CLI.
+/// the exact same value. Must stay in sync with the web `getAgentRedirectUri()`
+/// and the CLI.
 fn agent_redirect_uri() -> &'static str {
-    if oauth_base_url().contains("longbridge.cn") {
-        "https://open.longbridge.cn/connect/done"
-    } else {
-        "https://open.longbridge.com/connect/done"
-    }
+    crate::endpoints::agent_redirect_uri()
 }
 
 /// Parameters for the `authenticate` tool.
@@ -93,16 +79,6 @@ struct TokenErrorResponse {
     error: Option<String>,
     #[serde(default)]
     error_description: Option<String>,
-}
-
-/// Base OAuth URL (no trailing slash), honoring `LONGBRIDGE_HTTP_URL` so tests
-/// and non-prod deployments can redirect the exchange. Mirrors
-/// `auth::metadata::longbridge_oauth_url`.
-fn oauth_base_url() -> String {
-    std::env::var("LONGBRIDGE_HTTP_URL")
-        .unwrap_or_else(|_| "https://openapi.longbridge.com".to_string())
-        .trim_end_matches('/')
-        .to_string()
 }
 
 fn self_heal_hint() -> String {
@@ -215,7 +191,7 @@ pub async fn authenticate(
 }
 
 async fn exchange_code(code: &str, client_id: &str) -> Result<TokenResponse, McpError> {
-    let url = format!("{}/oauth2/token", oauth_base_url());
+    let url = format!("{}/oauth2/token", crate::endpoints::oauth_url());
 
     let form = [
         ("grant_type", "authorization_code"),
@@ -333,10 +309,29 @@ mod tests {
         .await
         .expect_err("empty code must be rejected");
         assert!(
-            err.message.contains(CONNECT_PAGE_URL),
+            err.message.contains(crate::endpoints::connect_page_url()),
             "got: {}",
             err.message
         );
+    }
+
+    /// The token exchange sends `agent_redirect_uri` verbatim and it must
+    /// byte-match what the connect page bound the code to, so the two URLs have
+    /// to stay on the same origin in every environment — a one-sided edit would
+    /// surface only as `invalid_grant` at exchange time.
+    #[test]
+    fn connect_page_and_redirect_uri_share_an_origin() {
+        for env in [
+            crate::endpoints::Environment::Production,
+            crate::endpoints::Environment::Canary,
+        ] {
+            let connect = env.connect_page_url();
+            assert_eq!(
+                env.agent_redirect_uri(),
+                format!("{connect}/done"),
+                "redirect_uri must be the connect page's /done for {env:?}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -371,23 +366,20 @@ mod tests {
             bs58::encode(v).into_string()
         };
 
-        // Serialized against other tests that mutate LONGBRIDGE_HTTP_URL. The
-        // guard is intentionally held across the .await: oauth_base_url() is
-        // called inside authenticate() and must see the redirected URL for the
-        // entire async call. tokio::sync::Mutex is used precisely so the guard
-        // can be held across suspension points without blocking the executor.
-        let err = {
-            let _env_guard = crate::tools::HTTP_URL_ENV_LOCK.lock().await;
-            // SAFETY: guarded by HTTP_URL_ENV_LOCK; set before call, cleared after.
-            unsafe { std::env::set_var("LONGBRIDGE_HTTP_URL", format!("http://{addr}")) };
-            let result = authenticate(false, AuthenticateParam { auth_code: packed }).await;
-            unsafe { std::env::remove_var("LONGBRIDGE_HTTP_URL") };
-            result
-        }
-        .expect_err("expired code must fail");
+        // The override wraps the whole call: the OAuth base URL is read deep
+        // inside `authenticate`, after several suspension points, and a
+        // task-local scope stays visible there. Being task-scoped rather than
+        // process-global, it needs no serialization against other tests.
+        let err = crate::endpoints::UPSTREAM_OVERRIDE
+            .scope(
+                format!("http://{addr}"),
+                authenticate(false, AuthenticateParam { auth_code: packed }),
+            )
+            .await
+            .expect_err("expired code must fail");
 
         assert!(
-            err.message.contains(CONNECT_PAGE_URL),
+            err.message.contains(crate::endpoints::connect_page_url()),
             "got: {}",
             err.message
         );

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -582,38 +582,6 @@ pub struct McpContext {
     pub extra_headers: Vec<(String, String)>,
 }
 
-/// Global-gateway endpoints, pinned for US-data-center tokens.
-///
-/// # Which access point can serve which data center
-///
-/// Every Longbridge credential carries its data center as a prefix: `us_…` for
-/// the US data center, `ap_…` (or unprefixed) for Asia-Pacific. That prefix
-/// decides which access point can serve it:
-///
-/// | Data center | `.com` | `.cn` |
-/// |-------------|--------|-------|
-/// | `us`        | yes — the only usable access point | no |
-/// | `ap`        | yes    | yes   |
-///
-/// `.cn` has no path to the US data center. This is a hard constraint, not a
-/// latency or preference question.
-///
-/// # Why this is pinned
-///
-/// Left unset, the SDK picks an access point by geolocation at request time,
-/// which resolves to `.cn` on a China Mainland network. A US token sent to `.cn`
-/// still authenticates — the WebSocket connects and basic calls such as
-/// `static_info` succeed — but every market-data request comes back
-/// `301604 no quote access`, because `.cn` cannot source US-account quotes. The
-/// failure reads like a missing permission and is not one, so pin the endpoints
-/// rather than letting geolocation decide.
-///
-/// AP tokens are deliberately left to geolocation: both access points serve
-/// them, so the nearer one is the right choice.
-const US_HTTP_URL: &str = "https://openapi.longbridge.com";
-const US_QUOTE_WS_URL: &str = "wss://openapi-quote.longbridge.com/v2";
-const US_TRADE_WS_URL: &str = "wss://openapi-trade.longbridge.com/v2";
-
 /// Server-side beacon endpoint. Quote operations flow over the WebSocket quote
 /// channel and never reach the HTTP access log; a request to this fake path lets
 /// the server record (and count) that a WS-backed quote tool ran. The path only
@@ -632,17 +600,6 @@ pub(crate) async fn send_quote_cmd(client: &longbridge::httpclient::HttpClient) 
         .await;
 }
 
-/// Serializes tests that mutate the process-global `LONGBRIDGE_HTTP_URL` env var
-/// to redirect the SDK base URL at a local capture server. Multiple such tests
-/// run concurrently in one binary and would otherwise clobber each other's URL.
-///
-/// `tokio::sync::Mutex` is used so the guard can be held across `.await` points
-/// without blocking the executor thread (needed by authenticate.rs's test, which
-/// must keep the env var set for the duration of an async call).
-#[cfg(test)]
-pub(crate) static HTTP_URL_ENV_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
-    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
-
 impl McpContext {
     /// This server's own identity as an RFC 9110 product token.
     const SELF_USER_AGENT: &'static str = concat!("longbridge-mcp/", env!("CARGO_PKG_VERSION"));
@@ -660,16 +617,11 @@ impl McpContext {
         }
     }
 
-    /// Whether this request's token belongs to the US data center and so needs
-    /// the global gateway pinned instead of geotest-selected endpoints.
+    /// Build an SDK `Config` for this request.
     ///
-    /// `LONGBRIDGE_HTTP_URL` takes precedence when set, so tests and local mock
-    /// servers can still redirect the SDK.
-    fn pin_us_endpoints(&self) -> bool {
-        std::env::var("LONGBRIDGE_HTTP_URL").is_err()
-            && longbridge::DcRegion::from_credential(&self.token) == longbridge::DcRegion::Us
-    }
-
+    /// All three upstream URLs are set explicitly from [`crate::endpoints`], so
+    /// the SDK neither reads them from the environment nor geolocates an access
+    /// point — see that module for why the endpoints are pinned.
     pub fn create_config(&self) -> Arc<longbridge::Config> {
         let mut config =
             longbridge::Config::from_oauth(longbridge::oauth::OAuth::from_token(&self.token))
@@ -677,13 +629,10 @@ impl McpContext {
                 .enable_overnight()
                 // Identify MCP-originated requests on the Context path (REST and
                 // WebSocket upgrades), mirroring how longbridge-cli tags itself.
-                .header("user-agent", self.user_agent());
-        if self.pin_us_endpoints() {
-            config = config
-                .http_url(US_HTTP_URL)
-                .quote_ws_url(US_QUOTE_WS_URL)
-                .trade_ws_url(US_TRADE_WS_URL);
-        }
+                .header("user-agent", self.user_agent())
+                .http_url(crate::endpoints::http_url())
+                .quote_ws_url(crate::endpoints::quote_ws_url())
+                .trade_ws_url(crate::endpoints::trade_ws_url());
         if let Some(ref lang) = self.language {
             let lb_lang = if lang.contains("zh-CN") || lang.contains("zh-Hans") {
                 longbridge::Language::ZH_CN
@@ -702,15 +651,14 @@ impl McpContext {
         Arc::new(config)
     }
 
+    /// Build an SDK `HttpClient` for this request. The base URL is pinned the
+    /// same way as in [`McpContext::create_config`], so REST calls can never
+    /// drift to a different access point than the WebSocket.
     pub fn create_http_client(&self) -> longbridge::httpclient::HttpClient {
-        let mut http_config = longbridge::httpclient::HttpClientConfig::from_oauth(
+        let http_config = longbridge::httpclient::HttpClientConfig::from_oauth(
             longbridge::oauth::OAuth::from_token(&self.token),
-        );
-        // Same US pinning as `create_config`, so REST calls do not drift to the
-        // CN node while the WebSocket is pinned to the global one.
-        if self.pin_us_endpoints() {
-            http_config = http_config.http_url(US_HTTP_URL);
-        }
+        )
+        .http_url(crate::endpoints::http_url());
         let mut client = longbridge::httpclient::HttpClient::new(http_config);
         // NOTE: This is very important for passing headers to upstream Longbridge services.
         // Do not remove this unless you have a good reason and know exactly which headers to forward instead.
@@ -1024,12 +972,37 @@ fn extract_context(ctx: &RequestContext<RoleServer>) -> Result<McpContext, McpEr
 fn all_tools_full_cached() -> &'static [rmcp::model::Tool] {
     static TOOLS: std::sync::OnceLock<Vec<rmcp::model::Tool>> = std::sync::OnceLock::new();
     TOOLS.get_or_init(|| {
+        // Descriptions and schema docs are literals naming
+        // `endpoints::STATIC_CONNECT_PAGE`; retarget them here, the one place
+        // every descriptor passes through, so a canary process does not send
+        // users to the production connect page. `None` in production, where
+        // there is nothing to rewrite. The matching rewrite for the translated
+        // descriptions lives in `crate::auth::build_locales_node`.
+        let connect_page = crate::endpoints::connect_page_url();
+        let retarget =
+            (connect_page != crate::endpoints::STATIC_CONNECT_PAGE).then_some(connect_page);
         cached_router()
             .list_all()
             .into_iter()
             .map(|mut tool| {
                 let mut schema = serde_json::Value::Object((*tool.input_schema).clone());
                 strip_null_from_type_arrays(&mut schema);
+                if let Some(connect_page) = retarget {
+                    replace_in_json_strings(
+                        &mut schema,
+                        crate::endpoints::STATIC_CONNECT_PAGE,
+                        connect_page,
+                    );
+                    if let Some(description) = &tool.description
+                        && description.contains(crate::endpoints::STATIC_CONNECT_PAGE)
+                    {
+                        tool.description = Some(
+                            description
+                                .replace(crate::endpoints::STATIC_CONNECT_PAGE, connect_page)
+                                .into(),
+                        );
+                    }
+                }
                 if let serde_json::Value::Object(obj) = schema {
                     tool.input_schema = std::sync::Arc::new(obj);
                 }
@@ -1349,6 +1322,31 @@ fn cached_router() -> &'static rmcp::handler::server::router::tool::ToolRouter<L
 
 /// Recursively remove `"null"` from JSON Schema `type` arrays.
 /// When the array is left with a single element it is unwrapped to a plain string.
+/// Replace every occurrence of `from` with `to` in all strings of a JSON value.
+/// Used to retarget URLs baked into static tool metadata (see
+/// [`all_tools_full_cached`]); descriptions live both at the top level of a
+/// schema and nested under `properties`, so the walk has to be recursive.
+fn replace_in_json_strings(value: &mut serde_json::Value, from: &str, to: &str) {
+    match value {
+        serde_json::Value::String(text) => {
+            if text.contains(from) {
+                *text = text.replace(from, to);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for v in map.values_mut() {
+                replace_in_json_strings(v, from, to);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                replace_in_json_strings(v, from, to);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn strip_null_from_type_arrays(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::Object(map) => {
@@ -5695,16 +5693,10 @@ mod tests {
             extra_headers: Vec::new(),
         };
         // Build the client with the SDK base URL redirected at the local server.
-        // Serialized against other env-mutating tests; the guard is released
-        // before the await so it is never held across a suspension point.
-        let client = {
-            let _env_guard = super::HTTP_URL_ENV_LOCK.lock().await;
-            // SAFETY: guarded by HTTP_URL_ENV_LOCK; set before build, cleared after.
-            unsafe { std::env::set_var("LONGBRIDGE_HTTP_URL", format!("http://{addr}")) };
-            let client = mctx.create_http_client();
-            unsafe { std::env::remove_var("LONGBRIDGE_HTTP_URL") };
-            client
-        };
+        // The override only has to cover construction: `HttpClientConfig`
+        // snapshots the base URL, so the later send needs no scope.
+        let client = crate::endpoints::UPSTREAM_OVERRIDE
+            .sync_scope(format!("http://{addr}"), || mctx.create_http_client());
         let _ = client
             .request(reqwest::Method::GET, "/v1/ping")
             .response::<String>()
@@ -5896,7 +5888,7 @@ mod tests {
 
 #[cfg(test)]
 mod quote_cmd_tests {
-    use super::{CURRENT_TOOL, HTTP_URL_ENV_LOCK, McpContext, QUOTE_CMD_PATH, send_quote_cmd};
+    use super::{CURRENT_TOOL, McpContext, QUOTE_CMD_PATH, send_quote_cmd};
     use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -5949,15 +5941,11 @@ mod quote_cmd_tests {
 
         // Build the client inside a `CURRENT_TOOL` scope (as `measured_tool_call`
         // does for real tool calls), with the SDK base URL redirected at the
-        // local server. `sync_scope` keeps the locked region free of any await.
-        let client = {
-            let _env_guard = HTTP_URL_ENV_LOCK.lock().await;
-            // SAFETY: guarded by HTTP_URL_ENV_LOCK; set before build, cleared after.
-            unsafe { std::env::set_var("LONGBRIDGE_HTTP_URL", format!("http://127.0.0.1:{port}")) };
-            let client = CURRENT_TOOL.sync_scope("depth", || mctx.create_http_client());
-            unsafe { std::env::remove_var("LONGBRIDGE_HTTP_URL") };
-            client
-        };
+        // local server.
+        let client = crate::endpoints::UPSTREAM_OVERRIDE
+            .sync_scope(format!("http://127.0.0.1:{port}"), || {
+                CURRENT_TOOL.sync_scope("depth", || mctx.create_http_client())
+            });
 
         send_quote_cmd(&client).await;
 
@@ -6041,6 +6029,49 @@ mod quote_cmd_tests {
              All other code must use `mctx.get_quote_context()` so calls go \
              through the connection pool and the /v1/quote/cmd beacon. \
              Untracked constructor at:\n{}",
+            offenders.join("\n")
+        );
+    }
+
+    /// Guard: upstream URLs come from `crate::endpoints` alone. The SDK would
+    /// happily pick them up from the environment (or a `.env` file) if any code
+    /// here read them back, which would reintroduce exactly the ambiguity that
+    /// module exists to remove. Structural rather than behavioral on purpose —
+    /// asserting it by setting the variables would need `unsafe` env mutation,
+    /// which the crate forbids.
+    #[test]
+    fn upstream_urls_are_never_read_from_the_environment() {
+        // Assembled from parts so this test does not match its own source.
+        const PREFIXES: &[&str] = &["LONGBRIDGE", "LONGPORT"];
+        const SUFFIXES: &[&str] = &["HTTP_URL", "QUOTE_WS_URL", "TRADE_WS_URL", "REGION"];
+        let forbidden: Vec<String> = PREFIXES
+            .iter()
+            .flat_map(|prefix| {
+                SUFFIXES
+                    .iter()
+                    .map(move |suffix| format!("{prefix}_{suffix}"))
+            })
+            .collect();
+        let src_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        // endpoints.rs names them in its module docs, as the variables it
+        // deliberately does not consult.
+        let allowed = src_dir.join("endpoints.rs");
+        let mut offenders = Vec::new();
+        for file in rs_files(&src_dir) {
+            if file == allowed {
+                continue;
+            }
+            let src = std::fs::read_to_string(&file).unwrap();
+            for (i, line) in src.lines().enumerate() {
+                if let Some(name) = forbidden.iter().find(|name| line.contains(name.as_str())) {
+                    offenders.push(format!("{}:{} ({name})", file.display(), i + 1));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "upstream endpoint selection must come from `crate::endpoints`, not \
+             the environment. Remove these references:\n{}",
             offenders.join("\n")
         );
     }


### PR DESCRIPTION
## Why

Upstream URLs were derived at request time, not decided by us:

- `HttpClientConfig::from_oauth` / `Config::from_oauth` read `LONGBRIDGE_HTTP_URL`, `LONGBRIDGE_QUOTE_WS_URL`, `LONGBRIDGE_TRADE_WS_URL` — plus the `LONGPORT_*` aliases, and a `.env` file via `dotenv`.
- With none of them set, the SDK probes `geotest.lbkrs.com` (5 s timeout) to pick `.cn` vs `.com`. The same binary talked to different hosts depending on where it ran.
- `pin_us_endpoints()` patched over only the case that broke outright — a `us_` token on `.cn` authenticates but returns `301604 no quote access` on every market-data request.

There was also no way to point the server at a non-production Longbridge environment, and two things were environment-blind besides the URLs: the OAuth scope ids and the connect page baked into static tool metadata.

## What changed

**Endpoint selection is a startup decision.** New `src/endpoints.rs` holds an `Environment` fixed once by `--canary` (or `"canary": true` in `config.json`) and resolves every upstream URL from it:

| | Production (default) | Canary (`--canary`) |
|---|---|---|
| OpenAPI | `https://openapi.longbridge.com` | `https://openapi-global.longbridge.xyz` |
| Quote WS | `wss://openapi-quote.longbridge.com/v2` | `wss://openapi-global-quote.longbridge.xyz/v2` |
| Trade WS | `wss://openapi-trade.longbridge.com/v2` | `wss://openapi-global-trade.longbridge.xyz/v2` |
| OAuth | `openapi.longbridge.com` | `openapi-global.longbridge.xyz` |
| Connect page | `open.longbridge.com/connect` | `open.longbridge.xyz/connect` |
| Scope ids | `4 6 10 11` (`/v2`: `4 6 10`) | `18 20 21 24` (`/v2`: `18 20 21`) |

All three data-plane URLs are now set explicitly on the SDK, so no environment variable and no geolocation probe can influence them.

**Canary uses the `-global` gateway, not `openapi.longbridge.xyz`.** Canary fronts the same backend with two gateways; only `openapi-global.longbridge.xyz` is CloudFront-fronted and performs `x-dc-region` data-center routing, exactly like production's host. `openapi.longbridge.xyz` resolves to regional (ap-east-1) addresses. This server serves `us_`- and `ap_`-prefixed credentials from one process and depends on that routing, so the regional endpoint would reproduce the same `301604` failure. `longbridge-terminal` (`src/region.rs`) and the SDK's staging OAuth base already point at the global gateway.

**`.cn` is gone.** Mainland acceleration through `openapi.longbridge.cn` is no longer used and `geotest.lbkrs.com` is never probed. Data-center routing is unchanged — that is the `x-dc-region` header the SDK derives from the credential prefix.

**Scope ids are environment-aware.** `SCOPES_SUPPORTED` was hardcoded to production's `4/6/10/11`; canary numbers the same four concepts `18/20/21/24`. Scopes are now `endpoints::Scope` — a concept with a stable `key` (`watchlist`, `account.read`, `trade.read`, `trade.write`, the strings the token endpoint echoes back and `data/scopes.json` records) plus a per-environment numeric id. The public `/mcp/scopes.json` and `/mcp/tools.json` manifests carry `id` fields straight from `data/scopes.json`, so those are retargeted through the same key; production output is byte-identical.

**Static tool metadata is retargeted.** Descriptions and schema docs are literals, so they name the production connect page, which doubles as a placeholder (`endpoints::STATIC_CONNECT_PAGE`) — the same idiom as the existing `LANDING_PAGE_URL_PLACEHOLDER`. It is replaced in the two places all metadata passes through: descriptions + input schemas in `all_tools_full_cached`, translations in `build_locales_node` (no translation content edited). Without this, canary would tell users to generate a code at the production page while the exchange sends the canary `redirect_uri` — a mismatch that surfaces as an opaque `invalid_grant`.

**Tests stopped mutating the process environment.** The three tests that redirected the SDK at a mock server via `unsafe { set_var("LONGBRIDGE_HTTP_URL") }` now scope `endpoints::UPSTREAM_OVERRIDE`, a `#[cfg(test)]` task-local. They run in parallel and `HTTP_URL_ENV_LOCK` is deleted. That left the crate with no `unsafe` at all, so `#![forbid(unsafe_code)]` is now set — which turns "upstream URLs are never read from the environment" into a compiler error instead of a convention.

## Notable decisions

- **`--canary` is `Option<bool>`, not a bare flag.** A bare `bool` cannot distinguish "not passed" from "passed false", so the CLI could only ever turn canary *on*. `--canary=false` now forces production on a host whose config file enables canary. Cost: stylistically inconsistent with the bare `--stdio`.
- **`main` parses config before the transport branch.** stdio previously dispatched on a raw argv scan and never called `Cli::parse()`, so `--canary` and `config.json` would not have applied there. Two consequences: stdio now rejects unknown flags, and a malformed `config.json` aborts stdio too (panic goes to stderr, not the stdout transport). `scripts/glama-start.sh` passes only `--stdio`.
- **`LONGBRIDGE_GLOBAL_OAUTH_URL` and `LONGBRIDGE_PUBLIC_HOSTS` stay env-driven.** They describe edge-entry topology supplied by the deployment, not environment selection, and keep precedence for allowlisted `X-Host` requests.
- **The `ALICLOUD-ALB-TRACE` filter is kept** even though our upstream is no longer `.cn`, so the second ALB traversal no longer originates here. It is a one-line allowlist entry and the 463 failure mode returns the moment a CN upstream is reintroduced; `docs/architecture.md` notes this.
- **`server.json`**: the three now-inert URL env vars are removed from `environmentVariables` (optional per the registry schema) and `--canary` is added to `runtimeArguments`, described as Longbridge-internal.

## Tests

`cargo +nightly fmt`, `cargo clippy --all-features --all-targets` (zero warnings), `cargo test` — 254 passed.

New: prod/canary URL table, per-environment domain check, no-trailing-slash check, override-scope behavior, `--canary` precedence matrix (6 rows), connect-page/`redirect_uri` same-origin pairing, production scope ids match `data/scopes.json`, scope sets well-formed (distinct ids per environment, `/v2` never carries trade execution), plus two structural guards — no source file may name the URL env vars, and the connect page may only appear in static metadata as the placeholder prefix.

## Manual verification

**Production, with hostile env vars set** (`LONGBRIDGE_HTTP_URL=https://example.invalid`, `LONGBRIDGE_QUOTE_WS_URL=…`, `LONGBRIDGE_REGION=CN`): SDK logs the real URL as `https://openapi.longbridge.com/v1/…` and the outbound connection goes to `13.226.69.63`. Metadata unchanged. Also verified end to end with a real production token: token exchange through this server's `/oauth2/token` proxy, a REST tool, a live quote over the quote WebSocket, `stock_positions` and `account_balance` — all succeeded, zero failures logged.

**Canary, end to end with a real token.** The client-driven OAuth flow now completes: dynamic registration, authorization code with PKCE, browser consent, callback, and token exchange through this server's proxy (outbound `13.33.183.15`, the `-global` pool). The authorize URL was built from this server's *own advertised metadata* — authorization server and scopes both read from `/.well-known/*` — so the run exercised both the gateway change and the scope change. Requested `scope=18 20 21 24` was accepted and granted `account.read trade.read trade.write watchlist`. Then:

- REST (`rank_categories`) — real data
- **Quote over the quote WebSocket** (`quote 700.HK`) — live quote returned, confirming `wss://openapi-global-quote.longbridge.xyz/v2`
- `stock_positions` — returned normally
- Zero errors in the log

**Both environments** advertise the right authorization server, scope sets, `/v2` read-only subset, and connect page — and `/mcp/tools.json` flips the connect page in the English description, the input schema, and both Chinese locales together.

## Open items (not blockers)

1. **`openapi-global-trade.longbridge.xyz` has no DNS record.** Confirmed harmless for this server: every trade tool queries over HTTP (`TradeContext::stock_positions` is `GET /v1/asset/stock`), and every call site drops the push receiver (`let (ctx, _) = TradeContext::new(…)`), so the trade WebSocket is never consumed. `stock_positions` succeeded on canary and the log stayed clean. `longbridge-terminal`'s `TRADE_WS_URL_TEST` names the same dead host, so it is worth fixing upstream regardless.
2. **The per-concept canary scope mapping is not independently proven.** Requesting all four ids returns all four keys, but the authorization server also grants extras (in production, requesting `4 6 10` returned `trade.write` as well), so the set match does not pin `24` to `trade.write` specifically. Operationally sufficient; worth confirming against the internal scope table before relying on `/v2`'s read-only subset (`18 20 21`) to exclude trade execution.
3. **Any deployment currently setting `LONGBRIDGE_HTTP_URL` must migrate.** It is now inert. A deployment pointing it at a `.xyz` host should use `--canary`; one pointing it at `openapi.longbridge.cn` loses that path (the `.cn` removal extends to the OAuth plane, not just the data plane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
