### PR TITLE
feat: MCP telemetry — client dimension + OAuth token/revoke metrics

### DIFF
--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -167,14 +167,7 @@ pub async fn mcp_auth_layer(
         req.extensions_mut().insert(RestrictedEndpoint(version));
     }
 
-    let client = crate::metrics::classify_client(
-        req.headers()
-            .get("user-agent")
-            .and_then(|v| v.to_str().ok()),
-    );
-    crate::metrics::CURRENT_CLIENT
-        .scope(client, next.run(req))
-        .await
+    next.run(req).await
 }
 
 #[cfg(test)]
@@ -212,37 +205,6 @@ mod tests {
             response.headers().contains_key("www-authenticate"),
             "401 must carry WWW-Authenticate per RFC 9728"
         );
-    }
-
-    #[tokio::test]
-    async fn sets_current_client_from_user_agent() {
-        let app = Router::new().route(
-            "/mcp",
-            get(|| async {
-                crate::metrics::CURRENT_CLIENT
-                    .try_with(|c| *c)
-                    .unwrap_or("MISSING")
-            })
-            .layer(axum::middleware::from_fn(
-                move |req: Request, next: Next| async move {
-                    mcp_auth_layer(req, next, "https://example.com", AuthMode::Optional, None).await
-                },
-            )),
-        );
-        let response = app
-            .oneshot(
-                axum::http::Request::builder()
-                    .uri("/mcp")
-                    .header("user-agent", "claude-code/2.1.89 (cli)")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        assert_eq!(&body[..], b"claude_code");
     }
 
     /// The 401 above is otherwise silent — logging the rejection is the whole

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -242,7 +242,7 @@ mod tests {
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();
-        assert_eq!(&body[..], b"claude");
+        assert_eq!(&body[..], b"claude_code");
     }
 
     /// The 401 above is otherwise silent — logging the rejection is the whole

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -167,7 +167,14 @@ pub async fn mcp_auth_layer(
         req.extensions_mut().insert(RestrictedEndpoint(version));
     }
 
-    next.run(req).await
+    let client = crate::metrics::classify_client(
+        req.headers()
+            .get("user-agent")
+            .and_then(|v| v.to_str().ok()),
+    );
+    crate::metrics::CURRENT_CLIENT
+        .scope(client, next.run(req))
+        .await
 }
 
 #[cfg(test)]
@@ -205,6 +212,37 @@ mod tests {
             response.headers().contains_key("www-authenticate"),
             "401 must carry WWW-Authenticate per RFC 9728"
         );
+    }
+
+    #[tokio::test]
+    async fn sets_current_client_from_user_agent() {
+        let app = Router::new().route(
+            "/mcp",
+            get(|| async {
+                crate::metrics::CURRENT_CLIENT
+                    .try_with(|c| *c)
+                    .unwrap_or("MISSING")
+            })
+            .layer(axum::middleware::from_fn(
+                move |req: Request, next: Next| async move {
+                    mcp_auth_layer(req, next, "https://example.com", AuthMode::Optional, None).await
+                },
+            )),
+        );
+        let response = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/mcp")
+                    .header("user-agent", "claude-code/2.1.89 (cli)")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"claude");
     }
 
     /// The 401 above is otherwise silent — logging the rejection is the whole

--- a/src/auth/oauth_proxy.rs
+++ b/src/auth/oauth_proxy.rs
@@ -27,13 +27,54 @@ static OAUTH_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
 const TOKEN_CREDENTIALS: &[&str] = &["refresh_token", "code"];
 const REVOKE_CREDENTIALS: &[&str] = &["token"];
 
