### PR TITLE
feat: add optional _jq response filtering to all MCP tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +635,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +813,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1037,6 +1085,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hifijson"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "hmac"
@@ -1403,6 +1457,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jaq-core"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f72ba7158fe9fc1bc4baace1b71e6d0d3d27c6839dd87dc1f233dd408f5dd85b"
+dependencies = [
+ "dyn-clone",
+ "once_cell",
+ "typed-arena",
+]
+
+[[package]]
+name = "jaq-json"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2f53207ffb1313a2d2ad819cfa8bfaa7936cb85a110eda10fd5da822cec94"
+dependencies = [
+ "bstr",
+ "bytes",
+ "foldhash",
+ "hifijson",
+ "indexmap",
+ "jaq-core",
+ "jaq-std",
+ "num-bigint",
+ "num-traits",
+ "ryu",
+ "self_cell",
+ "serde_core",
+]
+
+[[package]]
+name = "jaq-std"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f90e485abfd3189510c996e77be55056a51038b0fa5805e6c97b5dcf0d9ab55"
+dependencies = [
+ "aho-corasick",
+ "base64 0.22.1",
+ "bstr",
+ "jaq-core",
+ "jiff",
+ "libm",
+ "log",
+ "regex-bites",
+ "urlencoding",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1600,12 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1577,6 +1738,9 @@ dependencies = [
  "base64 0.22.1",
  "bs58",
  "clap",
+ "jaq-core",
+ "jaq-json",
+ "jaq-std",
  "longbridge",
  "prometheus",
  "reqwest 0.12.28",
@@ -1753,10 +1917,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2007,6 +2190,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -2345,6 +2543,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-bites"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
 
 [[package]]
 name = "regex-syntax"
@@ -2750,6 +2954,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "serde"
@@ -3529,6 +3739,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3579,6 +3795,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,8 @@ serde-transcode = "1.1"
 anyhow = "1"
 rustls = { version = "0.23", features = ["ring"] }
 sha2 = "0.10"
+
+# Embedded jq-compatible response filtering (no external jq executable).
+jaq-core = "3.1"
+jaq-std = "3.0"
+jaq-json = { version = "2.0", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Built in Rust with [rmcp](https://github.com/anthropics/rmcp) and [axum](https:/
 Every tool accepts an optional `_jq` string in its arguments. The expression runs
 on the complete returned JSON, after the normal response serialization. The `_jq`
 name is reserved for response filtering to avoid conflicts with business parameters.
+Usage guidance is sent once in the MCP `initialize` response's `instructions`;
+each tool schema declares only the optional parameter name and type.
 For example:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -41,9 +41,49 @@ Sign in once with your Longbridge account. Every request runs over the same host
 - **163 tools, one endpoint** — quotes, options, order routing, fundamentals, analyst research, screeners, IPO, alerts, DCA, grid trading and portfolio analytics across **US and HK markets**.
 - **Stateless by design** — every request forwards its Bearer token straight to the Longbridge SDK. No sessions, no database, nothing stored server-side.
 - **OAuth 2.1, auto-discovered** — RFC 9728 protected-resource and RFC 8414 authorization-server metadata; clients complete the flow with no token to paste.
-- **Clean, typed responses** — snake_case fields, RFC 3339 timestamps, human-readable symbols, and typed `outputSchema` descriptors for compatible clients.
+- **Clean, typed responses** — snake_case fields, RFC 3339 timestamps, human-readable symbols, and typed response schemas available as MCP resources.
 
 Built in Rust with [rmcp](https://github.com/anthropics/rmcp) and [axum](https://github.com/tokio-rs/axum).
+
+## Filter tool responses with jq
+
+Every tool accepts an optional `_jq` string in its arguments. The expression runs
+on the complete returned JSON, after the normal response serialization. The `_jq`
+name is reserved for response filtering to avoid conflicts with business parameters.
+For example:
+
+```json
+{
+  "name": "quote",
+  "arguments": {
+    "symbols": ["AAPL.US", "MSFT.US"],
+    "_jq": "map({symbol, last_done})"
+  }
+}
+```
+
+Use `.data[:5]` to take the first five entries of a `data` array,
+`.data | map(select(.price > 10))` to select rows, or `{total: .total}` to
+project fields. Expressions use the embedded [jaq](https://github.com/01mf02/jaq)
+engine's jq-compatible syntax; no separate `jq` executable is needed.
+
+- Omit `_jq` (or pass `null`) to preserve the original response.
+- One output value is returned directly, multiple values as an array, and no
+  values as `[]`. Scalars and arrays are JSON text; objects also appear in
+  `structuredContent`, containing only the filtered fields.
+- Plain text responses are available as JSON strings. Multiple content blocks
+  without structured content are available as an array.
+- Tool errors and permission/no-data explanations remain unfiltered.
+- Empty, invalid, or non-string expressions are rejected before the tool runs.
+  If filtering fails at runtime, the response explicitly says the tool already
+  executed. Do not automatically retry writes such as placing an order.
+- Environment access, filesystem imports, and logging filters are unavailable.
+  Output is limited to 10,000 values and 8 MiB; exceeding a limit returns an
+  error rather than a partial result.
+
+Because filters can change the response shape, tools do not advertise a fixed
+`outputSchema`. Original typed schemas remain available through `resources/list`
+and `resources/read` at `lb://tools/{tool-name}/output-schema` for schema-backed tools.
 
 ## Connect your own client
 

--- a/src/tools/jq.rs
+++ b/src/tools/jq.rs
@@ -12,17 +12,18 @@ use rmcp::{
 use serde_json::Value;
 
 type Filter = jaq_core::Filter<data::JustLut<Val>>;
+pub(super) const INSTRUCTIONS: &str = "All tools accept optional _jq to filter response JSON, e.g. .data | map({symbol}). Omit for full output. One result is returned directly, multiple as an array, none as []. Errors remain unfiltered.";
 const MAX_RESULTS: usize = 10_000;
 const MAX_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
 
 pub(super) fn describe(tool: &mut Tool) {
     let schema = std::sync::Arc::make_mut(&mut tool.input_schema);
-    schema.entry("properties").or_insert_with(|| serde_json::json!({}))
-        .as_object_mut().expect("tool properties must be an object")
-        .insert("_jq".into(), serde_json::json!({
-            "type": "string",
-            "description": "Optional jq filter on response JSON, e.g. .data | map({symbol}). Omit for full output."
-        }));
+    schema
+        .entry("properties")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .expect("tool properties must be an object")
+        .insert("_jq".into(), serde_json::json!({"type": "string"}));
     // A jq projection may return any JSON value. A fixed object schema would
     // reject valid filtered results. Full unfiltered schemas remain resources.
     tool.output_schema = None;
@@ -339,7 +340,10 @@ mod tests {
             }});
             writer.write_all(format!("{initialize}\n").as_bytes()).await.unwrap();
             reader.read_line(&mut line).await.unwrap();
-            assert!(serde_json::from_str::<Value>(&line).unwrap().get("result").is_some());
+            let init: Value = serde_json::from_str(&line).unwrap();
+            let instructions = init["result"]["instructions"].as_str().unwrap();
+            assert_eq!(instructions.matches("_jq").count(), 1);
+            assert!(instructions.contains("map({symbol})"));
             writer.write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n").await.unwrap();
             for (id, jq, expected) in [(2, ". | {kind: type}", json!({"kind":"string"})), (3, "empty", json!([]))] {
                 let call = json!({"jsonrpc":"2.0","id":id,"method":"tools/call","params":{"name":"now","arguments":{"_jq":jq}}});

--- a/src/tools/jq.rs
+++ b/src/tools/jq.rs
@@ -1,0 +1,365 @@
+//! Common response projection for every MCP tool. Keep jq out of business
+//! parameters: it controls only the response, never an upstream request.
+use jaq_core::{
+    Ctx, Vars, data,
+    load::{Arena, File, Loader},
+};
+use jaq_json::Val;
+use rmcp::{
+    ErrorData as McpError,
+    model::{CallToolRequestParams, CallToolResult, Content, Tool},
+};
+use serde_json::Value;
+
+type Filter = jaq_core::Filter<data::JustLut<Val>>;
+const MAX_RESULTS: usize = 10_000;
+const MAX_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
+
+pub(super) fn describe(tool: &mut Tool) {
+    let schema = std::sync::Arc::make_mut(&mut tool.input_schema);
+    schema.entry("properties").or_insert_with(|| serde_json::json!({}))
+        .as_object_mut().expect("tool properties must be an object")
+        .insert("_jq".into(), serde_json::json!({
+            "type": "string",
+            "description": "Optional jq expression applied to the returned JSON, e.g. .data | map({symbol}). Omit for full output. One result is returned directly; multiple results as an array; no results as []. Errors remain unfiltered. Original response schemas: lb://tools/{tool-name}/output-schema."
+        }));
+    // A jq projection may return any JSON value. A fixed object schema would
+    // reject valid filtered results. Full unfiltered schemas remain resources.
+    tool.output_schema = None;
+}
+
+fn compile(code: &str) -> Result<Filter, McpError> {
+    if code.trim().is_empty() {
+        return Err(McpError::invalid_params(
+            "_jq must be a non-empty expression",
+            None,
+        ));
+    }
+    let arena = Arena::default();
+    // Loader::new rejects imports/includes; do not give filters filesystem access.
+    let modules = Loader::new(
+        jaq_core::defs()
+            .chain(jaq_std::defs().filter(|def| def.name != "debug"))
+            .chain(jaq_json::defs()),
+    )
+    .load(&arena, File { code, path: () })
+    .map_err(|errors| {
+        McpError::invalid_params(format!("Invalid _jq expression: {errors:?}"), None)
+    })?;
+    let funs = jaq_core::funs()
+        .chain(jaq_std::funs())
+        .chain(jaq_json::funs())
+        // Server environment contains credentials. Logging would also allow
+        // queries to write upstream account data into server logs.
+        .filter(|(name, _, _)| !matches!(*name, "env" | "debug" | "debug_empty" | "stderr"));
+    jaq_core::Compiler::default()
+        .with_funs(funs)
+        .compile(modules)
+        .map_err(|errors| {
+            McpError::invalid_params(format!("Invalid _jq expression: {errors:?}"), None)
+        })
+}
+
+pub(super) async fn call<F, Fut>(
+    mut request: CallToolRequestParams,
+    invoke: F,
+) -> Result<CallToolResult, McpError>
+where
+    F: FnOnce(CallToolRequestParams) -> Fut,
+    Fut: std::future::Future<Output = Result<CallToolResult, McpError>>,
+{
+    let code = request
+        .arguments
+        .as_mut()
+        .and_then(|args| args.remove("_jq"));
+    let code = match code {
+        None | Some(Value::Null) => return invoke(request).await,
+        Some(Value::String(code)) => code,
+        Some(_) => {
+            return Ok(super::tool_error(
+                &request.name,
+                &McpError::invalid_params("_jq must be a string", None),
+            ));
+        }
+    };
+    // Compile before any tool execution, particularly before trade writes.
+    let filter = match compile(&code) {
+        Ok(filter) => filter,
+        Err(error) => return Ok(super::tool_error(&request.name, &error)),
+    };
+    let result = invoke(request).await?;
+    if result.is_error == Some(true) || is_error_envelope(&result) {
+        return Ok(result);
+    }
+    let filtered = tokio::task::spawn_blocking(move || apply(filter, result)).await;
+    Ok(match filtered {
+        Ok(Ok(result)) => result,
+        Ok(Err(message)) => filter_error(&message),
+        Err(_) => filter_error("filter worker failed"),
+    })
+}
+
+fn is_error_envelope(result: &CallToolResult) -> bool {
+    // Terminal permission/no-data errors deliberately use isError:false and
+    // schema-shaped placeholder structured content. Preserve their explanation.
+    result
+        .content
+        .iter()
+        .filter_map(|content| content.as_text())
+        .any(|text| {
+            serde_json::from_str::<Value>(&text.text)
+                .ok()
+                .is_some_and(|value| {
+                    value.get("error_code").is_some() && value.get("recoverable").is_some()
+                })
+        })
+}
+
+fn filter_error(message: &str) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(serde_json::json!({
+        "error_code": "jq_filter_error",
+        "message": format!("_jq response filtering failed: {message}. The tool has already executed."),
+        "recoverable": "none",
+        "hint": "Do not automatically retry a write operation; verify its outcome first. For read-only tools, correct _jq and retry.",
+        "data": null
+    }).to_string())])
+}
+
+fn apply(filter: Filter, mut result: CallToolResult) -> Result<CallToolResult, String> {
+    let input = result.structured_content.take().unwrap_or_else(|| {
+        let mut values: Vec<Value> = result
+            .content
+            .iter()
+            .map(|content| {
+                if let Some(text) = content.as_text() {
+                    serde_json::from_str(&text.text)
+                        .unwrap_or_else(|_| Value::String(text.text.clone()))
+                } else {
+                    serde_json::to_value(content).expect("MCP content must serialize")
+                }
+            })
+            .collect();
+        if values.len() == 1 {
+            values.pop().unwrap()
+        } else {
+            Value::Array(values)
+        }
+    });
+    let input: Val = serde_json::from_value(input).map_err(|error| error.to_string())?;
+    let ctx = Ctx::<data::JustLut<Val>>::new(&filter.lut, Vars::new([]));
+    let mut values = Vec::new();
+    let mut bytes = 0;
+    for value in filter.id.run((ctx, input)).map(jaq_core::unwrap_valr) {
+        let value = value.map_err(|error| error.to_string())?.to_string();
+        bytes += value.len();
+        if values.len() >= MAX_RESULTS || bytes > MAX_OUTPUT_BYTES {
+            return Err(
+                "output limit exceeded (10,000 results or 8 MiB); narrow the _jq expression".into(),
+            );
+        }
+        values.push(serde_json::from_str::<Value>(&value).map_err(|error| error.to_string())?);
+    }
+    let value = if values.len() == 1 {
+        values.pop().unwrap()
+    } else {
+        Value::Array(values)
+    };
+    result.content = vec![Content::text(value.to_string())];
+    result.structured_content = value.is_object().then_some(value);
+    Ok(result)
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn request(jq: serde_json::Value) -> CallToolRequestParams {
+        CallToolRequestParams::new("test").with_arguments(
+            json!({"symbol":"AAPL.US", "jq":"business argument", "_jq":jq})
+                .as_object()
+                .unwrap()
+                .clone(),
+        )
+    }
+
+    async fn filtered(code: &str, value: serde_json::Value) -> CallToolResult {
+        call(request(json!(code)), |request| async move {
+            assert_eq!(
+                request.arguments.unwrap(),
+                json!({"symbol":"AAPL.US", "jq":"business argument"})
+                    .as_object()
+                    .unwrap()
+                    .clone()
+            );
+            Ok(super::super::tool_result(value.to_string()))
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn projects_and_selects_from_the_complete_json_payload() {
+        let result = filtered(
+            ".data | map(select(.price > 10) | {symbol})",
+            json!({"data":[{"symbol":"A", "price":5},{"symbol":"B", "price":20}], "total":2}),
+        )
+        .await;
+        assert_eq!(
+            result.content[0].as_text().unwrap().text,
+            r#"[{"symbol":"B"}]"#
+        );
+        assert!(result.structured_content.is_none());
+    }
+
+    #[tokio::test]
+    async fn normalizes_streams_and_keeps_structured_content_in_sync() {
+        for (code, expected) in [
+            ("{chosen: .a}", json!({"chosen":1})),
+            (".a", json!(1)),
+            (".a, .b", json!([1, 2])),
+            ("empty", json!([])),
+            (".missing", json!(null)),
+            ("false", json!(false)),
+            (r#""hello""#, json!("hello")),
+        ] {
+            let result = filtered(code, json!({"a":1,"b":2})).await;
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(
+                    &result.content[0].as_text().unwrap().text
+                )
+                .unwrap(),
+                expected,
+                "{code}"
+            );
+            assert_eq!(
+                result.structured_content,
+                expected.is_object().then_some(expected)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_filters_never_execute_the_tool() {
+        for code in [
+            json!(42),
+            json!(""),
+            json!("   "),
+            json!(".["),
+            json!("unknown_function"),
+            json!("env"),
+            json!("$ENV"),
+            json!("debug"),
+            json!("debug_empty"),
+            json!("include \"/etc/passwd\"; ."),
+        ] {
+            let result = call(request(code.clone()), |_| async {
+                panic!("tool must not execute for {code}")
+            })
+            .await
+            .unwrap();
+            assert_eq!(result.is_error, Some(true), "{code}");
+            assert!(result.content[0].as_text().unwrap().text.contains("_jq"));
+        }
+    }
+
+    #[tokio::test]
+    async fn absent_and_null_filters_preserve_results() {
+        let original = super::super::tool_result(r#"{ "a": 1 }"#.into());
+        for arguments in [None, Some(json!({"_jq":null}).as_object().unwrap().clone())] {
+            let mut request = CallToolRequestParams::new("test");
+            request.arguments = arguments;
+            let result = call(request, |_| async { Ok(original.clone()) })
+                .await
+                .unwrap();
+            assert_eq!(result, original);
+        }
+    }
+
+    #[tokio::test]
+    async fn errors_and_permission_placeholders_are_not_filtered() {
+        let error =
+            super::super::tool_error("depth", &McpError::invalid_params("bad symbol", None));
+        let terminal =
+            super::super::tool_error("depth", &McpError::internal_error("no quote access", None));
+        for original in [error, terminal] {
+            let result = call(request(json!("empty")), |_| async { Ok(original.clone()) })
+                .await
+                .unwrap();
+            assert_eq!(result, original);
+        }
+    }
+
+    #[tokio::test]
+    async fn runtime_failure_does_not_return_unfiltered_data_or_retry() {
+        let result = filtered(".a[]", json!({"a":1,"secret":"not requested"})).await;
+        assert_eq!(result.is_error, Some(true));
+        let text = &result.content[0].as_text().unwrap().text;
+        assert!(text.contains("_jq"));
+        assert!(text.contains("already executed"));
+        assert!(!text.contains("not requested"));
+        assert!(result.structured_content.is_none());
+    }
+
+    #[tokio::test]
+    async fn json_text_and_plain_text_are_supported() {
+        let result = call(request(json!("ascii_upcase")), |_| async {
+            Ok(CallToolResult::success(vec![Content::text("hello")]))
+        })
+        .await
+        .unwrap();
+        assert_eq!(result.content[0].as_text().unwrap().text, r#""HELLO""#);
+    }
+    #[tokio::test]
+    async fn excessive_output_is_an_error_without_partial_results() {
+        let result = filtered("range(0; 10001)", json!(null)).await;
+        assert_eq!(result.is_error, Some(true));
+        assert!(
+            result.content[0]
+                .as_text()
+                .unwrap()
+                .text
+                .contains("output limit")
+        );
+        assert!(result.structured_content.is_none());
+    }
+
+    #[tokio::test]
+    async fn real_mcp_dispatch_filters_a_tool_without_business_arguments() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            let (client, server) = tokio::io::duplex(64 * 1024);
+            let server_task = tokio::spawn(async move {
+                rmcp::serve_server(super::super::Longbridge, server).await.unwrap().waiting().await.unwrap();
+            });
+            let (reader, mut writer) = tokio::io::split(client);
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            let initialize = json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+                "protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"jq-test","version":"1"}
+            }});
+            writer.write_all(format!("{initialize}\n").as_bytes()).await.unwrap();
+            reader.read_line(&mut line).await.unwrap();
+            assert!(serde_json::from_str::<Value>(&line).unwrap().get("result").is_some());
+            writer.write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n").await.unwrap();
+            for (id, jq, expected) in [(2, ". | {kind: type}", json!({"kind":"string"})), (3, "empty", json!([]))] {
+                let call = json!({"jsonrpc":"2.0","id":id,"method":"tools/call","params":{"name":"now","arguments":{"_jq":jq}}});
+                writer.write_all(format!("{call}\n").as_bytes()).await.unwrap();
+                line.clear();
+                reader.read_line(&mut line).await.unwrap();
+                let response: Value = serde_json::from_str(&line).unwrap();
+                assert_eq!(response["id"], id);
+                let result = &response["result"];
+                assert_eq!(result["isError"], false, "{response}");
+                assert_eq!(serde_json::from_str::<Value>(result["content"][0]["text"].as_str().unwrap()).unwrap(), expected);
+                if expected.is_object() {
+                    assert_eq!(result["structuredContent"], expected);
+                } else {
+                    assert!(result.get("structuredContent").is_none());
+                }
+            }
+            drop(writer);
+            drop(reader);
+            server_task.await.unwrap();
+        }).await.expect("MCP test timed out");
+    }
+}

--- a/src/tools/jq.rs
+++ b/src/tools/jq.rs
@@ -12,7 +12,7 @@ use rmcp::{
 use serde_json::Value;
 
 type Filter = jaq_core::Filter<data::JustLut<Val>>;
-pub(super) const INSTRUCTIONS: &str = "All tools accept _jq to filter JSON, e.g. .data | map({symbol}). Omit for full output. Multiple results form an array; errors stay unchanged.";
+pub(super) const INSTRUCTIONS: &str = "Optional _jq filters response JSON, e.g. .data[:5].";
 const MAX_RESULTS: usize = 10_000;
 const MAX_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
 
@@ -343,7 +343,6 @@ mod tests {
             let init: Value = serde_json::from_str(&line).unwrap();
             let instructions = init["result"]["instructions"].as_str().unwrap();
             assert_eq!(instructions.matches("_jq").count(), 1);
-            assert!(instructions.contains("map({symbol})"));
             writer.write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n").await.unwrap();
             for (id, jq, expected) in [(2, ". | {kind: type}", json!({"kind":"string"})), (3, "empty", json!([]))] {
                 let call = json!({"jsonrpc":"2.0","id":id,"method":"tools/call","params":{"name":"now","arguments":{"_jq":jq}}});

--- a/src/tools/jq.rs
+++ b/src/tools/jq.rs
@@ -21,7 +21,7 @@ pub(super) fn describe(tool: &mut Tool) {
         .as_object_mut().expect("tool properties must be an object")
         .insert("_jq".into(), serde_json::json!({
             "type": "string",
-            "description": "Optional jq expression applied to the returned JSON, e.g. .data | map({symbol}). Omit for full output. One result is returned directly; multiple results as an array; no results as []. Errors remain unfiltered. Original response schemas: lb://tools/{tool-name}/output-schema."
+            "description": "Optional jq filter on response JSON, e.g. .data | map({symbol}). Omit for full output."
         }));
     // A jq projection may return any JSON value. A fixed object schema would
     // reject valid filtered results. Full unfiltered schemas remain resources.

--- a/src/tools/jq.rs
+++ b/src/tools/jq.rs
@@ -12,7 +12,7 @@ use rmcp::{
 use serde_json::Value;
 
 type Filter = jaq_core::Filter<data::JustLut<Val>>;
-pub(super) const INSTRUCTIONS: &str = "Optional _jq filters response JSON, e.g. .data[:5].";
+pub(super) const INSTRUCTIONS: &str = "All tools accept optional _jq to filter response JSON, e.g. .data | map({symbol}). Omit it for the full response.";
 const MAX_RESULTS: usize = 10_000;
 const MAX_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
 

--- a/src/tools/jq.rs
+++ b/src/tools/jq.rs
@@ -12,7 +12,7 @@ use rmcp::{
 use serde_json::Value;
 
 type Filter = jaq_core::Filter<data::JustLut<Val>>;
-pub(super) const INSTRUCTIONS: &str = "All tools accept optional _jq to filter response JSON, e.g. .data | map({symbol}). Omit it for the full response.";
+pub(super) const INSTRUCTIONS: &str = "All tools accept optional `_jq`, a filter expression using jq CLI syntax, e.g. .data | map({symbol}). Omit it for the full JSON response.";
 const MAX_RESULTS: usize = 10_000;
 const MAX_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
 

--- a/src/tools/jq.rs
+++ b/src/tools/jq.rs
@@ -12,19 +12,7 @@ use rmcp::{
 use serde_json::Value;
 
 type Filter = jaq_core::Filter<data::JustLut<Val>>;
-pub(super) const INSTRUCTIONS: &str = concat!(
-    "All tools accept optional _jq (string), a jq-compatible expression applied to the returned JSON ",
-    "after the tool executes. It filters the response, not the upstream query or business arguments. ",
-    "Use it to select fields, filter rows, or summarize data. Match the expression to the response shape: ",
-    "map({symbol}) for a root array; .data | map({symbol}) for a data array; ",
-    ".data | map(select(.price > 10)) to filter rows; .data | length to count them. ",
-    "Omit the parameter or pass null for the full response. One output value is returned directly, ",
-    "multiple values as an array, and no values as []. Objects also populate structuredContent; ",
-    "arrays and scalars are returned as JSON text. Tool errors and permission/no-data explanations ",
-    "remain unfiltered. Invalid expressions are rejected before execution; runtime filtering errors ",
-    "mean the tool has already executed, so do not automatically retry writes. ",
-    "Original typed response schemas are available at lb://tools/{tool-name}/output-schema for schema-backed tools."
-);
+pub(super) const INSTRUCTIONS: &str = "All tools accept _jq to filter JSON, e.g. .data | map({symbol}). Omit for full output. Multiple results form an array; errors stay unchanged.";
 const MAX_RESULTS: usize = 10_000;
 const MAX_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
 

--- a/src/tools/jq.rs
+++ b/src/tools/jq.rs
@@ -12,7 +12,19 @@ use rmcp::{
 use serde_json::Value;
 
 type Filter = jaq_core::Filter<data::JustLut<Val>>;
-pub(super) const INSTRUCTIONS: &str = "All tools accept optional _jq to filter response JSON, e.g. .data | map({symbol}). Omit for full output. One result is returned directly, multiple as an array, none as []. Errors remain unfiltered.";
+pub(super) const INSTRUCTIONS: &str = concat!(
+    "All tools accept optional _jq (string), a jq-compatible expression applied to the returned JSON ",
+    "after the tool executes. It filters the response, not the upstream query or business arguments. ",
+    "Use it to select fields, filter rows, or summarize data. Match the expression to the response shape: ",
+    "map({symbol}) for a root array; .data | map({symbol}) for a data array; ",
+    ".data | map(select(.price > 10)) to filter rows; .data | length to count them. ",
+    "Omit the parameter or pass null for the full response. One output value is returned directly, ",
+    "multiple values as an array, and no values as []. Objects also populate structuredContent; ",
+    "arrays and scalars are returned as JSON text. Tool errors and permission/no-data explanations ",
+    "remain unfiltered. Invalid expressions are rejected before execution; runtime filtering errors ",
+    "mean the tool has already executed, so do not automatically retry writes. ",
+    "Original typed response schemas are available at lb://tools/{tool-name}/output-schema for schema-backed tools."
+);
 const MAX_RESULTS: usize = 10_000;
 const MAX_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -5298,9 +5298,8 @@ impl ServerHandler for Longbridge {
 
     /// `initialize`, with endpoint-aware `instructions`.
     ///
-    /// Main endpoint: byte-for-byte the macro default (`get_info`), so the
-    /// pre-feature `initialize` response is unchanged. Unauthenticated
-    /// `/agent` sessions instead get instructions that explicitly frame the
+    /// Each endpoint gets shared response-filtering guidance. Unauthenticated
+    /// `/agent` sessions also get instructions that explicitly frame the
     /// endpoint as a temporary authorization channel, so AI clients do not
     /// mistake `<host>/agent` for the Longbridge MCP service address itself.
     async fn initialize(
@@ -5338,6 +5337,13 @@ impl ServerHandler for Longbridge {
                 }
             });
         }
+        // Shared guidance belongs in initialize once, after endpoint-specific
+        // instructions are selected, rather than in every tool's input schema.
+        info.instructions = Some(format!(
+            "{}\n\n{}",
+            info.instructions.as_deref().unwrap_or_default(),
+            jq::INSTRUCTIONS
+        ));
         Ok(info)
     }
 
@@ -7052,6 +7058,11 @@ mod jq_catalog_tests {
                 tool.output_schema.is_none(),
                 "{} cannot constrain arbitrary jq output",
                 tool.name
+            );
+            assert!(
+                tool.input_schema["properties"]["_jq"]
+                    .get("description")
+                    .is_none()
             );
             let lookup = Longbridge.get_tool(&tool.name).unwrap();
             assert_eq!(lookup.input_schema, tool.input_schema);

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -461,6 +461,7 @@ mod dca;
 mod fundamental;
 mod grid;
 mod ipo;
+mod jq;
 mod macrodata;
 mod market;
 mod output;
@@ -574,9 +575,8 @@ const TERMINAL_OBJECT_ROOTED: &[&str] = &["depth", "capital_distribution"];
 pub struct Longbridge;
 
 pub(crate) fn tool_result(json: String) -> CallToolResult {
-    // MCP spec §tool-result: a tool that declares an `outputSchema` MUST
-    // return `structuredContent`. We populate it for every response so the
-    // invariant holds regardless of which tools gain a schema in the future.
+    // Keep object responses available to clients as structured content.
+    // Optional jq projection replaces both representations together.
     let structured = serde_json::from_str::<serde_json::Value>(&json)
         .ok()
         .filter(serde_json::Value::is_object);
@@ -1088,8 +1088,8 @@ fn all_tools_cached() -> &'static [rmcp::model::Tool] {
             .iter()
             .cloned()
             .map(|mut tool| {
-                compact_output_schema_for_tool_list(&mut tool);
                 compact_tool_description_for_tool_list(&mut tool);
+                jq::describe(&mut tool);
                 tool
             })
             .collect()
@@ -1373,8 +1373,8 @@ pub fn v2_list_tools() -> Vec<rmcp::model::Tool> {
 
 /// Returns the tool router, built once and cached for the lifetime of the process.
 ///
-/// Shared by `ServerHandler::call_tool` (dispatch) and `ServerHandler::get_tool`
-/// (task-support validation, called by rmcp on every `CallToolRequest`).
+/// Used for dispatch and as the source of the cached public tool descriptors.
+/// `get_tool` returns those public descriptors, including the common _jq input.
 fn cached_router() -> &'static rmcp::handler::server::router::tool::ToolRouter<Longbridge> {
     use rmcp::handler::server::router::tool::ToolRouter;
     static ROUTER: std::sync::OnceLock<ToolRouter<Longbridge>> = std::sync::OnceLock::new();
@@ -1408,54 +1408,6 @@ fn strip_null_from_type_arrays(value: &mut serde_json::Value) {
             }
         }
         _ => {}
-    }
-}
-
-/// Recursively remove documentation-only JSON Schema keys from tool descriptors.
-/// Validation keywords stay in `tools/list`; verbose descriptions remain
-/// available through `lb://tools/{tool}/output-schema` resources.
-fn strip_schema_documentation_keys(value: &mut serde_json::Value) {
-    match value {
-        serde_json::Value::Object(map) => {
-            map.remove("$schema");
-            map.remove("title");
-            map.remove("description");
-            for (key, v) in map.iter_mut() {
-                // The values of these keywords are maps keyed by *names*
-                // (property / definition names), not schema objects — a
-                // property legitimately named "title" or "description" must
-                // not be stripped. Recurse into each named child schema
-                // directly instead.
-                if matches!(
-                    key.as_str(),
-                    "properties" | "patternProperties" | "$defs" | "definitions"
-                ) && let serde_json::Value::Object(children) = v
-                {
-                    for child in children.values_mut() {
-                        strip_schema_documentation_keys(child);
-                    }
-                    continue;
-                }
-                strip_schema_documentation_keys(v);
-            }
-        }
-        serde_json::Value::Array(arr) => {
-            for v in arr.iter_mut() {
-                strip_schema_documentation_keys(v);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn compact_output_schema_for_tool_list(tool: &mut rmcp::model::Tool) {
-    let Some(schema) = tool.output_schema.as_ref() else {
-        return;
-    };
-    let mut schema = serde_json::Value::Object(schema.as_ref().clone());
-    strip_schema_documentation_keys(&mut schema);
-    if let serde_json::Value::Object(obj) = schema {
-        tool.output_schema = Some(std::sync::Arc::new(obj));
     }
 }
 
@@ -1579,7 +1531,7 @@ fn output_schema_resources() -> Vec<Resource> {
             let mut raw = RawResource::new(uri, format!("{}.output_schema", tool.name))
                 .with_title(format!("{title} Output Schema"))
                 .with_description(format!(
-                    "Full JSON Schema output contract for the `{}` tool.",
+                    "Full JSON Schema for the `{}` tool before optional jq filtering.",
                     tool.name
                 ))
                 .with_mime_type(OUTPUT_SCHEMA_RESOURCE_MIME);
@@ -5404,7 +5356,10 @@ impl ServerHandler for Longbridge {
     ///   self-authorize. After `authenticate` succeeds and the client starts
     ///   sending the returned token, the next `tools/list` returns the full set.
     fn get_tool(&self, name: &str) -> Option<rmcp::model::Tool> {
-        cached_router().get(name).cloned()
+        all_tools_cached()
+            .iter()
+            .find(|tool| tool.name == name)
+            .cloned()
     }
 
     async fn call_tool(
@@ -5454,10 +5409,13 @@ impl ServerHandler for Longbridge {
         // same spawned task, so a `CURRENT_CLIENT` scope set here is visible to
         // `record_tool_call`; one set in the middleware would not be.
         let client = client_bucket_from_context(&context);
-        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
-        crate::metrics::CURRENT_CLIENT
-            .scope(client, cached_router().call(tcc))
-            .await
+        jq::call(request, |request| async move {
+            let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+            crate::metrics::CURRENT_CLIENT
+                .scope(client, cached_router().call(tcc))
+                .await
+        })
+        .await
     }
 
     async fn list_tools(
@@ -5508,37 +5466,6 @@ impl ServerHandler for Longbridge {
 
 #[cfg(test)]
 mod tests {
-    use super::strip_schema_documentation_keys;
-
-    #[test]
-    fn schema_compactor_keeps_properties_named_title_or_description() {
-        // "title"/"description" are documentation keywords on a *schema*
-        // object, but inside a `properties` map they are property *names* —
-        // stripping them there deletes real fields (news_detail's headline
-        // fields) from the advertised outputSchema.
-        let mut schema = serde_json::json!({
-            "title": "NewsDetailResponse",
-            "description": "doc",
-            "type": "object",
-            "properties": {
-                "title": { "type": "string", "description": "Title." },
-                "description": { "type": "string", "description": "Excerpt." },
-                "body": { "type": "string", "description": "Markdown." }
-            }
-        });
-        strip_schema_documentation_keys(&mut schema);
-        let props = schema["properties"].as_object().unwrap();
-        assert!(props.contains_key("title"), "property name must survive");
-        assert!(
-            props.contains_key("description"),
-            "property name must survive"
-        );
-        // Schema-level annotations are stripped, including on child schemas.
-        assert!(schema.get("title").is_none());
-        assert!(schema.get("description").is_none());
-        assert!(props["body"].get("description").is_none());
-    }
-
     use axum::http::{HeaderMap, HeaderName, HeaderValue};
 
     use super::collect_headers;
@@ -5954,7 +5881,7 @@ mod tests {
         // schema must impose no required fields — every field optional and no
         // `deny_unknown_fields` — so BOTH the generic and the US variant conform.
         // Otherwise the US structuredContent would violate the declared schema.
-        let tools = crate::tools::list_tools();
+        let tools = super::all_tools_full_cached();
         for name in ["dividend", "consensus", "valuation", "company"] {
             let tool = tools
                 .iter()
@@ -6158,29 +6085,6 @@ mod quote_cmd_tests {
     }
 
     #[test]
-    fn tool_list_output_schemas_are_compact_validation_contracts() {
-        let depth = super::list_tools()
-            .into_iter()
-            .find(|tool| tool.name == "depth")
-            .expect("depth tool must be registered");
-        let output_schema = depth
-            .output_schema
-            .expect("depth tool must keep an outputSchema in tools/list");
-        let output_schema = serde_json::Value::Object(output_schema.as_ref().clone());
-
-        assert!(
-            output_schema.get("properties").is_some(),
-            "compact outputSchema must keep validation structure"
-        );
-        for stripped_key in ["$schema", "title", "description"] {
-            assert!(
-                !schema_contains_key(&output_schema, stripped_key),
-                "`{stripped_key}` should move out of the tools/list outputSchema"
-            );
-        }
-    }
-
-    #[test]
     fn tool_list_output_schema_tools_omit_redundant_return_field_lists() {
         let screener_search = super::list_tools()
             .into_iter()
@@ -6188,7 +6092,7 @@ mod quote_cmd_tests {
             .expect("screener_search tool must be registered");
 
         assert!(
-            screener_search.output_schema.is_some(),
+            super::output_schema_map().contains_key("screener_search"),
             "fixture must cover a typed-output tool"
         );
         assert!(
@@ -6217,8 +6121,8 @@ mod quote_cmd_tests {
             assert_eq!(annotations.destructive_hint, Some(false));
             assert_eq!(annotations.open_world_hint, Some(true));
             assert!(
-                tool.output_schema.is_some(),
-                "{name} must declare an outputSchema"
+                super::output_schema_map().contains_key(name),
+                "{name} must provide an unfiltered output schema resource"
             );
         }
     }
@@ -6251,8 +6155,8 @@ mod quote_cmd_tests {
             assert_eq!(annotations.destructive_hint, Some(false));
             assert_eq!(annotations.open_world_hint, Some(true));
             assert!(
-                tool.output_schema.is_some(),
-                "{name} must declare an outputSchema"
+                super::output_schema_map().contains_key(name),
+                "{name} must provide an unfiltered output schema resource"
             );
         }
     }
@@ -6261,7 +6165,7 @@ mod quote_cmd_tests {
     fn tool_metadata_lint_keeps_typed_output_descriptions_compact() {
         let offenders: Vec<String> = super::list_tools()
             .into_iter()
-            .filter(|tool| tool.output_schema.is_some())
+            .filter(|tool| super::output_schema_map().contains_key(tool.name.as_ref()))
             .filter_map(|tool| {
                 let description = tool.description.as_deref().unwrap_or_default();
                 let lower = description.to_ascii_lowercase();
@@ -7121,6 +7025,37 @@ mod tool_error_tests {
         let map = super::output_schema_map();
         for name in super::TERMINAL_OBJECT_ROOTED {
             assert!(map.contains_key(*name), "schema map missing {name}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod jq_catalog_tests {
+    use super::*;
+
+    #[test]
+    fn jq_is_optional_on_every_public_tool_and_lookup() {
+        for tool in list_tools() {
+            assert_eq!(
+                tool.input_schema["properties"]["_jq"]["type"], "string",
+                "{}",
+                tool.name
+            );
+            assert!(
+                !tool
+                    .input_schema
+                    .get("required")
+                    .and_then(serde_json::Value::as_array)
+                    .is_some_and(|fields| fields.iter().any(|field| field == "_jq"))
+            );
+            assert!(
+                tool.output_schema.is_none(),
+                "{} cannot constrain arbitrary jq output",
+                tool.name
+            );
+            let lookup = Longbridge.get_tool(&tool.name).unwrap();
+            assert_eq!(lookup.input_schema, tool.input_schema);
+            assert!(lookup.output_schema.is_none());
         }
     }
 }

--- a/src/tools/trade.rs
+++ b/src/tools/trade.rs
@@ -1213,10 +1213,9 @@ mod execute_gate_tests {
 
     #[test]
     fn gated_output_schemas_admit_the_dry_run_shape() {
-        // MCP requires every response from a tool with an `outputSchema` to
-        // validate against it. The dry run has no order ID, so `order_id` must
-        // not be required — otherwise the safe path returns an invalid result.
-        let tools = crate::tools::list_tools();
+        // The original response schema remains available as a resource even
+        // when jq projections have a different shape. It must admit dry runs.
+        let tools = crate::tools::all_tools_full_cached();
         for name in ["submit_order", "grid_submit"] {
             let schema = tools
                 .iter()


### PR DESCRIPTION
## Summary

All MCP tools now accept an optional `_jq` expression to return only the requested data. For example, calling `quote` with `_jq: "map({symbol, last_done})"` returns those fields instead of the full quote payload. Usage guidance appears once in global `initialize.instructions` on every endpoint; tool schemas contain only the optional `_jq` name and string type to avoid repeated descriptions. The shared dispatcher strips `_jq` before passing business arguments to the tool and uses embedded jaq, without requiring an external executable.

Text and structured content reflect the same filtered result. Omitting `_jq` preserves existing responses; tool errors and permission/no-data explanations remain unfiltered. Invalid expressions fail before execution, while runtime filtering failures explicitly warn that the tool has already executed. Environment access, module loading, and logging filters are disabled, and output limits return errors rather than partial results.

Because projections can return arbitrary JSON shapes, public tool descriptors no longer advertise fixed `outputSchema` contracts. The original typed schemas remain available through the existing MCP schema resources. README examples document the parameter and result semantics.

## Test Plan

- `cargo +nightly fmt --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test` — 268 passed, 3 ignored.
- Coverage includes every tool's optional `_jq` schema, preservation of business arguments named `jq`, filtering and stream normalization, error handling, output limits, and real MCP dispatch to the parameterless `now` tool.

- Live verification against the built local HTTP MCP server: 14 checks passed across `/mcp`, `/v2`, and authenticated `/agent`, including real AAPL/MSFT static info and quotes. Static info projected to symbol/name matched the full response exactly (777 to 83 bytes). Verified object/array/scalar/empty results, invalid filters, runtime errors, and readable original schema resources.

- Verified global `_jq` instructions appear exactly once on `/mcp`, `/v2`, and unauthenticated `/agent`; every visible tool exposes only the parameter type, and endpoint-specific instructions remain intact.
