### PR TITLE
feat(grid)!: remove grid_questionnaire tool

### DIFF
--- a/data/scopes.json
+++ b/data/scopes.json
@@ -194,7 +194,6 @@
         "dca_stop",
         "dca_update",
         "grid_cancel",
-        "grid_questionnaire",
         "grid_replace",
         "grid_restart",
         "grid_submit",

--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -573,7 +573,7 @@
     },
     "grid_submit": {
       "title": "提交网格订单",
-      "description": "提交网格交易订单。需提供 symbol、settlement_currency 及网格规则:基准价/上限价/下限价、trigger_price_type(1=价差,2=百分比)及对应的价差/百分比上下沿、trigger_quantity、上下限数量、time_in_force(0=当日,1=GTC,6=GTD)、grid_order_type_up/down(GMO/GLO/GTG)、边界事件(1=忽略,2=按最新价平仓)。价格/数量为字符串。需先通过 grid_questionnaire 授权。【必须两步确认】未传本次试运行返回的 confirmation_code 时，本工具为 DRY RUN（试运行）：只校验并回显请求内容，不会发往交易所。请先不带 execute 调用一次，把返回的预览完整展示给用户，只有在用户明确确认之后，才可再次调用并把该确认码传入 execute。确认码由订单本身（代码、方向、数量、价格）推导而来，只对这一笔完全相同的请求生效。绝不可自行决定回填确认码。网格一旦生效会自行持续交易",
+      "description": "提交网格交易订单。需提供 symbol、settlement_currency 及网格规则:基准价/上限价/下限价、trigger_price_type(1=价差,2=百分比)及对应的价差/百分比上下沿、trigger_quantity、上下限数量、time_in_force(0=当日,1=GTC,6=GTD)、grid_order_type_up/down(GMO/GLO/GTG)、边界事件(1=忽略,2=按最新价平仓)。价格/数量为字符串。【必须两步确认】未传本次试运行返回的 confirmation_code 时，本工具为 DRY RUN（试运行）：只校验并回显请求内容，不会发往交易所。请先不带 execute 调用一次，把返回的预览完整展示给用户，只有在用户明确确认之后，才可再次调用并把该确认码传入 execute。确认码由订单本身（代码、方向、数量、价格）推导而来，只对这一笔完全相同的请求生效。绝不可自行决定回填确认码。网格一旦生效会自行持续交易",
       "properties": {
         "symbol": "证券代码,例如 \"700.HK\"",
         "settlement_currency": "结算货币,例如 \"HKD\"",
@@ -655,10 +655,6 @@
         "order_id": "网格订单号",
         "execute": "本次试运行返回的 confirmation_code。省略（默认）表示 DRY RUN：只校验并回显请求，同时返回一个三位确认码，不会发往交易所。必须先不带该参数调用一次，把预览展示给用户，待用户明确确认后才可再次调用并回填该码。确认码由订单本身（代码、方向、数量、价格）推导而来，只对这一笔完全相同的请求生效——改动任何字段即失效。不可自行决定回填。"
       }
-    },
-    "grid_questionnaire": {
-      "title": "网格策略授权",
-      "description": "记录提交网格订单前所需的一次性策略风险披露同意,无需参数。"
     },
     "history_candlesticks_by_date": {
       "title": "历史 K 线（按日期）",

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -573,7 +573,7 @@
     },
     "grid_submit": {
       "title": "提交網格訂單",
-      "description": "提交網格交易訂單。需提供 symbol、settlement_currency 及網格規則:基準價/上限價/下限價、trigger_price_type(1=價差,2=百分比)及對應的價差/百分比上下沿、trigger_quantity、上下限數量、time_in_force(0=當日,1=GTC,6=GTD)、grid_order_type_up/down(GMO/GLO/GTG)、邊界事件(1=忽略,2=按最新價平倉)。價格/數量為字串。需先通過 grid_questionnaire 授權。【必須兩步確認】未傳本次試執行返回的 confirmation_code 時，本工具為 DRY RUN（試執行）：只校驗並回顯請求內容，不會發往交易所。請先不帶 execute 呼叫一次，把返回的預覽完整展示給用戶，只有在用戶明確確認之後，才可再次呼叫並把該確認碼傳入 execute。確認碼由訂單本身（代碼、方向、數量、價格）推導而來，只對這一筆完全相同的請求生效。絕不可自行決定回填確認碼。網格一旦生效會自行持續交易",
+      "description": "提交網格交易訂單。需提供 symbol、settlement_currency 及網格規則:基準價/上限價/下限價、trigger_price_type(1=價差,2=百分比)及對應的價差/百分比上下沿、trigger_quantity、上下限數量、time_in_force(0=當日,1=GTC,6=GTD)、grid_order_type_up/down(GMO/GLO/GTG)、邊界事件(1=忽略,2=按最新價平倉)。價格/數量為字串。【必須兩步確認】未傳本次試執行返回的 confirmation_code 時，本工具為 DRY RUN（試執行）：只校驗並回顯請求內容，不會發往交易所。請先不帶 execute 呼叫一次，把返回的預覽完整展示給用戶，只有在用戶明確確認之後，才可再次呼叫並把該確認碼傳入 execute。確認碼由訂單本身（代碼、方向、數量、價格）推導而來，只對這一筆完全相同的請求生效。絕不可自行決定回填確認碼。網格一旦生效會自行持續交易",
       "properties": {
         "symbol": "證券代碼,例如 \"700.HK\"",
         "settlement_currency": "結算貨幣,例如 \"HKD\"",
@@ -655,10 +655,6 @@
         "order_id": "網格訂單號",
         "execute": "本次試執行返回的 confirmation_code。省略（預設）表示 DRY RUN：只校驗並回顯請求，同時返回一個三位確認碼，不會發往交易所。必須先不帶該參數呼叫一次，把預覽展示給用戶，待用戶明確確認後才可再次呼叫並回填該碼。確認碼由訂單本身（代碼、方向、數量、價格）推導而來，只對這一筆完全相同的請求生效——改動任何欄位即失效。不可自行決定回填。"
       }
-    },
-    "grid_questionnaire": {
-      "title": "網格策略授權",
-      "description": "記錄提交網格訂單前所需的一次性策略風險披露同意,無需參數。"
     },
     "history_candlesticks_by_date": {
       "title": "歷史 K 線（按日期）",

--- a/src/tools/grid.rs
+++ b/src/tools/grid.rs
@@ -7,8 +7,7 @@ use longbridge::Decimal;
 use longbridge::grid::{
     GetGridOrderDetailOptions, GetGridOrdersByIdsOptions, GetGridOrdersOptions,
     GetGridTriggerHistoryOptions, GridContext, GridLimitEvent, GridTimeInForce, GridTradeRule,
-    ReplaceGridOrderOptions, SubmitGridOrderOptions, SubmitStrategyQuestionnaireOptions,
-    TriggerPriceType,
+    ReplaceGridOrderOptions, SubmitGridOrderOptions, TriggerPriceType,
 };
 use rmcp::ErrorData as McpError;
 use rmcp::model::CallToolResult;
@@ -274,9 +273,6 @@ pub struct GridOrderIdParam {
     pub execute: Option<String>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GridQuestionnaireParam {}
-
 fn parse_decimal(field: &str, value: &Option<String>) -> Result<Option<Decimal>, McpError> {
     match value {
         Some(s) => Decimal::from_str(s)
@@ -459,19 +455,6 @@ pub async fn grid_restart(
     let ctx = GridContext::new(mctx.create_config());
     ctx.restart(p.order_id).await.map_err(Error::longbridge)?;
     Ok(tool_result("grid order restarted".to_string()))
-}
-
-pub async fn grid_questionnaire(
-    mctx: &crate::tools::McpContext,
-    _p: GridQuestionnaireParam,
-) -> Result<CallToolResult, McpError> {
-    let ctx = GridContext::new(mctx.create_config());
-    ctx.submit_strategy_questionnaire(SubmitStrategyQuestionnaireOptions::new())
-        .await
-        .map_err(Error::longbridge)?;
-    Ok(tool_result(
-        "strategy risk-disclosure questionnaire submitted".to_string(),
-    ))
 }
 
 #[cfg(test)]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1059,7 +1059,6 @@ const TOOL_ENDPOINTS: &[(&str, u8)] = &[
     ("grid_detail", 0),
     ("grid_list", 0),
     ("grid_list_by_ids", 0),
-    ("grid_questionnaire", 0),
     ("grid_replace", 0),
     ("grid_restart", 0),
     ("grid_submit", 0),
@@ -3871,7 +3870,7 @@ impl Longbridge {
             open_world_hint = true
         ),
         output_schema = schema_for::<output::grid::GridSubmitResponse>(),
-        description = "Submit a grid trading order. DRY RUN unless execute is the confirmation_code from its own dry run: call once without execute, show the preview, then re-call quoting the code only after the user confirms. A live grid keeps trading on its own. Requires symbol, settlement_currency, and the grid rule: base/upper/lower price, trigger_price_type (1=spread, 2=percent) with the matching spread/percent up/down, trigger_quantity, upper/lower_limit_quantity, time_in_force (0=Day, 1=GTC, 6=GTD), grid_order_type_up/down (GMO/GLO/GTG), and boundary events (1=ignore, 2=close-at-last). Prices/quantities are decimal strings. Requires the one-time grid_questionnaire consent."
+        description = "Submit a grid trading order. DRY RUN unless execute is the confirmation_code from its own dry run: call once without execute, show the preview, then re-call quoting the code only after the user confirms. A live grid keeps trading on its own. Requires symbol, settlement_currency, and the grid rule: base/upper/lower price, trigger_price_type (1=spread, 2=percent) with the matching spread/percent up/down, trigger_quantity, upper/lower_limit_quantity, time_in_force (0=Day, 1=GTC, 6=GTD), grid_order_type_up/down (GMO/GLO/GTG), and boundary events (1=ignore, 2=close-at-last). Prices/quantities are decimal strings."
     )]
     async fn grid_submit(
         &self,
@@ -3973,29 +3972,6 @@ impl Longbridge {
         let mctx = extract_context(&ctx)?;
         measured_tool_call("grid_restart", format!("{p:?}"), || {
             grid::grid_restart(&mctx, p)
-        })
-        .await
-    }
-
-    /// Submit the grid strategy risk-disclosure questionnaire.
-    #[tool(
-        title = "Grid Strategy Consent",
-        annotations(
-            read_only_hint = false,
-            destructive_hint = false,
-            idempotent_hint = true,
-            open_world_hint = true
-        ),
-        description = "Record the one-time grid strategy risk-disclosure consent required before submitting grid orders. Takes no parameters."
-    )]
-    async fn grid_questionnaire(
-        &self,
-        ctx: RequestContext<RoleServer>,
-        Parameters(p): Parameters<grid::GridQuestionnaireParam>,
-    ) -> Result<CallToolResult, McpError> {
-        let mctx = extract_context(&ctx)?;
-        measured_tool_call("grid_questionnaire", format!("{p:?}"), || {
-            grid::grid_questionnaire(&mctx, p)
         })
         .await
     }


### PR DESCRIPTION
## Why

Upstream SDK removed `GridContext::submit_strategy_questionnaire` (`/v1/record/questionnaire`) in longbridge/openapi#585 (`0e013a6`, between our pinned `f31ce227` and current `0621e3f`). Any future SDK bump would fail to compile against `grid.rs`.

## What

- Remove the `grid_questionnaire` tool: handler in `grid.rs`, `#[tool]` method and tool-count entry in `mod.rs`, `GridQuestionnaireParam`
- Remove the tool from `data/scopes.json` and zh-CN / zh-HK locale files
- Drop the "requires grid_questionnaire consent" wording from `grid_submit` descriptions (en/zh-CN/zh-HK)

## Verification

- `cargo clippy --all-features --all-targets`: clean
- `cargo test`: 229 passed (includes locale/schema consistency test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)