+/// 正在代理的是哪种携带凭据的 OAuth POST,决定 `forward` 记哪个指标。
+#[derive(Clone, Copy)]
+enum OAuthOp {
+    Token,
+    Revoke,
+}
+
+/// 把 form 里的 `grant_type` 归到有界桶,作为低基数 label。
+fn grant_type_of(pairs: &[(String, String)]) -> &'static str {
+    match pairs
+        .iter()
+        .find(|(key, _)| key == "grant_type")
+        .map(|(_, value)| value.as_str())
+    {
+        Some("authorization_code") => "authorization_code",
+        Some("refresh_token") => "refresh_token",
+        _ => "other",
+    }
+}
+
+/// 把上游是否 2xx 映射为指标 `result` label。
+fn result_label(is_success: bool) -> &'static str {
+    if is_success { "success" } else { "error" }
+}
+
+/// 按操作类型记录对应的 OAuth 指标。
+fn record(op: OAuthOp, grant_type: &str, result: &str) {
+    match op {
+        OAuthOp::Token => crate::metrics::record_oauth_token(grant_type, result),
+        OAuthOp::Revoke => crate::metrics::record_oauth_revoke(result),
+    }
+}
+
 /// Proxy a token exchange and attach the region derived from its credential.
 pub async fn token(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
-    forward(&state, &headers, "/oauth2/token", TOKEN_CREDENTIALS, body).await
+    forward(
+        &state,
+        &headers,
+        "/oauth2/token",
+        TOKEN_CREDENTIALS,
+        OAuthOp::Token,
+        body,
+    )
+    .await
 }
 
 /// Proxy token revocation and attach the region derived from the token.
