### PR TITLE
chore(ci): rename the canary Docker build to preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,11 +1,17 @@
-name: Canary Docker Build
+# Unreleased preview image, built on demand from the current branch.
+#
+# This is a release channel, not an environment: the image is byte-identical to
+# a release build and talks to production unless it is started with `--canary`.
+# Do not confuse it with that flag, which selects the Longbridge canary
+# upstream at runtime.
+name: Preview Docker Build
 
 on:
   workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}-canary
+  IMAGE_NAME: ${{ github.repository }}-preview
 
 jobs:
   docker:


### PR DESCRIPTION
## Why

`.github/workflows/canary.yml` builds an unreleased image from the current branch — a **release channel**, not an environment. It shares the Dockerfile with `release.yml` and passes no build arg, env, or feature flag, so its output is byte-identical to a release build and talks to production.

Since #145, `--canary` means something else entirely: the runtime switch that points the server at Longbridge's canary upstream (`*.longbridge.xyz`). Leaving both named canary invites the obvious misread:

```
docker run ghcr.io/longbridge/longbridge-mcp-canary     # named canary, talks to production
docker run ghcr.io/longbridge/longbridge-mcp --canary   # named production, talks to canary
```

## What changed

- `canary.yml` → `preview.yml`, `name: Canary Docker Build` → `Preview Docker Build`
- `IMAGE_NAME` suffix `-canary` → `-preview`
- A header comment stating this is a release channel, not an environment, so the distinction survives the next reader

Nothing else in the repo referenced the old workflow or image name (`grep` for `longbridge-mcp-canary` / `canary.yml` / `Canary Docker` returns only the workflow itself).

## Impact

The workflow is `workflow_dispatch`-only, so nothing breaks automatically. Anyone pulling `ghcr.io/longbridge/longbridge-mcp-canary` needs to switch to `-preview` after the next manual run; existing tags under the old image name stay where they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