@@ -42,7 +83,15 @@ pub async fn revoke(
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
-    forward(&state, &headers, "/oauth2/revoke", REVOKE_CREDENTIALS, body).await
+    forward(
+        &state,
+        &headers,
+        "/oauth2/revoke",
+        REVOKE_CREDENTIALS,
+        OAuthOp::Revoke,
+        body,
+    )
+    .await
 }
 
 fn derive_region(pairs: &[(String, String)], credential_fields: &[&str]) -> DcRegion {
@@ -62,22 +111,29 @@ async fn forward(
     headers: &HeaderMap,
     upstream_path: &str,
     credential_fields: &[&str],
+    op: OAuthOp,
     body: Bytes,
 ) -> Response {
-    let region = serde_urlencoded::from_bytes::<Vec<(String, String)>>(&body)
-        .map(|pairs| derive_region(&pairs, credential_fields))
-        .unwrap_or(DcRegion::Ap);
+    let pairs = serde_urlencoded::from_bytes::<Vec<(String, String)>>(&body).unwrap_or_default();
+    let region = derive_region(&pairs, credential_fields);
+    let grant_type = grant_type_of(&pairs);
     let public = public_url_from_headers(headers, &state.base_url);
     let upstream = oauth_upstream_url(public.via_global_entry);
     let url = format!("{}{upstream_path}", upstream.trim_end_matches('/'));
 
     match upstream_request(&url, region, body).send().await {
-        Ok(response) => relay(response).await,
-        Err(error) => (
-            StatusCode::BAD_GATEWAY,
-            format!("upstream OAuth request failed: {error}"),
-        )
-            .into_response(),
+        Ok(response) => {
+            record(op, grant_type, result_label(response.status().is_success()));
+            relay(response).await
+        }
+        Err(error) => {
+            record(op, grant_type, "error");
+            (
+                StatusCode::BAD_GATEWAY,
+                format!("upstream OAuth request failed: {error}"),
+            )
+                .into_response()
+        }
     }
 }
 
@@ -123,6 +179,29 @@ mod tests {
             .iter()
             .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
             .collect()
+    }
+
+    #[test]
+    fn grant_type_buckets() {
+        assert_eq!(
+            grant_type_of(&pairs(&[("grant_type", "authorization_code")])),
+            "authorization_code"
+        );
+        assert_eq!(
+            grant_type_of(&pairs(&[("grant_type", "refresh_token")])),
+            "refresh_token"
+        );
+        assert_eq!(
+            grant_type_of(&pairs(&[("grant_type", "client_credentials")])),
+            "other"
+        );
+        assert_eq!(grant_type_of(&pairs(&[("code", "x")])), "other");
+    }
+
+    #[test]
+    fn result_label_maps_status() {
+        assert_eq!(result_label(true), "success");
+        assert_eq!(result_label(false), "error");
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6,6 +6,24 @@ use std::sync::LazyLock;
 
 static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
 
+/// 把 MCP 客户端的 `User-Agent` 映射到一个有界的客户端桶,以便作为低基数的
+/// Prometheus label。大小写不敏感的子串匹配;缺失或空白归为 `"unknown"`。
+pub fn classify_client(user_agent: Option<&str>) -> &'static str {
+    match user_agent {
+        Some(ua) if !ua.trim().is_empty() => {
+            let ua = ua.to_ascii_lowercase();
+            if ua.contains("claude") || ua.contains("anthropic") {
+                "claude"
+            } else if ua.contains("chatgpt") || ua.contains("openai") {
+                "chatgpt"
+            } else {
+                "other"
+            }
+        }
+        _ => "unknown",
+    }
+}
+
 static TOOL_CALLS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     let counter = IntCounterVec::new(
         Opts::new("mcp_tool_calls_total", "Total tool calls"),
@@ -97,5 +115,22 @@ pub async fn metrics_handler() -> impl IntoResponse {
             [("content-type", "text/plain; version=0.0.4")],
             format!("encode error: {e}").into_bytes(),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_client_buckets() {
+        assert_eq!(classify_client(Some("claude-code/2.1.89 (cli)")), "claude");
+        assert_eq!(classify_client(Some("ChatGPT-User/1.0")), "chatgpt");
+        assert_eq!(classify_client(Some("x-openai-mcp/2")), "chatgpt");
+        assert_eq!(classify_client(Some("Anthropic-Internal")), "claude");
+        assert_eq!(classify_client(Some("curl/8.0")), "other");
+        assert_eq!(classify_client(Some("")), "unknown");
+        assert_eq!(classify_client(Some("   ")), "unknown");
+        assert_eq!(classify_client(None), "unknown");
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6,6 +6,14 @@ use std::sync::LazyLock;
 
 static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
 
+tokio::task_local! {
+    /// 当前 MCP 请求的来源客户端桶(`"claude"` / `"chatgpt"` / `"other"` /
+    /// `"unknown"`),由 `mcp_auth_layer` 在每个 MCP 请求外层设置,供
+    /// [`record_tool_call`] 给工具指标打 `client` label。在 MCP 请求之外
+    /// (如服务初始化或单元测试)未设置,此时回落为 `"unknown"`。
+    pub(crate) static CURRENT_CLIENT: &'static str;
+}
+
 /// 把 MCP 客户端的 `User-Agent` 映射到一个有界的客户端桶,以便作为低基数的
 /// Prometheus label。大小写不敏感的子串匹配;缺失或空白归为 `"unknown"`。
 pub fn classify_client(user_agent: Option<&str>) -> &'static str {
@@ -27,7 +35,7 @@ pub fn classify_client(user_agent: Option<&str>) -> &'static str {
 static TOOL_CALLS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     let counter = IntCounterVec::new(
         Opts::new("mcp_tool_calls_total", "Total tool calls"),
-        &["tool_name"],
+        &["tool_name", "client"],
     )
     .unwrap();
     REGISTRY.register(Box::new(counter.clone())).unwrap();
@@ -37,7 +45,7 @@ static TOOL_CALLS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
 static TOOL_CALL_ERRORS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     let counter = IntCounterVec::new(
         Opts::new("mcp_tool_call_errors_total", "Total tool call errors"),
-        &["tool_name"],
+        &["tool_name", "client"],
     )
     .unwrap();
     REGISTRY.register(Box::new(counter.clone())).unwrap();
@@ -50,7 +58,7 @@ static TOOL_CALL_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
             "mcp_tool_call_duration_seconds",
             "Tool call duration in seconds",
         ),
-        &["tool_name"],
+        &["tool_name", "client"],
     )
     .unwrap();
     REGISTRY.register(Box::new(histogram.clone())).unwrap();
@@ -81,12 +89,17 @@ static QUOTE_WS_POOL_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
 });
 
 pub fn record_tool_call(tool_name: &str, duration_secs: f64, is_error: bool) {
-    TOOL_CALLS_TOTAL.with_label_values(&[tool_name]).inc();
+    let client = CURRENT_CLIENT.try_with(|c| *c).unwrap_or("unknown");
+    TOOL_CALLS_TOTAL
+        .with_label_values(&[tool_name, client])
+        .inc();
     TOOL_CALL_DURATION
-        .with_label_values(&[tool_name])
+        .with_label_values(&[tool_name, client])
         .observe(duration_secs);
     if is_error {
-        TOOL_CALL_ERRORS_TOTAL.with_label_values(&[tool_name]).inc();
+        TOOL_CALL_ERRORS_TOTAL
+            .with_label_values(&[tool_name, client])
+            .inc();
     }
 }
 
@@ -132,5 +145,35 @@ mod tests {
         assert_eq!(classify_client(Some("")), "unknown");
         assert_eq!(classify_client(Some("   ")), "unknown");
         assert_eq!(classify_client(None), "unknown");
+    }
+
+    #[test]
+    fn record_tool_call_labels_by_client() {
+        let before = TOOL_CALLS_TOTAL
+            .with_label_values(&["telemetry_test_tool", "chatgpt"])
+            .get();
+        CURRENT_CLIENT.sync_scope("chatgpt", || {
+            record_tool_call("telemetry_test_tool", 0.01, false);
+        });
+        let after = TOOL_CALLS_TOTAL
+            .with_label_values(&["telemetry_test_tool", "chatgpt"])
+            .get();
+        assert_eq!(after - before, 1);
+    }
+
+    #[test]
+    fn record_tool_call_falls_back_to_unknown_outside_scope() {
+        let before = TOOL_CALLS_TOTAL
+            .with_label_values(&["telemetry_test_tool2", "unknown"])
+            .get();
+        record_tool_call("telemetry_test_tool2", 0.01, true);
+        let calls = TOOL_CALLS_TOTAL
+            .with_label_values(&["telemetry_test_tool2", "unknown"])
+            .get();
+        let errs = TOOL_CALL_ERRORS_TOTAL
+            .with_label_values(&["telemetry_test_tool2", "unknown"])
+            .get();
+        assert_eq!(calls - before, 1);
+        assert!(errs >= 1);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -7,10 +7,11 @@ use std::sync::LazyLock;
 static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
 
 tokio::task_local! {
-    /// 当前 MCP 请求的来源客户端桶(`"claude"` / `"chatgpt"` / `"other"` /
-    /// `"unknown"`),由 `mcp_auth_layer` 在每个 MCP 请求外层设置,供
-    /// [`record_tool_call`] 给工具指标打 `client` label。在 MCP 请求之外
-    /// (如服务初始化或单元测试)未设置,此时回落为 `"unknown"`。
+    /// 当前 MCP 请求的来源产品桶(见 [`classify_client`]:`claude_ai` /
+    /// `claude_code` / `claude_desktop` / `claude_vscode` / `claude` /
+    /// `chatgpt` / `other` / `unknown`),由 `mcp_auth_layer` 在每个 MCP 请求
+    /// 外层设置,供 [`record_tool_call`] 给工具指标打 `client` label。在 MCP
+    /// 请求之外(如服务初始化或单元测试)未设置,此时回落为 `"unknown"`。
     pub(crate) static CURRENT_CLIENT: &'static str;
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -14,13 +14,28 @@ tokio::task_local! {
     pub(crate) static CURRENT_CLIENT: &'static str;
 }
 
-/// 把 MCP 客户端的 `User-Agent` 映射到一个有界的客户端桶,以便作为低基数的
+/// 把 MCP 客户端的 `User-Agent` 映射到一个有界的产品桶,以便作为低基数的
 /// Prometheus label。大小写不敏感的子串匹配;缺失或空白归为 `"unknown"`。
+///
+/// Claude 各产品发的 UA 有区分度(实测):claude.ai 网页/connector 发
+/// `Mozilla/5.0 ... Claude-User/1.0 ... +claude-user@anthropic.com`;其余
+/// 是 `claude-code/<ver> (<surface>)`,`<surface>` 标明宿主(cli、sdk-cli、
+/// sdk-ts、local-agent、claude-desktop、claude-vscode)。匹配顺序从具体到
+/// 笼统:先认 claude.ai / desktop / vscode,再落到通用的 claude_code。
+/// 「全部 Claude 流量」在查询侧用 `client=~"claude.*"` 聚合。
 pub fn classify_client(user_agent: Option<&str>) -> &'static str {
     match user_agent {
         Some(ua) if !ua.trim().is_empty() => {
             let ua = ua.to_ascii_lowercase();
-            if ua.contains("claude") || ua.contains("anthropic") {
+            if ua.contains("claude-user") {
+                "claude_ai"
+            } else if ua.contains("claude-desktop") {
+                "claude_desktop"
+            } else if ua.contains("claude-vscode") {
+                "claude_vscode"
+            } else if ua.contains("claude-code") {
+                "claude_code"
+            } else if ua.contains("claude") || ua.contains("anthropic") {
                 "claude"
             } else if ua.contains("chatgpt") || ua.contains("openai") {
                 "chatgpt"
@@ -177,10 +192,36 @@ mod tests {
 
     #[test]
     fn classify_client_buckets() {
-        assert_eq!(classify_client(Some("claude-code/2.1.89 (cli)")), "claude");
+        // Real UAs observed hitting the server (401-rejection logs).
+        assert_eq!(
+            classify_client(Some(
+                "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Claude-User/1.0; +claude-user@anthropic.com)"
+            )),
+            "claude_ai"
+        );
+        assert_eq!(
+            classify_client(Some(
+                "claude-code/2.1.260 (claude-desktop, agent-sdk/0.3.260)"
+            )),
+            "claude_desktop"
+        );
+        assert_eq!(
+            classify_client(Some(
+                "claude-code/2.1.263 (claude-vscode, agent-sdk/0.3.263)"
+            )),
+            "claude_vscode"
+        );
+        assert_eq!(
+            classify_client(Some("claude-code/2.1.220 (cli)")),
+            "claude_code"
+        );
+        assert_eq!(
+            classify_client(Some("claude-code/2.1.218 (sdk-ts, agent-sdk/0.3.218)")),
+            "claude_code"
+        );
+        assert_eq!(classify_client(Some("Anthropic-Internal")), "claude");
         assert_eq!(classify_client(Some("ChatGPT-User/1.0")), "chatgpt");
         assert_eq!(classify_client(Some("x-openai-mcp/2")), "chatgpt");
-        assert_eq!(classify_client(Some("Anthropic-Internal")), "claude");
         assert_eq!(classify_client(Some("curl/8.0")), "other");
         assert_eq!(classify_client(Some("")), "unknown");
         assert_eq!(classify_client(Some("   ")), "unknown");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -73,7 +73,14 @@ static TOOL_CALL_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
         prometheus::HistogramOpts::new(
             "mcp_tool_call_duration_seconds",
             "Tool call duration in seconds",
-        ),
+        )
+        // Extend the default buckets' 10s ceiling: some tools (candlesticks,
+        // financial reports) can exceed 10s against upstream, and without tail
+        // buckets every such call lands in +Inf, making p99 uncomputable above
+        // 10s.
+        .buckets(vec![
+            0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0,
+        ]),
         &["tool_name", "client"],
     )
     .unwrap();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -88,6 +88,32 @@ static QUOTE_WS_POOL_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
     gauge
 });
 
+static OAUTH_TOKEN_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new(
+            "mcp_oauth_token_total",
+            "OAuth token exchanges proxied through this server",
+        ),
+        &["grant_type", "result"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static OAUTH_REVOKE_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new(
+            "mcp_oauth_revoke_total",
+            "OAuth token revocations proxied through this server",
+        ),
+        &["result"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
 pub fn record_tool_call(tool_name: &str, duration_secs: f64, is_error: bool) {
     let client = CURRENT_CLIENT.try_with(|c| *c).unwrap_or("unknown");
     TOOL_CALLS_TOTAL
@@ -101,6 +127,20 @@ pub fn record_tool_call(tool_name: &str, duration_secs: f64, is_error: bool) {
             .with_label_values(&[tool_name, client])
             .inc();
     }
+}
+
+/// 记录一次经本服务代理的 OAuth token 交换。`grant_type` 已由调用方归到有界桶,
+/// `result` 为 `"success"`(上游 2xx)或 `"error"`。
+pub fn record_oauth_token(grant_type: &str, result: &str) {
+    OAUTH_TOKEN_TOTAL
+        .with_label_values(&[grant_type, result])
+        .inc();
+}
+
+/// 记录一次经本服务代理的 OAuth token 撤销(断连信号)。`result` 为
+/// `"success"`(上游 2xx)或 `"error"`。
+pub fn record_oauth_revoke(result: &str) {
+    OAUTH_REVOKE_TOTAL.with_label_values(&[result]).inc();
 }
 
 pub fn record_quote_ws_pool_event(event: &str, count: u64) {
@@ -175,5 +215,25 @@ mod tests {
             .get();
         assert_eq!(calls - before, 1);
         assert!(errs >= 1);
+    }
+
+    #[test]
+    fn record_oauth_token_increments() {
+        let before = OAUTH_TOKEN_TOTAL
+            .with_label_values(&["authorization_code", "success"])
+            .get();
+        record_oauth_token("authorization_code", "success");
+        let after = OAUTH_TOKEN_TOTAL
+            .with_label_values(&["authorization_code", "success"])
+            .get();
+        assert_eq!(after - before, 1);
+    }
+
+    #[test]
+    fn record_oauth_revoke_increments() {
+        let before = OAUTH_REVOKE_TOTAL.with_label_values(&["error"]).get();
+        record_oauth_revoke("error");
+        let after = OAUTH_REVOKE_TOTAL.with_label_values(&["error"]).get();
+        assert_eq!(after - before, 1);
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -73,6 +73,14 @@ where
             if let Err(err) = &result {
                 let code = err.code.0;
                 let elapsed_ms = (duration * 1000.0) as u64;
+                // Same task-local `record_tool_call` labels the metric with, so
+                // failures can be sliced by originating client in logs too (the
+                // "error_code drill-down by client" half of the telemetry). It
+                // also doubles as a propagation check: if this reads `unknown`
+                // in prod, the metric's `client` label is `unknown` as well.
+                let client = crate::metrics::CURRENT_CLIENT
+                    .try_with(|c| *c)
+                    .unwrap_or("unknown");
                 // `tool` name alone isn't unique on a hosted, multi-tenant
                 // server — two concurrent calls to the same tool can each
                 // fail and interleave their log lines. `call_id` is the only
@@ -104,7 +112,14 @@ where
                 // pre-bound to a local, so it's only evaluated when the
                 // target is actually enabled.
                 if routine {
-                    tracing::info!(tool = name, call_id, elapsed_ms, code, "tool call rejected");
+                    tracing::info!(
+                        tool = name,
+                        client,
+                        call_id,
+                        elapsed_ms,
+                        code,
+                        "tool call rejected"
+                    );
                     tracing::info!(
                         target: "longbridge_mcp::tools::error_detail",
                         tool = name,
@@ -114,7 +129,14 @@ where
                         "tool call error detail"
                     );
                 } else {
-                    tracing::warn!(tool = name, call_id, elapsed_ms, code, "tool call failed");
+                    tracing::warn!(
+                        tool = name,
+                        client,
+                        call_id,
+                        elapsed_ms,
+                        code,
+                        "tool call failed"
+                    );
                     tracing::warn!(
                         target: "longbridge_mcp::tools::error_detail",
                         tool = name,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -823,6 +823,19 @@ fn extract_context(ctx: &RequestContext<RoleServer>) -> Result<McpContext, McpEr
     })
 }
 
+/// Classify the originating client from the request's `User-Agent`, for the
+/// `CURRENT_CLIENT` metric/log label. Unlike [`extract_context`] this never
+/// fails (a request with no parts or no UA is simply `"unknown"`), so it can
+/// run on every `call_tool`, including token-less `authenticate` calls.
+fn client_bucket_from_context(ctx: &RequestContext<RoleServer>) -> &'static str {
+    let user_agent = ctx
+        .extensions
+        .get::<axum::http::request::Parts>()
+        .and_then(|parts| parts.headers.get("user-agent"))
+        .and_then(|value| value.to_str().ok());
+    crate::metrics::classify_client(user_agent)
+}
+
 /// Returns all registered MCP tools with full schema metadata, sorted by name.
 ///
 /// This is used for documentation resources where verbose field descriptions
@@ -5241,8 +5254,18 @@ impl ServerHandler for Longbridge {
                 ));
             }
         }
+        // Classify the originating client here — NOT in the HTTP middleware. In
+        // stateless mode rmcp runs the service (and therefore every `#[tool]`
+        // method and its `measured_tool_call`/`record_tool_call`) on a task it
+        // `tokio::spawn`s, which does not inherit task-locals set by the axum
+        // layer. `call_tool` is the innermost funnel that still runs on that
+        // same spawned task, so a `CURRENT_CLIENT` scope set here is visible to
+        // `record_tool_call`; one set in the middleware would not be.
+        let client = client_bucket_from_context(&context);
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
-        cached_router().call(tcc).await
+        crate::metrics::CURRENT_CLIENT
+            .scope(client, cached_router().call(tcc))
+            .await
     }
 
     async fn list_tools(


### PR DESCRIPTION
## Purpose

Add Prometheus telemetry to longbridge-mcp so Grafana can:
- break tool-call usage / error rate / latency down by **originating client** (Claude products vs ChatGPT vs other), and
- count **OAuth token / revoke exchanges** (new authorization vs refresh, success vs failure, disconnect signal).

This PR only makes the data **exist** (instrumentation). The Grafana dashboard, `/metrics` scrape wiring, and Slack alert are follow-on work on the Grafana/devops side, not part of this PR.

## Changes

**`src/metrics.rs`**
- `classify_client(ua) -> &'static str`: maps the client `User-Agent` to a bounded product bucket. Match strings are grounded in real UAs observed in the server's 401-rejection logs:
  - `claude-user` → `claude_ai` (claude.ai web / connector, UA `Mozilla/5.0 … Claude-User/1.0 … +claude-user@anthropic.com`)
  - `claude-desktop` → `claude_desktop`, `claude-vscode` → `claude_vscode`, `claude-code` → `claude_code`
  - other `claude`/`anthropic` → `claude`; `chatgpt`/`openai` → `chatgpt`; else `other`; missing → `unknown`
  - "all Claude traffic" is aggregated query-side with `client=~"claude.*"`.
- `CURRENT_CLIENT` task-local.
- Adds a `client` label to the three tool metrics: `mcp_tool_calls_total{tool_name,client}`, `mcp_tool_call_errors_total{tool_name,client}`, `mcp_tool_call_duration_seconds{tool_name,client}`. `record_tool_call` reads the task-local, falling back to `unknown` when unset.
- The latency histogram uses explicit buckets extended to 60s (default tops out at 10s), so p99 is computable for slow tools instead of collapsing into `+Inf`.
- Adds `mcp_oauth_token_total{grant_type,result}` and `mcp_oauth_revoke_total{result}` plus `record_oauth_token` / `record_oauth_revoke`.

**`src/tools/mod.rs`**
- `call_tool` classifies the originating client from the request and wraps the tool-router dispatch in `CURRENT_CLIENT.scope(...)`. **This is deliberately in `call_tool`, not the axum middleware:** in stateless mode rmcp runs the service (and thus every `#[tool]` method and its `record_tool_call`) on a `tokio::spawn`'d task that does not inherit task-locals set by the HTTP layer. `call_tool` is the innermost funnel still on that spawned task, so the label is real instead of always `unknown`.
- The tool-failure logs (`tool call rejected` / `failed`) now carry `client`, enabling per-client error-code drill-down from logs.

**`src/auth/oauth_proxy.rs`**
- `forward()` reads `grant_type` (bucketed to `{authorization_code, refresh_token, other}`) alongside the region it already parses, and records `success`/`error` (by upstream 2xx) after the response. Token exchanges go to `record_oauth_token`, revocations to `record_oauth_revoke`. Region behaviour is unchanged.

## Why OAuth can be instrumented in this repo

`/oauth2/token` and `/oauth2/revoke` are proxied through this server, so token-exchange success/failure is observable here; `/oauth2/authorize` and `/oauth2/register` go straight to upstream and are not. "Daily new authorizations" is measured as `grant_type=authorization_code` with an upstream 2xx — a more accurate signal than counting authorize-page views.

## Cardinality

`client` ≤ 8 × `tool_name` (~150) ≈ 1200 series; oauth token 6 + revoke 2. All bounded — no unbounded labels.

## Testing

Unit tests for `classify_client` (against real UAs), the `client` label, OAuth counters, and the `grant_type` / result helpers. `cargo test` green; `cargo clippy --all-features --all-targets` clean; `cargo +nightly fmt` no diff.

## Follow-on (not in this PR)

- devops: scrape `/metrics` (served unauthenticated on the MCP port, `0.0.0.0:8000`) into Prometheus/VM.
- Grafana: dashboard (ChatGPT/Claude usage + error rate + latency, Claude product split, OAuth daily authorizations / disconnects) + OAuth low-volume Slack alert. Note for the alert: a counter series does not exist until its first increment, so `increase(mcp_oauth_token_total{...}[24h])` returns NoData (not 0) before the first-ever authorization — guard with `... or vector(0)` / NoData handling.
- Verify empirically once scraped: `count by (client) (mcp_tool_calls_total)` should show real product buckets, not all `unknown`. The `chatgpt` matcher is not yet verified against a real ChatGPT UA.
