### PR TITLE
feat: trim redundant/empty fields from tool responses (token savings)

### DIFF
--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -107,6 +107,56 @@ pub(crate) fn round_decimals(value: &mut serde_json::Value, dp: u32) {
     }
 }
 
+/// Recursively strip non-significant trailing zeros from every plain decimal
+/// string in `value` (e.g. `"459962879.0000"` → `"459962879"`, `"4.50"` →
+/// `"4.5"`, `"0.0000"` → `"0"`).
+///
+/// This is lossless — it never rounds, only removes zeros that carry no value —
+/// so unlike [`round_decimals`] it is safe to apply blindly. Only a bare decimal
+/// (optional sign, digits, one `.`, digits) is touched; dates (`"2026.09.09"`),
+/// versions and ids are left alone. For passthrough tools whose upstream pads
+/// integer counts with a fake fractional part (e.g. share-count deltas stored as
+/// `"123.0000"`).
+pub(crate) fn strip_trailing_zeros(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for v in map.values_mut() {
+                strip_trailing_zeros(v);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                strip_trailing_zeros(v);
+            }
+        }
+        serde_json::Value::String(s) => {
+            if let Some(trimmed) = trimmed_decimal(s) {
+                *s = trimmed;
+            }
+        }
+        _ => {}
+    }
+}
+
+/// If `s` is a plain decimal string with trailing zeros in its fractional part,
+/// return the trimmed form; otherwise `None`. Requires exactly one `.` with
+/// digits on both sides, so multi-dot strings (dates, versions) are ignored.
+fn trimmed_decimal(s: &str) -> Option<String> {
+    let body = s.strip_prefix('-').unwrap_or(s);
+    let (int_part, frac_part) = body.split_once('.')?;
+    let is_digits = |p: &str| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit());
+    if !is_digits(int_part) || !is_digits(frac_part) || !frac_part.ends_with('0') {
+        return None;
+    }
+    let trimmed_frac = frac_part.trim_end_matches('0');
+    let sign = if s.starts_with('-') { "-" } else { "" };
+    Some(if trimmed_frac.is_empty() {
+        format!("{sign}{int_part}")
+    } else {
+        format!("{sign}{int_part}.{trimmed_frac}")
+    })
+}
+
 /// Rewrite `[st]TYPE/MARKET/CODE#Readable[/st]` cashtag markup to just
 /// `Readable` (the text after `#`, or the inner text when there is no `#`).
 /// Community posts wrap every ticker mention in this markup, which is pure
@@ -446,6 +496,31 @@ mod tests {
         assert_eq!(v["symbol"], "700.HK", "non-numeric: untouched");
         assert_eq!(v["date"], "2026-09-10", "date: untouched");
         assert_eq!(v["ts"], "1789007822", "integer: untouched");
+    }
+
+    #[test]
+    fn strip_trailing_zeros_is_lossless_and_skips_non_decimals() {
+        let mut v = serde_json::json!({
+            "shares": {"value": "459962879", "chg_1": "123.0000", "chg_5": "-45.0000"},
+            "ratio": "0.0505",
+            "padded": "4.50",
+            "zero": "0.0000",
+            "date": "2026.09.09",
+            "iso": "2026-09-10",
+            "symbol": "700.HK",
+            "int": "42"
+        });
+        strip_trailing_zeros(&mut v);
+        assert_eq!(v["shares"]["value"], "459962879", "integer untouched");
+        assert_eq!(v["shares"]["chg_1"], "123", "fake .0000 stripped");
+        assert_eq!(v["shares"]["chg_5"], "-45", "negative fake .0000 stripped");
+        assert_eq!(v["ratio"], "0.0505", "significant digits kept");
+        assert_eq!(v["padded"], "4.5", "trailing zero stripped");
+        assert_eq!(v["zero"], "0", "0.0000 becomes 0");
+        assert_eq!(v["date"], "2026.09.09", "multi-dot date untouched");
+        assert_eq!(v["iso"], "2026-09-10", "iso date untouched");
+        assert_eq!(v["symbol"], "700.HK", "ticker untouched");
+        assert_eq!(v["int"], "42", "plain integer untouched");
     }
 
     #[test]

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -71,6 +71,30 @@ pub(crate) fn strip_nulls(value: &mut serde_json::Value) {
     }
 }
 
+/// Recursively drop entries whose (snake_case) key is in `keys` from every
+/// object in `value`, at any depth and through arrays.
+///
+/// For passthrough tools that echo upstream fields with no analytic value:
+/// duplicates (`code` == `symbol` without suffix), derivable fields
+/// (`market`), constant flags (`delay`), and display assets (`icon`). Keys
+/// must be given in the post-transform snake_case form.
+pub(crate) fn drop_keys(value: &mut serde_json::Value, keys: &[&str]) {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.retain(|k, _| !keys.contains(&k.as_str()));
+            for v in map.values_mut() {
+                drop_keys(v, keys);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                drop_keys(v, keys);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Return `true` iff `s` matches the `<PREFIX>/<MARKET>/<CODE>` counter_id
 /// pattern used internally by Longbridge (e.g. `ST/US/AAPL`, `ETF/HK/2800`,
 /// `IX/HK/HSI`, `OP/US/AAPL270115C300000`). Used to distinguish dynamic map
@@ -313,6 +337,27 @@ mod tests {
         let mut v = serde_json::json!({"s": "", "arr": [], "n": 0, "gone": null});
         strip_nulls(&mut v);
         assert_eq!(v, serde_json::json!({"s": "", "arr": [], "n": 0}));
+    }
+
+    #[test]
+    fn drop_keys_removes_named_keys_recursively() {
+        let mut v = serde_json::json!({
+            "items": [
+                {"symbol": "9988.HK", "code": "09988", "market": "HK", "chg": "0.01"},
+                {"symbol": "700.HK", "code": "00700", "market": "HK", "chg": "0.02"}
+            ],
+            "market": "HK"
+        });
+        drop_keys(&mut v, &["code", "market"]);
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "items": [
+                    {"symbol": "9988.HK", "chg": "0.01"},
+                    {"symbol": "700.HK", "chg": "0.02"}
+                ]
+            })
+        );
     }
 
     #[test]

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -107,6 +107,60 @@ pub(crate) fn round_decimals(value: &mut serde_json::Value, dp: u32) {
     }
 }
 
+/// Rewrite `[st]TYPE/MARKET/CODE#Readable[/st]` cashtag markup to just
+/// `Readable` (the text after `#`, or the inner text when there is no `#`).
+/// Community posts wrap every ticker mention in this markup, which is pure
+/// noise to a model reading the prose.
+fn strip_cashtags(input: &str) -> String {
+    if !input.contains("[st]") {
+        return input.to_string();
+    }
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find("[st]") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + "[st]".len()..];
+        match after.find("[/st]") {
+            Some(end) => {
+                let inner = &after[..end];
+                let readable = inner.rsplit_once('#').map_or(inner, |(_, r)| r);
+                out.push_str(readable);
+                rest = &after[end + "[/st]".len()..];
+            }
+            None => {
+                out.push_str(&rest[start..]);
+                return out;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Apply [`strip_cashtags`] to every `field`-keyed string in `value`,
+/// recursively (through nested objects and arrays).
+pub(crate) fn strip_cashtags_in_field(value: &mut serde_json::Value, field: &str) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (k, v) in map.iter_mut() {
+                if k == field
+                    && let serde_json::Value::String(s) = v
+                {
+                    *s = strip_cashtags(s);
+                } else {
+                    strip_cashtags_in_field(v, field);
+                }
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                strip_cashtags_in_field(v, field);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Recursively drop entries whose (snake_case) key is in `keys` from every
 /// object in `value`, at any depth and through arrays.
 ///
@@ -392,6 +446,27 @@ mod tests {
         assert_eq!(v["symbol"], "700.HK", "non-numeric: untouched");
         assert_eq!(v["date"], "2026-09-10", "date: untouched");
         assert_eq!(v["ts"], "1789007822", "integer: untouched");
+    }
+
+    #[test]
+    fn strip_cashtags_in_field_keeps_readable_ticker() {
+        let mut v = serde_json::json!({
+            "items": [
+                {"description": "[st]ST/HK/700#TENCENT.HK[/st] CFO said prepaid 50bn"},
+                {"description": "no markup here"},
+                {"description": "[st]ST/US/BABA#Alibaba.US[/st][st]ST/HK/700#TENCENT.HK[/st] two tags"}
+            ]
+        });
+        strip_cashtags_in_field(&mut v, "description");
+        assert_eq!(
+            v["items"][0]["description"],
+            "TENCENT.HK CFO said prepaid 50bn"
+        );
+        assert_eq!(v["items"][1]["description"], "no markup here");
+        assert_eq!(
+            v["items"][2]["description"],
+            "Alibaba.USTENCENT.HK two tags"
+        );
     }
 
     #[test]

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -71,6 +71,30 @@ pub(crate) fn strip_nulls(value: &mut serde_json::Value) {
     }
 }
 
+/// Recursively drop object entries whose value is an empty string.
+///
+/// The sibling of [`strip_nulls`] for upstreams that signal "no value" with `""`
+/// rather than `null` (e.g. the `est_value`/`cmp` columns that only apply to a
+/// forecast row and are blank on an actuals row). To an AI consumer an absent
+/// key and an empty-string key both mean "no data", so removing them is
+/// lossless. Non-empty strings, and empty *arrays*/*objects*, are left intact.
+pub(crate) fn strip_empty_strings(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.retain(|_, v| !matches!(v, serde_json::Value::String(s) if s.is_empty()));
+            for v in map.values_mut() {
+                strip_empty_strings(v);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                strip_empty_strings(v);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Recursively cap the fractional precision of decimal-valued strings to at
 /// most `dp` digits.
 ///
@@ -477,6 +501,34 @@ mod tests {
         let mut v = serde_json::json!({"s": "", "arr": [], "n": 0, "gone": null});
         strip_nulls(&mut v);
         assert_eq!(v, serde_json::json!({"s": "", "arr": [], "n": 0}));
+    }
+
+    #[test]
+    fn strip_empty_strings_drops_only_empty_string_keys() {
+        let mut v = serde_json::json!({
+            "fr_revenue": {"value": "416161000000", "yoy": "6.43", "est_value": "",
+                           "est_yoy": "", "cmp": "", "cmp_desc": ""},
+            "kept": "x",
+            "arr": [{"a": "", "b": "1"}],
+            "empty_arr": [],
+            "empty_obj": {},
+            "zero": 0,
+            "nul": null
+        });
+        strip_empty_strings(&mut v);
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "fr_revenue": {"value": "416161000000", "yoy": "6.43"},
+                "kept": "x",
+                "arr": [{"b": "1"}],
+                "empty_arr": [],
+                "empty_obj": {},
+                "zero": 0,
+                "nul": null
+            }),
+            "only empty-string values are dropped, recursively; null, empty array/object, and 0 stay"
+        );
     }
 
     #[test]

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -71,6 +71,42 @@ pub(crate) fn strip_nulls(value: &mut serde_json::Value) {
     }
 }
 
+/// Recursively cap the fractional precision of decimal-valued strings to at
+/// most `dp` digits.
+///
+/// Only touches strings that parse as a plain decimal and carry *more* than
+/// `dp` fractional digits (e.g. an SDK leverage field serialized as
+/// `"11.50005084745763"`). Symbols (`700.HK`), dates, integers, and values
+/// already within `dp` are left byte-for-byte unchanged, so display formatting
+/// like `"438.400"` is preserved. `dp` is a floor: callers pass 6 to keep at
+/// least six decimal places.
+pub(crate) fn round_decimals(value: &mut serde_json::Value, dp: u32) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for v in map.values_mut() {
+                round_decimals(v, dp);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                round_decimals(v, dp);
+            }
+        }
+        serde_json::Value::String(s) => {
+            let frac = match s.rsplit_once('.') {
+                Some((_, frac)) => frac.len(),
+                None => return,
+            };
+            if frac > dp as usize
+                && let Ok(d) = s.parse::<rust_decimal::Decimal>()
+            {
+                *s = d.round_dp(dp).to_string();
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Recursively drop entries whose (snake_case) key is in `keys` from every
 /// object in `value`, at any depth and through arrays.
 ///
@@ -337,6 +373,25 @@ mod tests {
         let mut v = serde_json::json!({"s": "", "arr": [], "n": 0, "gone": null});
         strip_nulls(&mut v);
         assert_eq!(v, serde_json::json!({"s": "", "arr": [], "n": 0}));
+    }
+
+    #[test]
+    fn round_decimals_caps_precision_at_six() {
+        let mut v = serde_json::json!({
+            "leverage": "11.50005084745763",
+            "premium": "0.23161592505854794",
+            "price": "438.400",
+            "symbol": "700.HK",
+            "date": "2026-09-10",
+            "ts": "1789007822"
+        });
+        round_decimals(&mut v, 6);
+        assert_eq!(v["leverage"], "11.500051");
+        assert_eq!(v["premium"], "0.231616");
+        assert_eq!(v["price"], "438.400", "already <=6 dp: untouched");
+        assert_eq!(v["symbol"], "700.HK", "non-numeric: untouched");
+        assert_eq!(v["date"], "2026-09-10", "date: untouched");
+        assert_eq!(v["ts"], "1789007822", "integer: untouched");
     }
 
     #[test]

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -45,6 +45,32 @@ pub fn transform_json(input: &[u8]) -> Result<String, serde_json::Error> {
     Ok(String::from_utf8(buf).expect("serde_json produces valid UTF-8"))
 }
 
+/// Recursively drop `null`-valued entries from every object in `value`,
+/// recursing through nested objects and arrays.
+///
+/// MCP consumers treat an absent key and an explicit `null` identically, so
+/// dropping nulls is lossless for them and cuts tokens. The motivating case is
+/// wide "all possible fields" SDK structs (e.g. `SecurityCalcIndex`, which
+/// serializes ~40 fields where every index the caller did not request comes
+/// back as `null`). Safe against `output_schema` validation because a field
+/// that can be `null` is `Option`-derived and therefore not `required`.
+pub(crate) fn strip_nulls(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.retain(|_, v| !v.is_null());
+            for v in map.values_mut() {
+                strip_nulls(v);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                strip_nulls(v);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Return `true` iff `s` matches the `<PREFIX>/<MARKET>/<CODE>` counter_id
 /// pattern used internally by Longbridge (e.g. `ST/US/AAPL`, `ETF/HK/2800`,
 /// `IX/HK/HSI`, `OP/US/AAPL270115C300000`). Used to distinguish dynamic map
@@ -260,6 +286,33 @@ mod tests {
         assert_eq!(to_snake_case("createdAt"), "created_at");
         assert_eq!(to_snake_case("counterIds"), "counter_ids");
         assert_eq!(to_snake_case("already_snake"), "already_snake");
+    }
+
+    #[test]
+    fn strip_nulls_drops_null_keys_recursively() {
+        let mut v = serde_json::json!({
+            "pe": "22.5",
+            "pb": null,
+            "nested": {"a": 1, "b": null},
+            "rows": [{"x": 1, "y": null}, {"x": null}]
+        });
+        strip_nulls(&mut v);
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "pe": "22.5",
+                "nested": {"a": 1},
+                "rows": [{"x": 1}, {}]
+            })
+        );
+    }
+
+    #[test]
+    fn strip_nulls_keeps_non_null_and_empty() {
+        // Empty string / empty array / zero are NOT null — they stay.
+        let mut v = serde_json::json!({"s": "", "arr": [], "n": 0, "gone": null});
+        strip_nulls(&mut v);
+        assert_eq!(v, serde_json::json!({"s": "", "arr": [], "n": 0}));
     }
 
     #[test]

--- a/src/tools/calendar.rs
+++ b/src/tools/calendar.rs
@@ -207,6 +207,25 @@ pub async fn finance_calendar(
     let mut value: serde_json::Value =
         serde_json::from_str(&transformed).map_err(Error::Serialize)?;
     convert_unix_paths(&mut value, &["list.*.infos.*.datetime"]);
+    // Drop always-empty (chart_uid, financial_market_time), constant (star=0,
+    // source_type=0), and display-only (icon URL, widget_short_display_date, the
+    // empty data_kv `key`) fields from each event. These names collide with
+    // neither the outer grouping `date` nor any field we keep. Verified across
+    // both the dividend and report categories: `date_type` ("盘前"/"盘后") and
+    // `live` (earnings-call object) carry real data in report events, so they
+    // are deliberately NOT dropped.
+    crate::serialize::drop_keys(
+        &mut value,
+        &[
+            "chart_uid",
+            "financial_market_time",
+            "star",
+            "source_type",
+            "icon",
+            "widget_short_display_date",
+            "key",
+        ],
+    );
     if let Some(reason) = partial_reason {
         value["partial"] = serde_json::Value::Bool(true);
         value["partial_reason"] = serde_json::Value::String(reason);

--- a/src/tools/content.rs
+++ b/src/tools/content.rs
@@ -158,7 +158,11 @@ pub async fn topic_detail(
         .topic_detail(p.topic_id)
         .await
         .map_err(Error::longbridge)?;
-    tool_json(&result)
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    for field in ["description", "body"] {
+        crate::serialize::strip_cashtags_in_field(&mut value, field);
+    }
+    tool_json(&value)
 }
 
 pub async fn topic_replies(

--- a/src/tools/content.rs
+++ b/src/tools/content.rs
@@ -137,7 +137,14 @@ pub async fn news_detail(
             None,
         ));
     }
-    tool_json(item)
+    let mut item = item.clone();
+    // Rewrite `[st]…#Name.HK[/st]` ticker markup to the readable ticker, and
+    // drop the display-only author avatar URL.
+    for field in ["description", "body"] {
+        crate::serialize::strip_cashtags_in_field(&mut item, field);
+    }
+    crate::serialize::drop_keys(&mut item, &["avatar"]);
+    tool_json(&item)
 }
 
 pub async fn topic(

--- a/src/tools/content.rs
+++ b/src/tools/content.rs
@@ -142,7 +142,11 @@ pub async fn topic(
 ) -> Result<CallToolResult, McpError> {
     let ctx = ContentContext::new(mctx.create_config());
     let result = ctx.topics(p.symbol).await.map_err(Error::longbridge)?;
-    tool_json(&result)
+    // Community posts wrap every ticker mention in `[st]…#Name.HK[/st]` markup;
+    // rewrite it to the readable ticker.
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    crate::serialize::strip_cashtags_in_field(&mut value, "description");
+    tool_json(&value)
 }
 
 pub async fn topic_detail(

--- a/src/tools/content.rs
+++ b/src/tools/content.rs
@@ -63,7 +63,11 @@ pub async fn news(
 ) -> Result<CallToolResult, McpError> {
     let ctx = ContentContext::new(mctx.create_config());
     let result = ctx.news(p.symbol).await.map_err(Error::longbridge)?;
-    tool_json(&result)
+    // News items sourced from community posts embed `[st]…#Name.HK[/st]` ticker
+    // markup in their description; rewrite it to the readable ticker.
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    crate::serialize::strip_cashtags_in_field(&mut value, "description");
+    tool_json(&value)
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -178,7 +182,13 @@ pub async fn topic_replies(
         .list_topic_replies(p.topic_id, opts)
         .await
         .map_err(Error::longbridge)?;
-    tool_json(&result)
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    // Reply bodies can embed `[st]…#Name.HK[/st]` ticker markup like topics do;
+    // rewrite it to the readable ticker.
+    crate::serialize::strip_cashtags_in_field(&mut value, "body");
+    // Drop the per-author avatar image URL — pure display, no analytic value.
+    crate::serialize::drop_keys(&mut value, &["avatar"]);
+    tool_json(&value)
 }
 
 pub async fn topic_create(

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -198,10 +198,14 @@ pub async fn dividend(
     }
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    // Each row's `symbol` echoes the queried security, and `dividend_summary` is
+    // an always-empty `{title:"", desc:""}` object (verified across HK and US
+    // histories back to the 1980s).
+    http_get_tool_dropping(
         &client,
         "/v1/quote/dividends",
         &[("counter_id", cid.as_str())],
+        &["symbol", "dividend_summary"],
     )
     .await
 }

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -972,18 +972,50 @@ pub struct ShareholderTopParam {
     pub symbol: String,
 }
 
+/// Drop the per-holder `period` (== the enclosing `info[].period` on every row)
+/// and the always-empty `title`, without touching the segment-level `period`
+/// label. NB: the leading "最新" segment is kept — it shares the newest quarter's
+/// share counts but recomputes `percent_shares_*` against current shares
+/// outstanding, so it is not a duplicate.
+fn trim_shareholder_top(value: &mut serde_json::Value) {
+    let Some(info) = value.get_mut("info").and_then(|v| v.as_array_mut()) else {
+        return;
+    };
+    for seg in info.iter_mut() {
+        let Some(holders) = seg.get_mut("share_holders").and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+        for holder in holders.iter_mut() {
+            if let Some(o) = holder.as_object_mut() {
+                o.remove("period");
+                o.remove("title");
+            }
+        }
+    }
+}
+
 pub async fn shareholder_top(
     mctx: &crate::tools::McpContext,
     p: ShareholderTopParam,
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    let raw = http_get_tool(
         &client,
         "/v1/quote/shareholders/top",
         &[("counter_id", cid.as_str())],
     )
-    .await
+    .await?;
+    let json = raw
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_default();
+    let mut value: serde_json::Value =
+        serde_json::from_str(&json).map_err(crate::error::Error::Serialize)?;
+    trim_shareholder_top(&mut value);
+    crate::tools::tool_json(&value)
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -1055,6 +1087,40 @@ mod tests {
     use super::rating_part;
     use rmcp::ErrorData as McpError;
     use rmcp::model::Content;
+
+    #[test]
+    fn trim_shareholder_top_drops_holder_period_and_title_keeps_segment() {
+        let mut v = serde_json::json!({
+            "periods": ["最新", "Q2 2026"],
+            "info": [
+                {"period": "最新", "share_holders": [
+                    {"object_id": "1", "name": "BlackRock", "title": "", "shares_held": "100",
+                     "percent_shares_held": "7.97%", "period": "最新"}
+                ]},
+                {"period": "Q2 2026", "share_holders": [
+                    {"object_id": "1", "name": "BlackRock", "title": "", "shares_held": "100",
+                     "percent_shares_held": "7.95%", "period": "Q2 2026"}
+                ]}
+            ]
+        });
+        super::trim_shareholder_top(&mut v);
+        // segment-level period label kept; both "最新" and "Q2 2026" segments kept
+        assert_eq!(v["info"][0]["period"], "最新");
+        assert_eq!(v["info"][1]["period"], "Q2 2026");
+        // per-holder redundant period + empty title dropped
+        let h = &v["info"][0]["share_holders"][0];
+        assert!(h.get("period").is_none() && h.get("title").is_none());
+        // the differing percent (the reason we keep 最新) is preserved
+        assert_eq!(
+            v["info"][0]["share_holders"][0]["percent_shares_held"],
+            "7.97%"
+        );
+        assert_eq!(
+            v["info"][1]["share_holders"][0]["percent_shares_held"],
+            "7.95%"
+        );
+        assert_eq!(h["object_id"], "1");
+    }
 
     #[test]
     fn dedup_rating_history_collapses_unchanged_runs() {

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -1042,7 +1042,22 @@ pub async fn financial_report_snapshot(
     if !period.is_empty() {
         params.push(("fiscal_period", period.as_str()));
     }
-    http_get_tool(&client, "/v1/quote/financials/earnings-snapshot", &params).await
+    let raw = http_get_tool(&client, "/v1/quote/financials/earnings-snapshot", &params).await?;
+    let json = raw
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_default();
+    let mut value: serde_json::Value =
+        serde_json::from_str(&json).map_err(crate::error::Error::Serialize)?;
+    // The `fr_*` financial-ratio objects always carry blank est_value/est_yoy/
+    // cmp/cmp_desc columns (those only apply to the `fo_*` forecast rows); drop
+    // the empty strings. Every figure is also padded to four fractional digits
+    // (e.g. "416161000000.0000"); strip the non-significant zeros (lossless).
+    crate::serialize::strip_empty_strings(&mut value);
+    crate::serialize::strip_trailing_zeros(&mut value);
+    crate::tools::tool_json(&value)
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -378,10 +378,13 @@ pub async fn shareholder(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    // `shareholder_id` is a constant "0" (no drill-down; use shareholder_top),
+    // and `institution_type` is empty on every row.
+    http_get_tool_dropping(
         &client,
         "/v1/quote/shareholders",
         &[("counter_id", cid.as_str()), ("position", "detail")],
+        &["shareholder_id", "institution_type"],
     )
     .await
 }

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -6,8 +6,8 @@ use rmcp::serde::Deserialize;
 use crate::counter::{counter_id_to_symbol, symbol_to_counter_id};
 use crate::serialize::convert_unix_paths;
 use crate::tools::support::http_client::{
-    http_get_tool, http_get_tool_dropping, http_get_tool_unix, http_get_tool_unix_dropping,
-    http_get_tool_unix_rounding,
+    http_get_tool, http_get_tool_dropping, http_get_tool_rounding, http_get_tool_unix,
+    http_get_tool_unix_dropping, http_get_tool_unix_rounding,
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -212,10 +212,12 @@ pub async fn dividend_detail(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    // Each row's `symbol` is empty (the query already fixes the security).
+    http_get_tool_dropping(
         &client,
         "/v1/quote/dividends/details",
         &[("counter_id", cid.as_str())],
+        &["symbol"],
     )
     .await
 }
@@ -393,10 +395,13 @@ pub async fn industry_valuation_dist(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    // Every pe/pb/ps bound arrives with ~16-19 fractional digits of bogus
+    // precision (e.g. "4.7548672033913246"); cap at 6 dp.
+    http_get_tool_rounding(
         &client,
         "/v1/quote/industry-valuation-distribution",
         &[("counter_id", cid.as_str())],
+        6,
     )
     .await
 }

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -221,6 +221,47 @@ pub async fn forecast_eps(
     .await
 }
 
+/// Hoist the per-metric `name`/`description` (identical across every period) out
+/// of `list[].details[]` into a single top-level `legend` keyed by `key`, and
+/// drop empty-string fields (unreleased periods carry empty
+/// actual/comp_value/comp_desc/comp). Restructures the non-US consensus shape
+/// `{list:[{..., details:[{key,name,description,actual,estimate,...}]}]}`.
+fn hoist_consensus_legend(value: &mut serde_json::Value) {
+    let Some(obj) = value.as_object_mut() else {
+        return;
+    };
+    let Some(list) = obj.get_mut("list").and_then(|v| v.as_array_mut()) else {
+        return;
+    };
+    let mut legend = serde_json::Map::new();
+    for period in list.iter_mut() {
+        let Some(details) = period.get_mut("details").and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+        for detail in details.iter_mut() {
+            let Some(dobj) = detail.as_object_mut() else {
+                continue;
+            };
+            if let Some(key) = dobj.get("key").and_then(|v| v.as_str()).map(str::to_owned)
+                && !legend.contains_key(&key)
+            {
+                let mut entry = serde_json::Map::new();
+                if let Some(name) = dobj.get("name").cloned() {
+                    entry.insert("name".to_string(), name);
+                }
+                if let Some(desc) = dobj.get("description").cloned() {
+                    entry.insert("description".to_string(), desc);
+                }
+                legend.insert(key, serde_json::Value::Object(entry));
+            }
+            dobj.remove("name");
+            dobj.remove("description");
+            dobj.retain(|_, v| !matches!(v, serde_json::Value::String(s) if s.is_empty()));
+        }
+    }
+    obj.insert("legend".to_string(), serde_json::Value::Object(legend));
+}
+
 pub async fn consensus(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
@@ -243,12 +284,22 @@ pub async fn consensus(
     }
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    let raw = http_get_tool(
         &client,
         "/v1/quote/financial-consensus-detail",
         &[("counter_id", cid.as_str())],
     )
-    .await
+    .await?;
+    let json = raw
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_default();
+    let mut value: serde_json::Value =
+        serde_json::from_str(&json).map_err(crate::error::Error::Serialize)?;
+    hoist_consensus_legend(&mut value);
+    crate::tools::tool_json(&value)
 }
 
 pub async fn valuation(
@@ -942,6 +993,37 @@ mod tests {
     use super::rating_part;
     use rmcp::ErrorData as McpError;
     use rmcp::model::Content;
+
+    #[test]
+    fn hoist_consensus_legend_dedups_name_desc_and_drops_empties() {
+        let mut v = serde_json::json!({
+            "list": [
+                {"period_text": "Q2 2026", "details": [
+                    {"key": "revenue", "name": "营业收入", "description": "主营业务收入。",
+                     "actual": "236", "estimate": "233", "comp_desc": "超出预期", "is_released": true}
+                ]},
+                {"period_text": "Q1 2027", "details": [
+                    {"key": "revenue", "name": "营业收入", "description": "主营业务收入。",
+                     "actual": "", "estimate": "249", "comp_desc": "", "is_released": false}
+                ]}
+            ],
+            "currency": "HKD"
+        });
+        super::hoist_consensus_legend(&mut v);
+        // legend carries name/description once
+        assert_eq!(v["legend"]["revenue"]["name"], "营业收入");
+        assert_eq!(v["legend"]["revenue"]["description"], "主营业务收入。");
+        // per-period rows no longer carry name/description
+        let released = &v["list"][0]["details"][0];
+        assert!(released.get("name").is_none() && released.get("description").is_none());
+        assert_eq!(released["actual"], "236");
+        assert_eq!(released["comp_desc"], "超出预期");
+        // unreleased row: empty-string fields dropped, estimate kept
+        let unreleased = &v["list"][1]["details"][0];
+        assert!(unreleased.get("actual").is_none() && unreleased.get("comp_desc").is_none());
+        assert_eq!(unreleased["estimate"], "249");
+        assert_eq!(unreleased["is_released"], false);
+    }
 
     #[test]
     fn rating_part_returns_the_payload_and_no_warning_on_success() {

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -5,7 +5,9 @@ use rmcp::serde::Deserialize;
 
 use crate::counter::{counter_id_to_symbol, symbol_to_counter_id};
 use crate::serialize::convert_unix_paths;
-use crate::tools::support::http_client::{http_get_tool, http_get_tool_unix};
+use crate::tools::support::http_client::{
+    http_get_tool, http_get_tool_dropping, http_get_tool_unix,
+};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SymbolParam {
@@ -677,10 +679,13 @@ pub async fn business_segments(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    // `bus_ids`/`reg_ids` re-list the per-row segment ids; `report` (e.g. "qf")
+    // duplicates the human-readable `report_txt`.
+    http_get_tool_dropping(
         &client,
         "/v1/quote/fundamentals/business-segments",
         &[("counter_id", cid.as_str())],
+        &["bus_ids", "reg_ids", "report"],
     )
     .await
 }

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -520,7 +520,9 @@ pub async fn financial_statement(
     let cid = symbol_to_counter_id(&p.symbol);
     let kind = p.kind.unwrap_or_else(|| "ALL".to_string()).to_uppercase();
     let report = p.report.unwrap_or_else(|| "af".to_string()).to_lowercase();
-    http_get_tool(
+    // Per statement-line render metadata with no analytic value: `value_type`
+    // (constant "bignumber") and `display_order` (the array is already ordered).
+    http_get_tool_dropping(
         &client,
         "/v1/quote/financials/statements",
         &[
@@ -528,6 +530,7 @@ pub async fn financial_statement(
             ("kind", kind.as_str()),
             ("report", report.as_str()),
         ],
+        &["value_type", "display_order"],
     )
     .await
 }
@@ -797,7 +800,9 @@ pub async fn industry_peers(
     } else {
         symbol_to_counter_id(&p.symbol)
     };
-    http_get_tool(
+    // Per-node `market` (constant), `parent_code` (== parent node's code in the
+    // tree), and `level` (== nesting depth) are all derivable from structure.
+    http_get_tool_dropping(
         &client,
         "/v1/quote/industries/peers",
         &[
@@ -806,6 +811,7 @@ pub async fn industry_peers(
             ("industry_id", ""),
             ("counter_id", cid.as_str()),
         ],
+        &["market", "parent_code", "level"],
     )
     .await
 }

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -429,10 +429,14 @@ pub async fn executive(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    // `name_zhcn` and `name_en` are unpopulated duplicates of the localized
+    // `name` (upstream echoes the same value into all three — the `_zhcn` field
+    // carries the romanized name, not 中文), and `photo` is a display image URL.
+    http_get_tool_dropping(
         &client,
         "/v1/quote/company-professionals",
         &[("counter_ids", cid.as_str())],
+        &["name_zhcn", "name_en", "photo"],
     )
     .await
 }
@@ -460,10 +464,13 @@ pub async fn fund_holder(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    // `code` is just `symbol` without its market suffix (e.g. "159983.SZ" →
+    // "159983"), derivable and redundant.
+    http_get_tool_dropping(
         &client,
         "/v1/quote/fund-holders",
         &[("counter_id", cid.as_str())],
+        &["code"],
     )
     .await
 }
@@ -1095,11 +1102,15 @@ pub async fn valuation_comparison(
         comp_json = serde_json::to_string(&cids).unwrap_or_default();
         params.push(("comparison_counter_ids", comp_json.as_str()));
     }
-    http_get_tool_unix(
+    // Valuation ratios arrive with ~16-19 fractional digits of bogus precision
+    // (e.g. pe "41.0867665494152307"), both on the top-level metrics and across
+    // every `history` row; cap at 6 dp.
+    http_get_tool_unix_rounding(
         &client,
         "/v1/quote/compare/valuation",
         &params,
         &["list.*.history.*.date"],
+        6,
     )
     .await
 }

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -7,6 +7,7 @@ use crate::counter::{counter_id_to_symbol, symbol_to_counter_id};
 use crate::serialize::convert_unix_paths;
 use crate::tools::support::http_client::{
     http_get_tool, http_get_tool_dropping, http_get_tool_unix, http_get_tool_unix_dropping,
+    http_get_tool_unix_rounding,
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -491,10 +492,15 @@ pub async fn invest_relation(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    // `company_name_zhcn` and `company_name_en` are unpopulated duplicates of
+    // the localized `company_name` (upstream echoes the same display name into
+    // all three — the `_en` field carries Chinese too), and `company_id` is a
+    // constant "0" placeholder.
+    http_get_tool_dropping(
         &client,
         "/v1/quote/invest-relations",
         &[("counter_id", cid.as_str()), ("count", "0")],
+        &["company_id", "company_name_zhcn", "company_name_en"],
     )
     .await
 }
@@ -886,11 +892,14 @@ pub async fn institutional_views(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool_unix(
+    // The `tlist` price series arrives with ~19 fractional digits of bogus
+    // precision (e.g. "803.3032108278430037073"); cap it at 6 dp.
+    http_get_tool_unix_rounding(
         &client,
         "/v1/quote/ratings/institutional",
         &[("counter_id", cid.as_str())],
         &["elist.*.date"],
+        6,
     )
     .await
 }

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -937,13 +937,27 @@ pub async fn business_segments(
     let cid = symbol_to_counter_id(&p.symbol);
     // `bus_ids`/`reg_ids` re-list the per-row segment ids; `report` (e.g. "qf")
     // duplicates the human-readable `report_txt`.
-    http_get_tool_dropping(
+    let raw = http_get_tool_dropping(
         &client,
         "/v1/quote/fundamentals/business-segments",
         &[("counter_id", cid.as_str())],
         &["bus_ids", "reg_ids", "report"],
     )
-    .await
+    .await?;
+    let json = raw
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_default();
+    let mut value: serde_json::Value =
+        serde_json::from_str(&json).map_err(crate::error::Error::Serialize)?;
+    // Per-segment `yoy` carries ~14 fractional digits (e.g. "1.52573570177189");
+    // cap at 6 dp. The current period may have no prior-year base, leaving an
+    // empty top-level `yoy` — drop it.
+    crate::serialize::round_decimals(&mut value, 6);
+    crate::serialize::strip_empty_strings(&mut value);
+    crate::tools::tool_json(&value)
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -650,9 +650,7 @@ pub async fn financial_statement(
     let cid = symbol_to_counter_id(&p.symbol);
     let kind = p.kind.unwrap_or_else(|| "ALL".to_string()).to_uppercase();
     let report = p.report.unwrap_or_else(|| "af".to_string()).to_lowercase();
-    // Per statement-line render metadata with no analytic value: `value_type`
-    // (constant "bignumber") and `display_order` (the array is already ordered).
-    http_get_tool_dropping(
+    let raw = http_get_tool(
         &client,
         "/v1/quote/financials/statements",
         &[
@@ -660,9 +658,26 @@ pub async fn financial_statement(
             ("kind", kind.as_str()),
             ("report", report.as_str()),
         ],
-        &["value_type", "display_order"],
     )
-    .await
+    .await?;
+    let json = raw
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_default();
+    let mut value: serde_json::Value =
+        serde_json::from_str(&json).map_err(crate::error::Error::Serialize)?;
+    // Per statement-line render metadata with no analytic value: `value_type`
+    // (constant "bignumber") and `display_order` (the array is already ordered).
+    crate::serialize::drop_keys(&mut value, &["value_type", "display_order"]);
+    // Line values carry ~8 sub-unit decimals and `yoy` ~16 (e.g. value
+    // "821650052055.36005741", yoy "0.1496252509936191"); cap at 6 dp.
+    crate::serialize::round_decimals(&mut value, 6);
+    // Section-header rows (收入/成本/费用 …) and lines with no prior-year base
+    // carry empty value/yoy/field strings; drop them.
+    crate::serialize::strip_empty_strings(&mut value);
+    crate::tools::tool_json(&value)
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -6,7 +6,7 @@ use rmcp::serde::Deserialize;
 use crate::counter::{counter_id_to_symbol, symbol_to_counter_id};
 use crate::serialize::convert_unix_paths;
 use crate::tools::support::http_client::{
-    http_get_tool, http_get_tool_dropping, http_get_tool_unix,
+    http_get_tool, http_get_tool_dropping, http_get_tool_unix, http_get_tool_unix_dropping,
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -592,7 +592,8 @@ pub async fn valuation_rank(
     if let Some(ref e) = p.end {
         params.push(("end_date", e.as_str()));
     }
-    http_get_tool_unix(
+    // Every pe/pb/ps/dvd row carries `total` == the top-level `max_num`.
+    http_get_tool_unix_dropping(
         &client,
         "/v1/quote/valuation/rank",
         &params,
@@ -602,6 +603,7 @@ pub async fn valuation_rank(
             "ps.*.timestamp",
             "dvd.*.timestamp",
         ],
+        &["total"],
     )
     .await
 }

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -59,7 +59,15 @@ pub async fn financial_report(
     if !report_type.is_empty() {
         params.push(("report", report_type.as_str()));
     }
-    http_get_tool(&client, "/v1/quote/financial-reports", &params).await
+    // Per-indicator app scaffolding: `entry` (tips/entries with light_icon/
+    // dark_icon/router nav URLs) and the constant `periods` nav array.
+    http_get_tool_dropping(
+        &client,
+        "/v1/quote/financial-reports",
+        &params,
+        &["entry", "periods"],
+    )
+    .await
 }
 
 /// Pull one half of `institution_rating`'s response out of a sub-request,
@@ -418,10 +426,13 @@ pub async fn operating(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    // `keywords` is always empty and `web_url` is a derivable community link;
+    // the nested `financial.*` label fields are empty on every row.
+    http_get_tool_dropping(
         &client,
         "/v1/quote/operatings",
         &[("counter_id", cid.as_str())],
+        &["keywords", "web_url"],
     )
     .await
 }

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -286,11 +286,23 @@ pub async fn valuation_history(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool_unix(
+    // ~90% of this response is chart scaffolding: `symbols` (a re-keyed dup of
+    // `stocks`), `layouts` (distribution-histogram buckets), `aichat_data`
+    // (chatbot routing), per-metric `circle`/`part` (plot coords), and
+    // `ai_summary` (a dup of `overview.metrics.*.desc`).
+    http_get_tool_unix_dropping(
         &client,
         "/v1/quote/valuation/detail",
         &[("counter_id", cid.as_str())],
         &["history.metrics.pe.list.*.timestamp"],
+        &[
+            "symbols",
+            "layouts",
+            "aichat_data",
+            "circle",
+            "part",
+            "ai_summary",
+        ],
     )
     .await
 }

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -156,19 +156,52 @@ pub async fn institution_rating(
     Ok(crate::tools::tool_result(out))
 }
 
+/// Trim an institution_rating_detail response.
+///
+/// - `target.list[].date` duplicates the day of that row's `timestamp`, so it is
+///   dropped. `evaluate.list[].date` is kept — those rows carry no `timestamp`,
+///   so their `date` is the only time key.
+/// - The `avg_target`/`min_target`/`max_target` prices arrive with up to ~21
+///   fractional digits, and `target.prediction_accuracy` with ~18; capping the
+///   whole document at 6 dp removes that bogus precision (clean prices like the
+///   3 dp `price` and the 4 dp `data_percent` are left untouched).
+fn trim_institution_rating_detail(value: &mut serde_json::Value) {
+    if let Some(rows) = value
+        .pointer_mut("/target/list")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        for row in rows.iter_mut() {
+            if let Some(obj) = row.as_object_mut() {
+                obj.remove("date");
+            }
+        }
+    }
+    crate::serialize::round_decimals(value, 6);
+}
+
 pub async fn institution_rating_detail(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool_unix(
+    let raw = http_get_tool_unix(
         &client,
         "/v1/quote/institution-ratings/detail",
         &[("counter_id", cid.as_str())],
         &["target.list.*.timestamp"],
     )
-    .await
+    .await?;
+    let json = raw
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_default();
+    let mut value: serde_json::Value =
+        serde_json::from_str(&json).map_err(crate::error::Error::Serialize)?;
+    trim_institution_rating_detail(&mut value);
+    crate::tools::tool_json(&value)
 }
 
 pub async fn dividend(
@@ -1137,6 +1170,52 @@ mod tests {
     use super::rating_part;
     use rmcp::ErrorData as McpError;
     use rmcp::model::Content;
+
+    #[test]
+    fn trim_institution_rating_detail_drops_target_date_and_rounds() {
+        let mut v = serde_json::json!({
+            "ccy_symbol": "HK$",
+            "evaluate": {"list": [
+                {"strong_buy": 30, "buy": 10, "hold": 2, "sell": 0, "under": 1, "date": "2026/09/04"}
+            ]},
+            "target": {
+                "updated_at": "2026 年 9 月 11 日",
+                "prediction_accuracy": "53.756097560975609756",
+                "data_percent": "0.9934",
+                "list": [
+                    {"timestamp": "2026-09-04T16:00:00Z", "date": "2026/09/05", "price": "425.600",
+                     "meet": true, "avg_target": "652.784671964390839056078",
+                     "min_target": "352.1344841539118652849", "max_target": "856.6001736100176178146"}
+                ]
+            }
+        });
+        super::trim_institution_rating_detail(&mut v);
+
+        let trow = &v["target"]["list"][0];
+        // Derivable target-row date is dropped; the timestamp remains the time key.
+        assert!(trow.get("date").is_none(), "target.list date is dropped");
+        assert_eq!(
+            trow["timestamp"], "2026-09-04T16:00:00Z",
+            "timestamp is kept"
+        );
+        // Bogus target precision is capped at 6 dp; clean price is untouched.
+        assert_eq!(trow["avg_target"], "652.784672");
+        assert_eq!(trow["min_target"], "352.134484");
+        assert_eq!(trow["max_target"], "856.600174");
+        assert_eq!(trow["price"], "425.600", "clean 3dp price untouched");
+        assert_eq!(trow["meet"], true, "boolean kept");
+        assert_eq!(
+            v["target"]["prediction_accuracy"], "53.756098",
+            "18dp accuracy rounded"
+        );
+        assert_eq!(v["target"]["data_percent"], "0.9934", "4dp untouched");
+        // evaluate.list keeps its date — it is the only time key there.
+        assert_eq!(
+            v["evaluate"]["list"][0]["date"], "2026/09/04",
+            "evaluate.list date is preserved"
+        );
+        assert_eq!(v["ccy_symbol"], "HK$", "currency symbol kept");
+    }
 
     #[test]
     fn trim_institution_rating_drops_redundant_instratings_evaluate() {

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -90,6 +90,18 @@ fn rating_part(label: &str, result: Result<CallToolResult, McpError>) -> (String
     }
 }
 
+/// `instratings.evaluate` re-encodes `analyst.evaluate`'s rating counts with
+/// renamed keys (strong_buy=buy, buy=over) and strictly less detail (no
+/// `total`/`no_opinion`/dates), so it is a lossy duplicate — drop it. Keep the
+/// rest of `instratings` (recommend/target/change are unique). `ccy_symbol` is
+/// a display glyph.
+fn trim_institution_rating(value: &mut serde_json::Value) {
+    if let Some(inst) = value.get_mut("instratings").and_then(|v| v.as_object_mut()) {
+        inst.remove("evaluate");
+        inst.remove("ccy_symbol");
+    }
+}
+
 pub async fn institution_rating(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
@@ -138,6 +150,7 @@ pub async fn institution_rating(
             "analyst.target.end_date",
         ],
     );
+    trim_institution_rating(&mut value);
     let out = serde_json::to_string(&value).map_err(crate::error::Error::Serialize)?;
     Ok(crate::tools::tool_result(out))
 }
@@ -1087,6 +1100,25 @@ mod tests {
     use super::rating_part;
     use rmcp::ErrorData as McpError;
     use rmcp::model::Content;
+
+    #[test]
+    fn trim_institution_rating_drops_redundant_instratings_evaluate() {
+        let mut v = serde_json::json!({
+            "analyst": {"evaluate": {"buy": 19, "over": 6, "hold": 14, "under": 2, "sell": 3, "total": 45, "no_opinion": 1}},
+            "instratings": {"recommend": "buy", "target": "324.4", "change": "2.87", "ccy_symbol": "$",
+                            "evaluate": {"strong_buy": 19, "buy": 6, "hold": 14, "sell": 3, "under": 2, "date": ""}}
+        });
+        super::trim_institution_rating(&mut v);
+        // redundant dup block + display glyph gone
+        assert!(v["instratings"].get("evaluate").is_none());
+        assert!(v["instratings"].get("ccy_symbol").is_none());
+        // unique instratings fields kept
+        assert_eq!(v["instratings"]["recommend"], "buy");
+        assert_eq!(v["instratings"]["target"], "324.4");
+        // the authoritative analyst.evaluate untouched
+        assert_eq!(v["analyst"]["evaluate"]["buy"], 19);
+        assert_eq!(v["analyst"]["evaluate"]["no_opinion"], 1);
+    }
 
     #[test]
     fn trim_shareholder_top_drops_holder_period_and_title_keeps_segment() {

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -689,18 +689,80 @@ pub async fn valuation_rank(
 }
 
 /// Get institution rating history (target price + evaluate history) for a security.
+/// The rating-distribution signature of one `evaluate_history` row (everything
+/// except the date range), used to collapse consecutive unchanged rows.
+fn eval_signature(o: &serde_json::Map<String, serde_json::Value>) -> Vec<serde_json::Value> {
+    ["buy", "over", "hold", "under", "sell", "no_opinion"]
+        .iter()
+        .map(|k| o.get(*k).cloned().unwrap_or(serde_json::Value::Null))
+        .collect()
+}
+
+/// Collapse runs of consecutive `evaluate_history` rows with an identical rating
+/// distribution into one row spanning `start_date`..`end_date`, drop the
+/// derivable `total`, and round `target_history` prices to 6 dp. The raw history
+/// carries one row per change *event date* even when the distribution is
+/// unchanged (hundreds of near-duplicate daily rows).
+fn dedup_rating_history(value: &mut serde_json::Value) {
+    let Some(obj) = value.as_object_mut() else {
+        return;
+    };
+    if let Some(hist) = obj
+        .get_mut("evaluate_history")
+        .and_then(|v| v.as_array_mut())
+    {
+        let mut merged: Vec<serde_json::Value> = Vec::with_capacity(hist.len());
+        for row in hist.drain(..) {
+            let same_as_prev = merged
+                .last()
+                .and_then(|l| l.as_object())
+                .zip(row.as_object())
+                .is_some_and(|(l, r)| eval_signature(l) == eval_signature(r));
+            if same_as_prev {
+                if let (Some(end), Some(last)) = (
+                    row.get("end_date").cloned(),
+                    merged.last_mut().and_then(|l| l.as_object_mut()),
+                ) {
+                    last.insert("end_date".to_string(), end);
+                }
+            } else {
+                merged.push(row);
+            }
+        }
+        for row in merged.iter_mut() {
+            if let Some(o) = row.as_object_mut() {
+                o.remove("total");
+            }
+        }
+        *hist = merged;
+    }
+    if let Some(tgt) = obj.get_mut("target_history") {
+        crate::serialize::round_decimals(tgt, 6);
+    }
+}
+
 pub async fn institution_rating_history(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    let raw = http_get_tool(
         &client,
         "/v1/quote/ratings/history",
         &[("counter_id", cid.as_str())],
     )
-    .await
+    .await?;
+    let json = raw
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_default();
+    let mut value: serde_json::Value =
+        serde_json::from_str(&json).map_err(crate::error::Error::Serialize)?;
+    dedup_rating_history(&mut value);
+    crate::tools::tool_json(&value)
 }
 
 /// Get institution rating industry rank for a security (peers ranked by analyst ratings).
@@ -993,6 +1055,34 @@ mod tests {
     use super::rating_part;
     use rmcp::ErrorData as McpError;
     use rmcp::model::Content;
+
+    #[test]
+    fn dedup_rating_history_collapses_unchanged_runs() {
+        let mut v = serde_json::json!({
+            "evaluate_history": [
+                {"buy":"17","over":"6","hold":"0","under":"1","sell":"0","no_opinion":"0","total":"24","start_date":"100","end_date":"200"},
+                {"buy":"17","over":"6","hold":"0","under":"1","sell":"0","no_opinion":"0","total":"24","start_date":"200","end_date":"300"},
+                {"buy":"18","over":"5","hold":"0","under":"1","sell":"0","no_opinion":"0","total":"24","start_date":"300","end_date":"400"}
+            ],
+            "target_history": [
+                {"timestamp":"1","close":"136.1","high_target_price":"217.2819933602771364252","low_target_price":"118.96"}
+            ]
+        });
+        super::dedup_rating_history(&mut v);
+        let hist = v["evaluate_history"].as_array().unwrap();
+        assert_eq!(hist.len(), 2, "two identical rows collapse to one");
+        assert_eq!(hist[0]["start_date"], "100");
+        assert_eq!(
+            hist[0]["end_date"], "300",
+            "end_date extended to the run's last"
+        );
+        assert!(hist[0].get("total").is_none(), "derivable total dropped");
+        assert_eq!(hist[1]["start_date"], "300");
+        assert_eq!(
+            v["target_history"][0]["high_target_price"], "217.281993",
+            "price rounded to 6 dp"
+        );
+    }
 
     #[test]
     fn hoist_consensus_legend_dedups_name_desc_and_drops_empties() {

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -935,12 +935,26 @@ pub async fn business_segments_history(
     if !cate.is_empty() {
         params.push(("cate", cate.as_str()));
     }
-    http_get_tool(
+    let raw = http_get_tool(
         &client,
         "/v1/quote/fundamentals/business-segments/history",
         &params,
     )
-    .await
+    .await?;
+    let json = raw
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_default();
+    let mut value: serde_json::Value =
+        serde_json::from_str(&json).map_err(crate::error::Error::Serialize)?;
+    // Every `yoy` growth figure carries ~14 fractional digits (e.g.
+    // "-32.48841750583911"); cap at 6 dp. The first period has no prior year, so
+    // its `yoy` is an empty string — drop those.
+    crate::serialize::round_decimals(&mut value, 6);
+    crate::serialize::strip_empty_strings(&mut value);
+    crate::tools::tool_json(&value)
 }
 
 pub async fn institutional_views(

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -486,7 +486,10 @@ pub async fn corp_action(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    // `date_str` is `date` reformatted ("20260812" → "08.12"), `date_zone` is a
+    // constant display label ("北京时间"), `security` is null on every row, and
+    // `icon` (inside `live`) is a constant replay-badge image URL.
+    http_get_tool_dropping(
         &client,
         "/v1/quote/company-act",
         &[
@@ -494,6 +497,7 @@ pub async fn corp_action(
             ("req_type", "1"),
             ("version", "3"),
         ],
+        &["date_str", "date_zone", "security", "icon"],
     )
     .await
 }

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -60,15 +60,25 @@ pub async fn financial_report(
     if !report_type.is_empty() {
         params.push(("report", report_type.as_str()));
     }
+    let raw = http_get_tool(&client, "/v1/quote/financial-reports", &params).await?;
+    let json = raw
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_default();
+    let mut value: serde_json::Value =
+        serde_json::from_str(&json).map_err(crate::error::Error::Serialize)?;
     // Per-indicator app scaffolding: `entry` (tips/entries with light_icon/
     // dark_icon/router nav URLs) and the constant `periods` nav array.
-    http_get_tool_dropping(
-        &client,
-        "/v1/quote/financial-reports",
-        &params,
-        &["entry", "periods"],
-    )
-    .await
+    crate::serialize::drop_keys(&mut value, &["entry", "periods"]);
+    // `yoy` growth figures carry ~14 fractional digits (e.g.
+    // "19.04333000476588"); cap at 6 dp.
+    crate::serialize::round_decimals(&mut value, 6);
+    // Ratio-only metrics have an empty `yoy`, and each account carries empty
+    // short_title/tip/industry_ranking/ranking_code/ratio display fields.
+    crate::serialize::strip_empty_strings(&mut value);
+    crate::tools::tool_json(&value)
 }
 
 /// Pull one half of `institution_rating`'s response out of a sub-request,
@@ -568,15 +578,26 @@ pub async fn operating(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    // `keywords` is always empty and `web_url` is a derivable community link;
-    // the nested `financial.*` label fields are empty on every row.
-    http_get_tool_dropping(
+    // `keywords` is always empty and `web_url` is a derivable community link.
+    let raw = http_get_tool_dropping(
         &client,
         "/v1/quote/operatings",
         &[("counter_id", cid.as_str())],
         &["keywords", "web_url"],
     )
-    .await
+    .await?;
+    let json = raw
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_default();
+    let mut value: serde_json::Value =
+        serde_json::from_str(&json).map_err(crate::error::Error::Serialize)?;
+    // Each report's nested `financial` block carries empty symbol/name/region/
+    // code/report/report_txt label fields; drop them.
+    crate::serialize::strip_empty_strings(&mut value);
+    crate::tools::tool_json(&value)
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/src/tools/fundamental.rs
+++ b/src/tools/fundamental.rs
@@ -384,11 +384,15 @@ pub async fn industry_valuation(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool_unix(
+    // Valuation ratios and per-share figures arrive with up to ~22 fractional
+    // digits of bogus precision (e.g. bps "145.6260066297869181464524"), on both
+    // the top-level metrics and every `history` row; cap at 6 dp.
+    http_get_tool_unix_rounding(
         &client,
         "/v1/quote/industry-valuation-comparison",
         &[("counter_id", cid.as_str())],
         &["list.*.history.*.date"],
+        6,
     )
     .await
 }

--- a/src/tools/ipo.rs
+++ b/src/tools/ipo.rs
@@ -106,7 +106,14 @@ pub async fn ipo_listed(
     let hk = http_get_tool(&client, "/v1/ipo/listed", &params).await?;
     let us = http_get_tool(&client, "/v1/us/ipo/listed", &params).await?;
     let combined = format!(r#"{{"hk":{},"us":{}}}"#, get_json(&hk), get_json(&us));
-    Ok(make_result(combined))
+    // Each entry echoes `market` (already implied by the hk/us grouping key) and
+    // an `icon` display URL; drop both.
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(&combined) else {
+        return Ok(make_result(combined));
+    };
+    crate::serialize::drop_keys(&mut value, &["market", "icon"]);
+    let json = serde_json::to_string(&value).unwrap_or(combined);
+    Ok(make_result(json))
 }
 
 /// Show IPO detail: profile + timeline + eligibility for a symbol.

--- a/src/tools/ipo.rs
+++ b/src/tools/ipo.rs
@@ -7,10 +7,20 @@ use crate::counter::symbol_to_counter_id;
 use crate::tools::support::http_client::{http_get_tool, http_get_tool_unix};
 
 fn make_result(json: String) -> CallToolResult {
-    let structured = serde_json::from_str::<serde_json::Value>(&json).ok();
-    let mut result = CallToolResult::success(vec![rmcp::model::Content::text(json)]);
-    result.structured_content = structured;
-    result
+    // Cap bogus decimal precision (e.g. investor `capital_ratio` values like
+    // "32.03116022394741") at 6 dp. When the payload parses, the rounded value
+    // is authoritative for both the text and structured content; a payload that
+    // does not parse is passed through unchanged.
+    match serde_json::from_str::<serde_json::Value>(&json) {
+        Ok(mut value) => {
+            crate::serialize::round_decimals(&mut value, 6);
+            let json = serde_json::to_string(&value).unwrap_or(json);
+            let mut result = CallToolResult::success(vec![rmcp::model::Content::text(json)]);
+            result.structured_content = Some(value);
+            result
+        }
+        Err(_) => CallToolResult::success(vec![rmcp::model::Content::text(json)]),
+    }
 }
 
 fn get_json(r: &CallToolResult) -> &str {

--- a/src/tools/macrodata.rs
+++ b/src/tools/macrodata.rs
@@ -77,6 +77,10 @@ pub async fn macrodata_indicators(
         for item in list {
             if let Some(obj) = item.as_object_mut() {
                 strip_indicator(obj);
+                // `describe` is a ~200-word essay per indicator; a directory
+                // listing of hundreds of indicators does not need it (the
+                // single-indicator `macrodata` tool keeps its explanation).
+                obj.remove("describe");
             }
         }
     }

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -10,7 +10,8 @@ use crate::counter::{index_symbol_to_counter_id, is_etf, symbol_to_counter_id};
 use crate::error::Error;
 use crate::serialize::convert_unix_paths;
 use crate::tools::support::http_client::{
-    http_get_tool, http_get_tool_dropping, http_get_tool_unix, http_get_tool_unix_dropping,
+    http_get_tool, http_get_tool_dropping, http_get_tool_trimming_zeros, http_get_tool_unix,
+    http_get_tool_unix_dropping,
 };
 use crate::tools::tool_json;
 
@@ -119,7 +120,10 @@ pub async fn broker_holding_detail(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    // The share-count delta fields (shares.chg_*) are integers padded with a
+    // fake ".0000" fractional part across all rows; strip the trailing zeros
+    // (lossless) — they are ~half the bytes of this ~100 KB payload.
+    http_get_tool_trimming_zeros(
         &client,
         "/v1/quote/broker-holding/detail",
         &[("counter_id", cid.as_str())],

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -372,8 +372,14 @@ pub async fn industry_rank(
         .send()
         .await
         .map_err(|e| Error::longbridge(e.into()))?;
-    let data: serde_json::Value =
+    let mut data: serde_json::Value =
         serde_json::from_str(&raw).map_err(crate::error::Error::Serialize)?;
+    // The response wraps the real rows in a group element whose own
+    // counter_id/symbol/name/chg are blank, and each row carries value_name/
+    // value_data/prev_close that are empty unless a value-column indicator (e.g.
+    // 市值) was requested. Drop the empty-string fields; they are re-added
+    // automatically when an indicator actually populates them.
+    crate::serialize::strip_empty_strings(&mut data);
     let out = serde_json::to_string(&data).map_err(crate::error::Error::Serialize)?;
     let structured = serde_json::from_str::<serde_json::Value>(&out).ok();
     let mut res = rmcp::model::CallToolResult::success(vec![rmcp::model::Content::text(out)]);

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -10,7 +10,7 @@ use crate::counter::{index_symbol_to_counter_id, is_etf, symbol_to_counter_id};
 use crate::error::Error;
 use crate::serialize::convert_unix_paths;
 use crate::tools::support::http_client::{
-    http_get_tool, http_get_tool_dropping, http_get_tool_unix,
+    http_get_tool, http_get_tool_dropping, http_get_tool_unix, http_get_tool_unix_dropping,
 };
 use crate::tools::tool_json;
 
@@ -162,7 +162,7 @@ pub async fn ah_premium(
         _ => "1000", // day
     };
     let count_str = p.count.unwrap_or(100).to_string();
-    http_get_tool_unix(
+    http_get_tool_unix_dropping(
         &client,
         "/v1/quote/ahpremium/klines",
         &[
@@ -171,6 +171,7 @@ pub async fn ah_premium(
             ("line_num", count_str.as_str()),
         ],
         &["klines.*.timestamp"],
+        &["price_spread"],
     )
     .await
 }

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -8,7 +8,7 @@ use rmcp::serde::{Deserialize, Serialize};
 
 use crate::counter::{index_symbol_to_counter_id, is_etf, symbol_to_counter_id};
 use crate::error::Error;
-use crate::serialize::convert_unix_paths;
+use crate::serialize::{convert_unix_paths, transform_json};
 use crate::tools::support::http_client::{
     http_get_tool, http_get_tool_dropping, http_get_tool_trimming_zeros, http_get_tool_unix,
     http_get_tool_unix_dropping,
@@ -182,21 +182,70 @@ pub async fn ah_premium(
     .await
 }
 
+/// Hoist the per-bar prior-close fields (`apreclose`, `hpreclose`) out of the
+/// `klines` array to the top level.
+///
+/// These are the A-share and H-share *previous* closing prices: fixed for the
+/// whole session by definition, so upstream repeats the identical value on every
+/// one of the ~240 minute bars. Lifting them to a single top-level copy is
+/// lossless and keeps a stable shape (always hoisted). The FX `currency_rate` is
+/// deliberately left per-bar — unlike a prior close it can move intraday.
+fn hoist_intraday_prev_closes(value: &mut serde_json::Value) {
+    let first = value
+        .get("klines")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|k| k.first());
+    let Some(first) = first else {
+        return;
+    };
+    let apreclose = first.get("apreclose").cloned();
+    let hpreclose = first.get("hpreclose").cloned();
+    if apreclose.is_none() && hpreclose.is_none() {
+        return;
+    }
+    if let Some(bars) = value
+        .get_mut("klines")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        for bar in bars.iter_mut() {
+            if let Some(obj) = bar.as_object_mut() {
+                obj.remove("apreclose");
+                obj.remove("hpreclose");
+            }
+        }
+    }
+    if let Some(obj) = value.as_object_mut() {
+        if let Some(v) = apreclose {
+            obj.insert("apreclose".to_owned(), v);
+        }
+        if let Some(v) = hpreclose {
+            obj.insert("hpreclose".to_owned(), v);
+        }
+    }
+}
+
 pub async fn ah_premium_intraday(
     mctx: &crate::tools::McpContext,
     p: SymbolParam,
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
+    let resp: String = client
+        .request(Method::GET, "/v1/quote/ahpremium/timeshares")
+        .query_params(vec![("counter_id", cid.as_str()), ("days", "1")])
+        .response::<String>()
+        .send()
+        .await
+        .map_err(|e| Error::longbridge(e.into()))?;
+    let transformed = transform_json(resp.as_bytes()).map_err(Error::Serialize)?;
+    let mut value: serde_json::Value =
+        serde_json::from_str(&transformed).map_err(Error::Serialize)?;
+    convert_unix_paths(&mut value, &["klines.*.timestamp"]);
     // `price_spread` is empty on every intraday minute bar.
-    http_get_tool_unix_dropping(
-        &client,
-        "/v1/quote/ahpremium/timeshares",
-        &[("counter_id", cid.as_str()), ("days", "1")],
-        &["klines.*.timestamp"],
-        &["price_spread"],
-    )
-    .await
+    crate::serialize::drop_keys(&mut value, &["price_spread"]);
+    hoist_intraday_prev_closes(&mut value);
+    let json = serde_json::to_string(&value).map_err(Error::Serialize)?;
+    Ok(crate::tools::tool_result(json))
 }
 
 pub async fn trade_stats(
@@ -638,7 +687,56 @@ pub async fn rank_list(
 
 #[cfg(test)]
 mod tests {
-    use super::trade_status_label;
+    use super::{hoist_intraday_prev_closes, trade_status_label};
+
+    #[test]
+    fn hoist_intraday_prev_closes_lifts_prior_closes_and_keeps_live_fields() {
+        let mut v = serde_json::json!({
+            "klines": [
+                {"aprice": "55.160", "apreclose": "52.890", "hprice": "53.750",
+                 "hpreclose": "56.250", "currency_rate": "0.855300",
+                 "ahpremium_rate": "-0.166563", "timestamp": "2026-09-11T01:30:00Z"},
+                {"aprice": "54.810", "apreclose": "52.890", "hprice": "53.550",
+                 "hpreclose": "56.250", "currency_rate": "0.855300",
+                 "ahpremium_rate": "-0.164362", "timestamp": "2026-09-11T01:31:00Z"}
+            ]
+        });
+        hoist_intraday_prev_closes(&mut v);
+
+        // Prior closes are lifted once to the top level.
+        assert_eq!(v["apreclose"], "52.890", "A-share prior close is hoisted");
+        assert_eq!(v["hpreclose"], "56.250", "H-share prior close is hoisted");
+        // …and removed from every bar.
+        for bar in v["klines"].as_array().expect("klines is an array") {
+            assert!(
+                bar.get("apreclose").is_none(),
+                "per-bar apreclose is dropped"
+            );
+            assert!(
+                bar.get("hpreclose").is_none(),
+                "per-bar hpreclose is dropped"
+            );
+            // Live per-bar fields stay put — including currency_rate.
+            assert!(bar.get("aprice").is_some(), "live aprice is kept");
+            assert!(bar.get("hprice").is_some(), "live hprice is kept");
+            assert!(
+                bar.get("currency_rate").is_some(),
+                "currency_rate stays per-bar (it can move intraday)"
+            );
+            assert!(bar.get("ahpremium_rate").is_some(), "premium rate is kept");
+        }
+    }
+
+    #[test]
+    fn hoist_intraday_prev_closes_tolerates_empty_klines() {
+        let mut v = serde_json::json!({ "klines": [] });
+        hoist_intraday_prev_closes(&mut v);
+        assert_eq!(
+            v,
+            serde_json::json!({ "klines": [] }),
+            "empty input is unchanged"
+        );
+    }
 
     #[test]
     fn trade_status_label_matches_openapi_status() {

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -106,7 +106,9 @@ pub async fn broker_holding(
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
     let period = p.period.as_deref().unwrap_or("rct_1");
-    http_get_tool(
+    // Each entry's `chg` is an integer share delta padded with a fake ".0000"
+    // fractional part; strip the trailing zeros (lossless).
+    http_get_tool_trimming_zeros(
         &client,
         "/v1/quote/broker-holding",
         &[("counter_id", cid.as_str()), ("type", period)],

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -500,11 +500,14 @@ pub async fn top_movers(
     if let Some(ref d) = p.date {
         body["date"] = serde_json::Value::String(d.clone());
     }
-    crate::tools::support::http_client::http_post_tool_unix(
+    // Per-event stock display noise: `profile` (~150-word paragraph), `logo`
+    // (URL), `full_name` (== name), and constant `latency`/`duplicate` flags.
+    crate::tools::support::http_client::http_post_tool_unix_dropping(
         &client,
         "/v1/quote/market/stock-events",
         body,
         &["events.*.timestamp"],
+        &["profile", "logo", "full_name", "latency", "duplicate"],
     )
     .await
 }

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -188,11 +188,13 @@ pub async fn ah_premium_intraday(
 ) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
     let cid = symbol_to_counter_id(&p.symbol);
-    http_get_tool_unix(
+    // `price_spread` is empty on every intraday minute bar.
+    http_get_tool_unix_dropping(
         &client,
         "/v1/quote/ahpremium/timeshares",
         &[("counter_id", cid.as_str()), ("days", "1")],
         &["klines.*.timestamp"],
+        &["price_spread"],
     )
     .await
 }

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -242,10 +242,13 @@ pub async fn constituent(
 
     let client = mctx.create_http_client();
     let cid = index_symbol_to_counter_id(&p.symbol);
-    http_get_tool(
+    // Per-constituent noise: `intro` (long blurb), `market` (derivable from
+    // symbol), constant `delay`/`trade_status`.
+    http_get_tool_dropping(
         &client,
         "/v1/quote/index-constituents",
         &[("counter_id", cid.as_str())],
+        &["intro", "market", "delay", "trade_status"],
     )
     .await
 }

--- a/src/tools/market.rs
+++ b/src/tools/market.rs
@@ -9,7 +9,9 @@ use rmcp::serde::{Deserialize, Serialize};
 use crate::counter::{index_symbol_to_counter_id, is_etf, symbol_to_counter_id};
 use crate::error::Error;
 use crate::serialize::convert_unix_paths;
-use crate::tools::support::http_client::{http_get_tool, http_get_tool_unix};
+use crate::tools::support::http_client::{
+    http_get_tool, http_get_tool_dropping, http_get_tool_unix,
+};
 use crate::tools::tool_json;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -588,7 +590,11 @@ pub async fn rank_list(
         .or_else(|| p.market.as_deref().map(|m| m.to_uppercase()))
         .unwrap_or_else(|| "US".to_string());
     let size = p.size.unwrap_or(20).to_string();
-    http_get_tool(
+    // Per-row upstream fields with no analytic value: `code` (== symbol without
+    // suffix), `market` (single-market query, derivable), constant/empty flags
+    // (`delay`, `is_pre_post`, `pre_post_*`, `extend_*`), the editorial `intro`
+    // blurb, and the `article` object.
+    http_get_tool_dropping(
         &client,
         "/v1/quote/market/rank/list",
         &[
@@ -597,6 +603,19 @@ pub async fn rank_list(
             ("need_article", need_article.as_str()),
             ("market", key_market.as_str()),
             ("size", size.as_str()),
+        ],
+        &[
+            "code",
+            "market",
+            "delay",
+            "is_pre_post",
+            "pre_post_price",
+            "pre_post_chg",
+            "extend_state",
+            "extend_price",
+            "extend_chg",
+            "article",
+            "intro",
         ],
     )
     .await

--- a/src/tools/output/discovery.rs
+++ b/src/tools/output/discovery.rs
@@ -386,6 +386,12 @@ pub struct ScreenerSearchResponse {
     /// Total number of matching securities.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total: Option<i64>,
+    /// Per-indicator display metadata, keyed by indicator key: `{ key: { name,
+    /// unit } }`. The `name`/`unit` labels are identical for a given key across
+    /// every result row, so they are listed once here instead of being repeated
+    /// on each row's `indicators[]`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub legend: Option<serde_json::Value>,
     /// Result rows for the current page.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub items: Option<Vec<ScreenerResultItem>>,

--- a/src/tools/output/fact.rs
+++ b/src/tools/output/fact.rs
@@ -91,15 +91,63 @@ impl NlField {
         match serde_json::from_str::<Vec<longbridge::signal::NlTag>>(raw) {
             Ok(tags) => Self::Tags(
                 tags.into_iter()
-                    .map(|t| NlTag {
-                        tag: t.tag,
-                        value: t.value,
+                    .map(|t| {
+                        // The `citations` entry embeds a JSON array of the raw
+                        // source documents behind the narrative; slim it to the
+                        // usable provenance (see `slim_citations`).
+                        let value = if t.tag == "citations" {
+                            slim_citations(&t.value)
+                        } else {
+                            t.value
+                        };
+                        NlTag { tag: t.tag, value }
                     })
                     .collect(),
             ),
             Err(_) => Self::Raw(raw.to_owned()),
         }
     }
+}
+
+/// Slim the `citations` payload on a natural-language field.
+///
+/// The value is a JSON-encoded array of the raw source documents behind the
+/// narrative — full article bodies, descriptions, favicons, source logos,
+/// member ids and display-ordering indices that together dominate a
+/// `security_facts` response (~75% of its bytes) while adding nothing beyond
+/// attribution. Reduce each citation to the provenance an AI consumer can act
+/// on: the source kind and drill-down `id` (fetch the article with
+/// `news_detail`), plus the human-facing `title`, `source`, `url` and
+/// `published_at`. A value that is not the expected JSON array is returned
+/// unchanged so an unexpected shape survives rather than being dropped.
+fn slim_citations(raw: &str) -> String {
+    let Ok(items) = serde_json::from_str::<Vec<serde_json::Value>>(raw) else {
+        return raw.to_owned();
+    };
+    let is_empty = |v: &serde_json::Value| {
+        v.is_null() || matches!(v, serde_json::Value::String(s) if s.is_empty())
+    };
+    let slimmed: Vec<serde_json::Value> = items
+        .iter()
+        .map(|item| {
+            let content = item.get("content");
+            let mut out = serde_json::Map::new();
+            // Source kind and drill-down id come from the citation entry itself.
+            for key in ["type", "id"] {
+                if let Some(v) = item.get(key).filter(|v| !is_empty(v)) {
+                    out.insert(key.to_owned(), v.clone());
+                }
+            }
+            // Human-facing provenance comes from the nested source document.
+            for key in ["title", "source", "url", "published_at"] {
+                if let Some(v) = content.and_then(|c| c.get(key)).filter(|v| !is_empty(v)) {
+                    out.insert(key.to_owned(), v.clone());
+                }
+            }
+            serde_json::Value::Object(out)
+        })
+        .collect();
+    serde_json::to_string(&slimmed).unwrap_or_else(|_| raw.to_owned())
 }
 
 /// Natural-language rendering of a fact, in the caller's language.
@@ -316,6 +364,83 @@ mod tests {
             serde_json::to_value(&field).expect("field must serialize"),
             serde_json::Value::String("not json".into()),
             "an unparsable payload must survive rather than be dropped"
+        );
+    }
+
+    #[test]
+    fn slim_citations_keeps_only_provenance() {
+        let raw = r#"[
+            {"type":"NewsArticle","id":"9","index":3,"original_index":7,
+             "content":{"title":"T","source":"Nasdaq","url":"http://x",
+                        "favicon":"http://f","source_logo":"http://l",
+                        "body":"a very long article body","member_id":"42",
+                        "published_at":"2026-09-10T00:00:00Z"}},
+            {"type":"WebSearch",
+             "content":{"title":"W","source":"Bing","url":"http://y",
+                        "domain":"y.com","favicon":"http://g","content":"raw"}}
+        ]"#;
+        let out = slim_citations(raw);
+        let v: Vec<serde_json::Value> = serde_json::from_str(&out).expect("slimmed must be JSON");
+        assert_eq!(v.len(), 2, "every citation is kept");
+        assert_eq!(
+            v[0],
+            serde_json::json!({
+                "type": "NewsArticle", "id": "9", "title": "T",
+                "source": "Nasdaq", "url": "http://x",
+                "published_at": "2026-09-10T00:00:00Z"
+            }),
+            "a news citation keeps drill-down id + provenance, drops the raw body"
+        );
+        assert_eq!(
+            v[1],
+            serde_json::json!({
+                "type": "WebSearch", "title": "W", "source": "Bing", "url": "http://y"
+            }),
+            "a web citation keeps provenance; absent fields are omitted"
+        );
+        for heavy in [
+            "favicon",
+            "source_logo",
+            "body",
+            "member_id",
+            "original_index",
+            "domain",
+        ] {
+            assert!(
+                !out.contains(heavy),
+                "the heavy display/plumbing field {heavy} must be dropped"
+            );
+        }
+    }
+
+    #[test]
+    fn slim_citations_passes_through_non_array_payloads() {
+        assert_eq!(
+            slim_citations("not json"),
+            "not json",
+            "an unexpected citations shape must survive unchanged"
+        );
+    }
+
+    #[test]
+    fn nl_field_slims_a_citations_tag() {
+        let embedded = serde_json::json!([{
+            "tag": "citations",
+            "value": serde_json::to_string(&serde_json::json!([{
+                "type": "NewsArticle", "id": "1",
+                "content": {"title": "T", "url": "http://x", "body": "huge body"}
+            }])).unwrap()
+        }])
+        .to_string();
+        let field = NlField::parse(&embedded);
+        let json = serde_json::to_value(&field).expect("field must serialize");
+        assert_eq!(json[0]["tag"], "citations", "the tag is preserved");
+        let inner: Vec<serde_json::Value> =
+            serde_json::from_str(json[0]["value"].as_str().expect("value is a string"))
+                .expect("slimmed citations must be JSON");
+        assert!(
+            inner[0].get("body").is_none() && inner[0]["title"] == "T",
+            "the citations tag value is slimmed in place"
         );
     }
 

--- a/src/tools/output/fact.rs
+++ b/src/tools/output/fact.rs
@@ -111,43 +111,42 @@ impl NlField {
 
 /// Slim the `citations` payload on a natural-language field.
 ///
-/// The value is a JSON-encoded array of the raw source documents behind the
-/// narrative — full article bodies, descriptions, favicons, source logos,
-/// member ids and display-ordering indices that together dominate a
-/// `security_facts` response (~75% of its bytes) while adding nothing beyond
-/// attribution. Reduce each citation to the provenance an AI consumer can act
-/// on: the source kind and drill-down `id` (fetch the article with
-/// `news_detail`), plus the human-facing `title`, `source`, `url` and
-/// `published_at`. A value that is not the expected JSON array is returned
-/// unchanged so an unexpected shape survives rather than being dropped.
+/// The value is a JSON-encoded array of the source documents behind the
+/// narrative. Each carries a readable summary an AI consumer may need even when
+/// the source URL is unreachable — a news/topic `description` or a web-search
+/// `content` snippet — which is kept. What is dropped is only the pure
+/// display/plumbing chrome (favicons, source logos, the derivable `domain`,
+/// internal `member_id`s, display-ordering indices) and the full-article `body`
+/// (redundant with the `description` summary and reachable via the retained
+/// `id`/`url`). Chrome plus the raw bodies dominate the payload, so this cuts
+/// roughly 60% of a `security_facts` response while losing no source's readable
+/// summary. A value that is not a JSON array is returned unchanged so an
+/// unexpected shape survives rather than being dropped.
 fn slim_citations(raw: &str) -> String {
-    let Ok(items) = serde_json::from_str::<Vec<serde_json::Value>>(raw) else {
+    /// Pure display / plumbing fields, plus the full-article `body`, dropped
+    /// from each citation and its nested source document.
+    const DROP: &[&str] = &[
+        "favicon",
+        "source_logo",
+        "source_url",
+        "domain",
+        "kind",
+        "content_via",
+        "member_id",
+        "logo",
+        "icon",
+        "index",
+        "original_index",
+        "body",
+    ];
+    let Ok(mut items) = serde_json::from_str::<serde_json::Value>(raw) else {
         return raw.to_owned();
     };
-    let is_empty = |v: &serde_json::Value| {
-        v.is_null() || matches!(v, serde_json::Value::String(s) if s.is_empty())
-    };
-    let slimmed: Vec<serde_json::Value> = items
-        .iter()
-        .map(|item| {
-            let content = item.get("content");
-            let mut out = serde_json::Map::new();
-            // Source kind and drill-down id come from the citation entry itself.
-            for key in ["type", "id"] {
-                if let Some(v) = item.get(key).filter(|v| !is_empty(v)) {
-                    out.insert(key.to_owned(), v.clone());
-                }
-            }
-            // Human-facing provenance comes from the nested source document.
-            for key in ["title", "source", "url", "published_at"] {
-                if let Some(v) = content.and_then(|c| c.get(key)).filter(|v| !is_empty(v)) {
-                    out.insert(key.to_owned(), v.clone());
-                }
-            }
-            serde_json::Value::Object(out)
-        })
-        .collect();
-    serde_json::to_string(&slimmed).unwrap_or_else(|_| raw.to_owned())
+    if !items.is_array() {
+        return raw.to_owned();
+    }
+    crate::serialize::drop_keys(&mut items, DROP);
+    serde_json::to_string(&items).unwrap_or_else(|_| raw.to_owned())
 }
 
 /// Natural-language rendering of a fact, in the caller's language.
@@ -368,47 +367,56 @@ mod tests {
     }
 
     #[test]
-    fn slim_citations_keeps_only_provenance() {
+    fn slim_citations_keeps_summaries_and_drops_chrome_and_body() {
         let raw = r#"[
             {"type":"NewsArticle","id":"9","index":3,"original_index":7,
-             "content":{"title":"T","source":"Nasdaq","url":"http://x",
-                        "favicon":"http://f","source_logo":"http://l",
-                        "body":"a very long article body","member_id":"42",
-                        "published_at":"2026-09-10T00:00:00Z"}},
+             "content":{"title":"NewsTitle","source":"Nasdaq","url":"http://x",
+                        "favicon":"http://f","source_logo":"http://l","domain":"nasdaq.com",
+                        "description":"a concise news summary","body":"the very long article body",
+                        "member_id":"42","published_at":"2026-09-10T00:00:00Z"}},
             {"type":"WebSearch",
-             "content":{"title":"W","source":"Bing","url":"http://y",
-                        "domain":"y.com","favicon":"http://g","content":"raw"}}
+             "content":{"title":"WebTitle","source":"Bing","url":"http://y",
+                        "domain":"y.com","favicon":"http://g","content":"a readable page snippet"}}
         ]"#;
         let out = slim_citations(raw);
         let v: Vec<serde_json::Value> = serde_json::from_str(&out).expect("slimmed must be JSON");
         assert_eq!(v.len(), 2, "every citation is kept");
-        assert_eq!(
-            v[0],
-            serde_json::json!({
-                "type": "NewsArticle", "id": "9", "title": "T",
-                "source": "Nasdaq", "url": "http://x",
-                "published_at": "2026-09-10T00:00:00Z"
-            }),
-            "a news citation keeps drill-down id + provenance, drops the raw body"
+        // Readable per-source summaries survive — the caller can read them even
+        // when the source URL is unreachable.
+        assert!(
+            out.contains("a concise news summary"),
+            "the news description summary must be kept"
         );
-        assert_eq!(
-            v[1],
-            serde_json::json!({
-                "type": "WebSearch", "title": "W", "source": "Bing", "url": "http://y"
-            }),
-            "a web citation keeps provenance; absent fields are omitted"
+        assert!(
+            out.contains("a readable page snippet"),
+            "the web-search content snippet must be kept"
         );
-        for heavy in [
-            "favicon",
-            "source_logo",
-            "body",
-            "member_id",
-            "original_index",
-            "domain",
+        // Drill-down and provenance survive.
+        for keep in [
+            "\"id\":\"9\"",
+            "http://x",
+            "Nasdaq",
+            "NewsTitle",
+            "WebTitle",
+            "2026-09-10",
         ] {
             assert!(
-                !out.contains(heavy),
-                "the heavy display/plumbing field {heavy} must be dropped"
+                out.contains(keep),
+                "the provenance field {keep} must be kept"
+            );
+        }
+        // Chrome and the full raw body are dropped.
+        for drop in [
+            "favicon",
+            "source_logo",
+            "\"domain\"",
+            "member_id",
+            "original_index",
+            "the very long article body",
+        ] {
+            assert!(
+                !out.contains(drop),
+                "the chrome/body field {drop} must be dropped"
             );
         }
     }
@@ -418,7 +426,12 @@ mod tests {
         assert_eq!(
             slim_citations("not json"),
             "not json",
-            "an unexpected citations shape must survive unchanged"
+            "an unparsable citations payload must survive unchanged"
+        );
+        assert_eq!(
+            slim_citations(r#"{"a":1}"#),
+            r#"{"a":1}"#,
+            "a non-array JSON citations payload must survive unchanged"
         );
     }
 
@@ -428,19 +441,20 @@ mod tests {
             "tag": "citations",
             "value": serde_json::to_string(&serde_json::json!([{
                 "type": "NewsArticle", "id": "1",
-                "content": {"title": "T", "url": "http://x", "body": "huge body"}
+                "content": {"title": "T", "url": "http://x",
+                            "description": "kept summary", "body": "huge body", "favicon": "f"}
             }])).unwrap()
         }])
         .to_string();
         let field = NlField::parse(&embedded);
         let json = serde_json::to_value(&field).expect("field must serialize");
         assert_eq!(json[0]["tag"], "citations", "the tag is preserved");
-        let inner: Vec<serde_json::Value> =
-            serde_json::from_str(json[0]["value"].as_str().expect("value is a string"))
-                .expect("slimmed citations must be JSON");
+        let value = json[0]["value"].as_str().expect("value is a string");
         assert!(
-            inner[0].get("body").is_none() && inner[0]["title"] == "T",
-            "the citations tag value is slimmed in place"
+            value.contains("kept summary")
+                && !value.contains("huge body")
+                && !value.contains("favicon"),
+            "the citations tag value is slimmed in place, keeping the summary"
         );
     }
 

--- a/src/tools/portfolio.rs
+++ b/src/tools/portfolio.rs
@@ -6,7 +6,9 @@ use rmcp::serde::Deserialize;
 use crate::counter::symbol_to_counter_id;
 use crate::error::Error;
 use crate::serialize::convert_unix_paths;
-use crate::tools::support::http_client::{http_get_tool, http_get_tool_unix};
+use crate::tools::support::http_client::{
+    http_get_tool, http_get_tool_dropping, http_get_tool_unix,
+};
 use crate::tools::tool_json;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -42,7 +44,16 @@ fn date_to_unix(s: &str, end_of_day: bool) -> Result<i64, McpError> {
 
 pub async fn exchange_rate(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {
     let client = mctx.create_http_client();
-    http_get_tool(&client, "/v1/asset/exchange_rates", &[]).await
+    // Longbridge's asset FX feed is a single mid-reference rate: `bid_rate` and
+    // `offer_rate` always equal `average_rate` (verified across all supported
+    // currencies), so they carry no spread information. Keep only `average_rate`.
+    http_get_tool_dropping(
+        &client,
+        "/v1/asset/exchange_rates",
+        &[],
+        &["bid_rate", "offer_rate"],
+    )
+    .await
 }
 
 pub async fn profit_analysis(

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -689,7 +689,12 @@ pub async fn history_market_temperature(
             mctx.evict_quote_context();
             Error::longbridge(e)
         })?;
-    tool_json(&result)
+    // The history series is numeric only: `description` (the point-in-time label
+    // populated by `market_temperature`) is empty on every row here — verified
+    // across markets and years. Drop it.
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    crate::serialize::drop_keys(&mut value, &["description"]);
+    tool_json(&value)
 }
 
 pub async fn watchlist(mctx: &crate::tools::McpContext) -> Result<CallToolResult, McpError> {

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -770,7 +770,12 @@ pub async fn warrant_list(
             mctx.evict_quote_context();
             Error::longbridge(e)
         })?;
-    tool_json(&result)
+    // Warrant analytics (premium, implied_volatility, delta, effective_leverage,
+    // leverage_ratio, balance_point, change_rate) serialize at ~17 significant
+    // digits; cap fractional precision at 6 across all 700+ rows.
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    crate::serialize::round_decimals(&mut value, 6);
+    tool_json(&value)
 }
 
 /// Default calc indexes when the caller omits `indexes`: common quote fields

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -277,6 +277,11 @@ pub async fn static_info(
             results.push(serde_json::to_value(&entry).map_err(Error::Serialize)?);
         }
     }
+    // eps/eps_ttm/bps/dividend_yield arrive with ~16 fractional digits of bogus
+    // precision (e.g. eps "27.3458639853059994"); cap at 6 dp. Integer share
+    // counts and non-numeric fields are left untouched.
+    let mut results = serde_json::Value::Array(results);
+    crate::serialize::round_decimals(&mut results, 6);
     tool_json(&results)
 }
 

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -400,7 +400,10 @@ pub async fn participants(mctx: &crate::tools::McpContext) -> Result<CallToolRes
         mctx.evict_quote_context();
         Error::longbridge(e)
     })?;
-    tool_json(&result)
+    // `name_hk` is the Traditional-script twin of `name_cn` on every broker row.
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    crate::serialize::drop_keys(&mut value, &["name_hk"]);
+    tool_json(&value)
 }
 
 pub async fn trades(
@@ -711,7 +714,10 @@ pub async fn warrant_issuers(mctx: &crate::tools::McpContext) -> Result<CallTool
         mctx.evict_quote_context();
         Error::longbridge(e)
     })?;
-    tool_json(&result)
+    // `name_hk` is the Traditional-script twin of `name_cn` on every issuer row.
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    crate::serialize::drop_keys(&mut value, &["name_hk"]);
+    tool_json(&value)
 }
 
 pub async fn warrant_list(

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -362,7 +362,10 @@ pub async fn warrant_quote(
         mctx.evict_quote_context();
         Error::longbridge(e)
     })?;
-    tool_json(&result)
+    // Cap warrant analytics precision at 6 dp (same as warrant_list).
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    crate::serialize::round_decimals(&mut value, 6);
+    tool_json(&value)
 }
 
 pub async fn depth(

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -693,7 +693,11 @@ pub async fn watchlist(mctx: &crate::tools::McpContext) -> Result<CallToolResult
         mctx.evict_quote_context();
         Error::longbridge(e)
     })?;
-    tool_json(&result)
+    // `market` on every security is derivable from the symbol suffix (and is
+    // "Unknown" for crypto).
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    crate::serialize::drop_keys(&mut value, &["market"]);
+    tool_json(&value)
 }
 
 pub async fn filings(

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -335,6 +335,9 @@ pub async fn quote(
     })?;
     let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
     normalize_extended_sessions(&mut value);
+    // Non-US symbols carry `pre_market_quote`/`post_market_quote`/
+    // `overnight_quote` as `null`; drop those (and any other absent optional).
+    crate::serialize::strip_nulls(&mut value);
     tool_json(&value)
 }
 
@@ -820,7 +823,12 @@ pub async fn calc_indexes(
         }
     }
 
-    tool_json(&result)
+    // `SecurityCalcIndex` is a wide struct: every one of its ~40 index fields
+    // the caller did not request serializes as an explicit `null`. Drop those
+    // so a per-symbol array doesn't carry ~38 dead `"x": null` pairs per row.
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    crate::serialize::strip_nulls(&mut value);
+    tool_json(&value)
 }
 
 pub async fn create_watchlist_group(

--- a/src/tools/quote.rs
+++ b/src/tools/quote.rs
@@ -9,7 +9,9 @@ use rmcp::serde::Deserialize;
 use crate::counter::symbol_to_counter_id;
 use crate::error::Error;
 use crate::tools::output;
-use crate::tools::support::http_client::{http_get_tool, http_get_tool_unix};
+use crate::tools::support::http_client::{
+    http_get_tool, http_get_tool_unix, http_get_tool_unix_dropping,
+};
 use crate::tools::support::parse;
 use crate::tools::support::tolerant::{
     tolerant_bool, tolerant_i64, tolerant_option_usize, tolerant_option_vec_i32,
@@ -1069,11 +1071,13 @@ pub async fn option_volume_daily(
         ("line_num", line_num.as_str()),
         ("direction", "1"),
     ];
-    http_get_tool_unix(
+    // `underlying_symbol` on every row == the queried `symbol`.
+    http_get_tool_unix_dropping(
         &client,
         "/v1/quote/option-volume-stats/daily",
         &params,
         &["stats.*.timestamp"],
+        &["underlying_symbol"],
     )
     .await
 }

--- a/src/tools/screener.rs
+++ b/src/tools/screener.rs
@@ -71,6 +71,9 @@ fn strip_strategy_keys(result: rmcp::model::CallToolResult) -> rmcp::model::Call
             strip_filter_prefix_from_strategy(s);
         }
     }
+    // Each filter condition carries a `min` and a `max`; the unbounded side is
+    // an empty string. Drop the blanks (an absent bound reads the same as "").
+    crate::serialize::strip_empty_strings(&mut d);
     let Ok(json) = serde_json::to_string(&d) else {
         return result;
     };

--- a/src/tools/screener.rs
+++ b/src/tools/screener.rs
@@ -426,30 +426,67 @@ pub async fn screener_search(
         .map_err(|e| Error::longbridge(e.into()))?;
 
     let json = crate::serialize::transform_json(resp.as_bytes()).map_err(Error::Serialize)?;
-    // Strip filter_ prefix from indicators[].key so keys are consistent with
-    // screener_indicators and conditions input (no filter_ prefix anywhere).
-    let json = strip_filter_prefix_from_search_results(json);
+    // Strip the filter_ prefix from indicators[].key (consistent with
+    // screener_indicators and the conditions input), hoist the repeated
+    // per-key name/unit labels into a top-level legend, and cap value precision.
+    let json = postprocess_search_results(json);
     Ok(crate::tools::tool_result(json))
 }
 
-/// Strip "filter_" prefix from `indicators[].key` in screener_search results.
-fn strip_filter_prefix_from_search_results(json: String) -> String {
+/// Post-process a screener_search response:
+/// 1. Strip the `filter_` prefix from every `indicators[].key`.
+/// 2. Hoist the per-key `name`/`unit` display labels — identical for a given
+///    key across all rows — into a single top-level `legend` (`{ key: { name,
+///    unit } }`), dropping them from each row's indicators.
+/// 3. Cap indicator value precision at 6 dp (upstream emits ~15 fractional
+///    digits on ratios like pettm/roe).
+fn postprocess_search_results(json: String) -> String {
     let Ok(mut d) = serde_json::from_str::<serde_json::Value>(&json) else {
         return json;
     };
+    let mut legend = serde_json::Map::new();
     if let Some(items) = d.get_mut("items").and_then(|v| v.as_array_mut()) {
         for item in items.iter_mut() {
-            if let Some(indicators) = item.get_mut("indicators").and_then(|v| v.as_array_mut()) {
-                for ind in indicators.iter_mut() {
-                    if let Some(k) = ind.get("key").and_then(|v| v.as_str()) {
-                        let stripped = k.strip_prefix("filter_").unwrap_or(k).to_string();
-                        if let Some(obj) = ind.as_object_mut() {
-                            obj.insert("key".to_string(), serde_json::Value::String(stripped));
-                        }
+            let Some(indicators) = item.get_mut("indicators").and_then(|v| v.as_array_mut()) else {
+                continue;
+            };
+            for ind in indicators.iter_mut() {
+                let Some(obj) = ind.as_object_mut() else {
+                    continue;
+                };
+                let key = obj
+                    .get("key")
+                    .and_then(|v| v.as_str())
+                    .map(|k| k.strip_prefix("filter_").unwrap_or(k).to_string());
+                let Some(key) = key else {
+                    continue;
+                };
+                let name = obj.remove("name");
+                let unit = obj.remove("unit");
+                // Record this key's labels once. A null or empty-string label
+                // carries nothing, so it is not stored.
+                if !legend.contains_key(&key) {
+                    let is_empty = |v: &serde_json::Value| {
+                        v.is_null() || v.as_str().is_some_and(str::is_empty)
+                    };
+                    let mut meta = serde_json::Map::new();
+                    if let Some(name) = name.filter(|v| !is_empty(v)) {
+                        meta.insert("name".to_string(), name);
                     }
+                    if let Some(unit) = unit.filter(|v| !is_empty(v)) {
+                        meta.insert("unit".to_string(), unit);
+                    }
+                    legend.insert(key.clone(), serde_json::Value::Object(meta));
                 }
+                obj.insert("key".to_string(), serde_json::Value::String(key));
             }
         }
+    }
+    crate::serialize::round_decimals(&mut d, 6);
+    if let Some(obj) = d.as_object_mut()
+        && !legend.is_empty()
+    {
+        obj.insert("legend".to_string(), serde_json::Value::Object(legend));
     }
     serde_json::to_string(&d).unwrap_or(json)
 }
@@ -547,4 +584,71 @@ fn strip_filter_prefix_from_indicators(
         return result;
     };
     crate::tools::tool_result(json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::postprocess_search_results;
+
+    #[test]
+    fn postprocess_hoists_legend_strips_prefix_and_rounds() {
+        let input = serde_json::json!({
+            "total": 839,
+            "items": [
+                {"symbol": "2460.HK", "name": "华润饮料", "indicators": [
+                    {"key": "filter_pettm", "name": "市盈率(TTM)", "value": "19.991124831097526", "unit": ""},
+                    {"key": "filter_marketcap", "name": "市值", "value": "17027195860", "unit": "亿"}
+                ]},
+                {"symbol": "866.HK", "name": "中国秦发", "indicators": [
+                    {"key": "filter_pettm", "name": "市盈率(TTM)", "value": "19.96675598973656", "unit": ""},
+                    {"key": "filter_marketcap", "name": "市值", "value": "5609528857.974999", "unit": "亿"}
+                ]}
+            ]
+        })
+        .to_string();
+        let out: serde_json::Value =
+            serde_json::from_str(&postprocess_search_results(input)).expect("valid JSON");
+
+        // Legend carries each key's labels exactly once.
+        assert_eq!(out["legend"]["pettm"]["name"], "市盈率(TTM)");
+        assert_eq!(out["legend"]["marketcap"]["unit"], "亿");
+        // Empty unit is omitted from the legend entry.
+        assert!(
+            out["legend"]["pettm"].get("unit").is_none(),
+            "an empty unit is not recorded"
+        );
+
+        let rows = out["items"].as_array().expect("items is an array");
+        for row in rows {
+            for ind in row["indicators"]
+                .as_array()
+                .expect("indicators is an array")
+            {
+                // filter_ prefix stripped; name/unit dropped from every row.
+                assert!(
+                    ind["key"]
+                        .as_str()
+                        .is_some_and(|k| !k.starts_with("filter_")),
+                    "filter_ prefix is stripped"
+                );
+                assert!(ind.get("name").is_none(), "per-row name is hoisted away");
+                assert!(ind.get("unit").is_none(), "per-row unit is hoisted away");
+            }
+        }
+        // Bogus precision is capped; already-short/integer values untouched.
+        assert_eq!(rows[0]["indicators"][0]["value"], "19.991125");
+        assert_eq!(
+            rows[0]["indicators"][1]["value"], "17027195860",
+            "integers are left alone"
+        );
+        assert_eq!(
+            rows[1]["indicators"][1]["value"], "5609528857.974999",
+            "exactly-6dp values are left alone"
+        );
+    }
+
+    #[test]
+    fn postprocess_passes_through_unparsable_payload() {
+        assert_eq!(postprocess_search_results("not json".into()), "not json");
+    }
 }

--- a/src/tools/signal.rs
+++ b/src/tools/signal.rs
@@ -96,6 +96,23 @@ fn unwrap_embedded_json(raw: &str) -> serde_json::Value {
     serde_json::from_str(raw).unwrap_or_else(|_| serde_json::Value::String(raw.to_owned()))
 }
 
+/// The embedded analysis document repeats the signal's `summary` and `title`
+/// verbatim inside `analysis.signal`; the canonical copies already sit at the
+/// top level, so drop the nested duplicates. The summary alone runs to ~1 KB of
+/// Markdown, so this is the largest single redundancy in a `signal_detail`
+/// payload. `outlook_desc` is deliberately kept — it is the *localized* outlook
+/// label (e.g. "强烈看多"), not a verbatim copy of the English `outlook` enum.
+fn drop_analysis_duplicates(item: &mut serde_json::Value) {
+    if let Some(signal) = item
+        .get_mut("analysis")
+        .and_then(|a| a.get_mut("signal"))
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        signal.remove("summary");
+        signal.remove("title");
+    }
+}
+
 /// `GET /v1/signals/{signal_id}` — one signal with its full analysis.
 pub async fn signal_detail(
     mctx: &crate::tools::McpContext,
@@ -107,7 +124,9 @@ pub async fn signal_detail(
     let analysis = unwrap_embedded_json(&signal.json_data);
     let mut item = SignalItem::from(signal);
     item.analysis = Some(analysis);
-    tool_json(&item)
+    let mut value = serde_json::to_value(&item).map_err(Error::Serialize)?;
+    drop_analysis_duplicates(&mut value);
+    tool_json(&value)
 }
 
 /// `GET /v1/facts/security_facts` — the fact (catalyst) events behind signals.
@@ -148,6 +167,59 @@ mod tests {
             v,
             serde_json::Value::String("not json".into()),
             "an unparsable payload must survive rather than be dropped"
+        );
+    }
+
+    #[test]
+    fn drop_analysis_duplicates_removes_nested_summary_and_title_only() {
+        let mut value = serde_json::json!({
+            "summary": "canonical summary",
+            "title": "canonical title",
+            "outlook": "Bullish",
+            "outlook_desc": "强烈看多",
+            "analysis": {
+                "confidence": "high",
+                "signal": {
+                    "summary": "canonical summary",
+                    "title": "canonical title",
+                    "outlook_desc": "强烈看多",
+                    "strategy_fit": 88
+                }
+            }
+        });
+        drop_analysis_duplicates(&mut value);
+
+        let signal = &value["analysis"]["signal"];
+        assert!(
+            signal.get("summary").is_none(),
+            "the nested verbatim summary duplicate must be dropped"
+        );
+        assert!(
+            signal.get("title").is_none(),
+            "the nested verbatim title duplicate must be dropped"
+        );
+        // Distinct nested data survives.
+        assert_eq!(
+            signal["strategy_fit"], 88,
+            "unrelated nested fields must be preserved"
+        );
+        // Top-level canonical copies survive.
+        assert_eq!(
+            value["summary"], "canonical summary",
+            "the top-level summary must be kept"
+        );
+        assert_eq!(
+            value["title"], "canonical title",
+            "the top-level title must be kept"
+        );
+        // The localized outlook label is kept, not treated as a duplicate.
+        assert_eq!(
+            value["outlook_desc"], "强烈看多",
+            "the localized outlook label must be preserved"
+        );
+        assert_eq!(
+            value["analysis"]["signal"]["outlook_desc"], "强烈看多",
+            "the nested localized outlook label must be preserved"
         );
     }
 }

--- a/src/tools/support/http_client.rs
+++ b/src/tools/support/http_client.rs
@@ -83,6 +83,32 @@ pub async fn http_get_tool_dropping(
     Ok(success_with_structured(json))
 }
 
+/// Combines `http_get_tool_unix` (unix-seconds → RFC3339 at `unix_paths`) with
+/// `drop` key removal, for passthrough tools that need both.
+pub async fn http_get_tool_unix_dropping(
+    client: &HttpClient,
+    path: &str,
+    params: &[(&str, &str)],
+    unix_paths: &[&str],
+    drop: &[&str],
+) -> Result<CallToolResult, McpError> {
+    let params: Vec<(&str, &str)> = params.to_vec();
+    let resp: String = client
+        .request(Method::GET, path)
+        .query_params(params)
+        .response::<String>()
+        .send()
+        .await
+        .map_err(|e| Error::longbridge(e.into()))?;
+    let transformed = transform_json(resp.as_bytes()).map_err(Error::Serialize)?;
+    let mut value: serde_json::Value =
+        serde_json::from_str(&transformed).map_err(Error::Serialize)?;
+    convert_unix_paths(&mut value, unix_paths);
+    crate::serialize::drop_keys(&mut value, drop);
+    let json = serde_json::to_string(&value).map_err(Error::Serialize)?;
+    Ok(success_with_structured(json))
+}
+
 /// Same as `http_get_tool`, but after the standard transform runs, the
 /// specified `unix_paths` are walked and any unix-seconds strings found are
 /// converted to RFC3339 in place. Use this for tools whose upstream returns

--- a/src/tools/support/http_client.rs
+++ b/src/tools/support/http_client.rs
@@ -109,6 +109,35 @@ pub async fn http_get_tool_unix_dropping(
     Ok(success_with_structured(json))
 }
 
+/// Combines `http_get_tool_unix` (unix-seconds → RFC3339 at `unix_paths`) with
+/// decimal-precision capping: every string number in the response with more
+/// than `dp` fractional digits is rounded to `dp` places. For passthrough tools
+/// whose upstream emits absurd precision (e.g. 19-decimal prices) that no
+/// consumer needs.
+pub async fn http_get_tool_unix_rounding(
+    client: &HttpClient,
+    path: &str,
+    params: &[(&str, &str)],
+    unix_paths: &[&str],
+    dp: u32,
+) -> Result<CallToolResult, McpError> {
+    let params: Vec<(&str, &str)> = params.to_vec();
+    let resp: String = client
+        .request(Method::GET, path)
+        .query_params(params)
+        .response::<String>()
+        .send()
+        .await
+        .map_err(|e| Error::longbridge(e.into()))?;
+    let transformed = transform_json(resp.as_bytes()).map_err(Error::Serialize)?;
+    let mut value: serde_json::Value =
+        serde_json::from_str(&transformed).map_err(Error::Serialize)?;
+    convert_unix_paths(&mut value, unix_paths);
+    crate::serialize::round_decimals(&mut value, dp);
+    let json = serde_json::to_string(&value).map_err(Error::Serialize)?;
+    Ok(success_with_structured(json))
+}
+
 /// Same as `http_get_tool`, but after the standard transform runs, the
 /// specified `unix_paths` are walked and any unix-seconds strings found are
 /// converted to RFC3339 in place. Use this for tools whose upstream returns

--- a/src/tools/support/http_client.rs
+++ b/src/tools/support/http_client.rs
@@ -162,6 +162,31 @@ pub async fn http_post_tool_unix(
     result_from_raw_json_with_unix_paths(&resp, unix_paths)
 }
 
+/// `http_post_tool_unix` plus `drop` key removal, for POST passthrough tools
+/// that need both unix conversion and field trimming.
+pub async fn http_post_tool_unix_dropping(
+    client: &HttpClient,
+    path: &str,
+    body: serde_json::Value,
+    unix_paths: &[&str],
+    drop: &[&str],
+) -> Result<CallToolResult, McpError> {
+    let resp: String = client
+        .request(Method::POST, path)
+        .body(Json(body))
+        .response::<String>()
+        .send()
+        .await
+        .map_err(|e| Error::longbridge(e.into()))?;
+    let transformed = transform_json(resp.as_bytes()).map_err(Error::Serialize)?;
+    let mut value: serde_json::Value =
+        serde_json::from_str(&transformed).map_err(Error::Serialize)?;
+    convert_unix_paths(&mut value, unix_paths);
+    crate::serialize::drop_keys(&mut value, drop);
+    let json = serde_json::to_string(&value).map_err(Error::Serialize)?;
+    Ok(success_with_structured(json))
+}
+
 pub async fn http_delete_tool(
     client: &HttpClient,
     path: &str,

--- a/src/tools/support/http_client.rs
+++ b/src/tools/support/http_client.rs
@@ -146,24 +146,8 @@ pub async fn http_post_tool(
     result_from_raw_json(&resp)
 }
 
-pub async fn http_post_tool_unix(
-    client: &HttpClient,
-    path: &str,
-    body: serde_json::Value,
-    unix_paths: &[&str],
-) -> Result<CallToolResult, McpError> {
-    let resp: String = client
-        .request(Method::POST, path)
-        .body(Json(body))
-        .response::<String>()
-        .send()
-        .await
-        .map_err(|e| Error::longbridge(e.into()))?;
-    result_from_raw_json_with_unix_paths(&resp, unix_paths)
-}
-
-/// `http_post_tool_unix` plus `drop` key removal, for POST passthrough tools
-/// that need both unix conversion and field trimming.
+/// POST passthrough with unix conversion at `unix_paths` and `drop` key
+/// removal.
 pub async fn http_post_tool_unix_dropping(
     client: &HttpClient,
     path: &str,

--- a/src/tools/support/http_client.rs
+++ b/src/tools/support/http_client.rs
@@ -109,6 +109,32 @@ pub async fn http_get_tool_unix_dropping(
     Ok(success_with_structured(json))
 }
 
+/// Same as `http_get_tool`, but after the standard transform runs, every string
+/// number in the response with more than `dp` fractional digits is rounded to
+/// `dp` places. For passthrough tools whose upstream emits absurd precision
+/// (e.g. 16-19 fractional digits on valuation ratios) that no consumer needs.
+pub async fn http_get_tool_rounding(
+    client: &HttpClient,
+    path: &str,
+    params: &[(&str, &str)],
+    dp: u32,
+) -> Result<CallToolResult, McpError> {
+    let params: Vec<(&str, &str)> = params.to_vec();
+    let resp: String = client
+        .request(Method::GET, path)
+        .query_params(params)
+        .response::<String>()
+        .send()
+        .await
+        .map_err(|e| Error::longbridge(e.into()))?;
+    let transformed = transform_json(resp.as_bytes()).map_err(Error::Serialize)?;
+    let mut value: serde_json::Value =
+        serde_json::from_str(&transformed).map_err(Error::Serialize)?;
+    crate::serialize::round_decimals(&mut value, dp);
+    let json = serde_json::to_string(&value).map_err(Error::Serialize)?;
+    Ok(success_with_structured(json))
+}
+
 /// Combines `http_get_tool_unix` (unix-seconds → RFC3339 at `unix_paths`) with
 /// decimal-precision capping: every string number in the response with more
 /// than `dp` fractional digits is rounded to `dp` places. For passthrough tools

--- a/src/tools/support/http_client.rs
+++ b/src/tools/support/http_client.rs
@@ -135,6 +135,31 @@ pub async fn http_get_tool_rounding(
     Ok(success_with_structured(json))
 }
 
+/// Same as `http_get_tool`, but after the standard transform runs, every plain
+/// decimal string has its non-significant trailing zeros stripped (lossless).
+/// For passthrough tools whose upstream pads integer counts with a fake
+/// fractional part (e.g. share-count deltas stored as `"123.0000"`).
+pub async fn http_get_tool_trimming_zeros(
+    client: &HttpClient,
+    path: &str,
+    params: &[(&str, &str)],
+) -> Result<CallToolResult, McpError> {
+    let params: Vec<(&str, &str)> = params.to_vec();
+    let resp: String = client
+        .request(Method::GET, path)
+        .query_params(params)
+        .response::<String>()
+        .send()
+        .await
+        .map_err(|e| Error::longbridge(e.into()))?;
+    let transformed = transform_json(resp.as_bytes()).map_err(Error::Serialize)?;
+    let mut value: serde_json::Value =
+        serde_json::from_str(&transformed).map_err(Error::Serialize)?;
+    crate::serialize::strip_trailing_zeros(&mut value);
+    let json = serde_json::to_string(&value).map_err(Error::Serialize)?;
+    Ok(success_with_structured(json))
+}
+
 /// Combines `http_get_tool_unix` (unix-seconds → RFC3339 at `unix_paths`) with
 /// decimal-precision capping: every string number in the response with more
 /// than `dp` fractional digits is rounded to `dp` places. For passthrough tools

--- a/src/tools/support/http_client.rs
+++ b/src/tools/support/http_client.rs
@@ -58,6 +58,31 @@ pub async fn http_get_tool(
     result_from_raw_json(&resp)
 }
 
+/// Same as `http_get_tool`, but after the standard transform runs, the given
+/// (snake_case) `drop` keys are removed from every object in the response at any
+/// depth. For passthrough tools that echo upstream fields with no analytic
+/// value (duplicate `code`, derivable `market`, constant flags, display URLs).
+pub async fn http_get_tool_dropping(
+    client: &HttpClient,
+    path: &str,
+    params: &[(&str, &str)],
+    drop: &[&str],
+) -> Result<CallToolResult, McpError> {
+    let params: Vec<(&str, &str)> = params.to_vec();
+    let resp: String = client
+        .request(Method::GET, path)
+        .query_params(params)
+        .response::<String>()
+        .send()
+        .await
+        .map_err(|e| Error::longbridge(e.into()))?;
+    let json = transform_json(resp.as_bytes()).map_err(Error::Serialize)?;
+    let mut value: serde_json::Value = serde_json::from_str(&json).map_err(Error::Serialize)?;
+    crate::serialize::drop_keys(&mut value, drop);
+    let json = serde_json::to_string(&value).map_err(Error::Serialize)?;
+    Ok(success_with_structured(json))
+}
+
 /// Same as `http_get_tool`, but after the standard transform runs, the
 /// specified `unix_paths` are walked and any unix-seconds strings found are
 /// converted to RFC3339 in place. Use this for tools whose upstream returns

--- a/src/tools/trade.rs
+++ b/src/tools/trade.rs
@@ -447,6 +447,7 @@ pub async fn today_orders(
                 crate::tools::support::us_normalize::normalize_us_order(order);
             }
         }
+        crate::serialize::strip_nulls(&mut value);
         return tool_json(&value);
     }
     let mut opts = GetTodayOrdersOptions::new();
@@ -460,7 +461,11 @@ pub async fn today_orders(
         opts = opts.is_attached();
     }
     let result = ctx.today_orders(opts).await.map_err(Error::longbridge)?;
-    tool_json(&result)
+    // Plain market/limit orders leave the ~9 conditional-order fields
+    // (trigger_*, trailing_*, monitor_price, limit_*) as null — drop them.
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    crate::serialize::strip_nulls(&mut value);
+    tool_json(&value)
 }
 
 pub async fn order_detail(
@@ -600,6 +605,7 @@ pub async fn history_orders(
                 crate::tools::support::us_normalize::normalize_us_order(order);
             }
         }
+        crate::serialize::strip_nulls(&mut value);
         return tool_json(&value);
     }
     let mut opts = longbridge::trade::GetHistoryOrdersOptions::new()
@@ -609,7 +615,9 @@ pub async fn history_orders(
         opts = opts.symbol(symbol);
     }
     let result = ctx.history_orders(opts).await.map_err(Error::longbridge)?;
-    tool_json(&result)
+    let mut value = serde_json::to_value(&result).map_err(Error::Serialize)?;
+    crate::serialize::strip_nulls(&mut value);
+    tool_json(&value)
 }
 
 pub async fn history_executions(


### PR DESCRIPTION
## Goal

Trim redundant/empty/duplicate fields from tool return values to cut token cost for AI consumers, from the production field audit (all 138 read tools called live). Tool-by-tool; each commit an independent, tested step. Write operations skipped.

## Reusable helpers

`src/serialize/mod.rs`: **strip_nulls** (drop null keys), **drop_keys** (drop named keys recursively), **round_decimals(v,6)** (cap decimal precision, keeps ≥6 dp; leaves symbols/dates/prices untouched), **strip_trailing_zeros** (lossless — drop non-significant trailing zeros, e.g. `"123.0000"`→`"123"`), **strip_empty_strings** (drop empty-string object entries, sibling of strip_nulls), **strip_cashtags_in_field** (rewrite `[st]…#Ticker[/st]` markup to the readable ticker), **strip_html_tags_in_field** (drop `<strong>`-style markup, keep the text).
`src/tools/support/http_client.rs`: **http_get_tool_dropping**, **http_get_tool_unix_dropping**, **http_post_tool_unix_dropping** (fetch + drop for passthrough tools), **http_get_tool_rounding** / **http_get_tool_unix_rounding** (fetch + cap decimal precision), **http_get_tool_trimming_zeros** (fetch + strip trailing zeros).

## Mechanical trims (helper-applied)

- **calc_indexes**, **quote**, **today_orders/history_orders** — strip null fields; **quote** and **depth** also strip fixed-decimal price/turnover padding (lossless).
- **today_orders / history_orders / order_detail / today_executions / history_executions** — strip fixed-decimal padding on order/execution prices + amounts (lossless).
- **rank_list**, **constituent**, **valuation_rank**, **option_volume_daily**, **ah_premium**, **industry_peers**, **shareholder**, **top_movers**, **watchlist** — drop duplicate/derivable/constant/display keys (code, market, delay, icons, empty scaffolding, etc.).
- **financial_report** — drop entry/periods scaffolding, cap yoy (~14dp) at 6dp, strip empty ratio/short_title/tip/ranking display fields.
- **operating** — drop keywords/web_url, strip the always-empty financial.{symbol,name,region,code,report,report_txt} labels.
- **financial_statement** — drop value_type/display_order render metadata, cap line-value (~8dp) + yoy (~16dp) precision at 6dp, and strip empty header/no-base value/yoy/field; ~33% off a 5-year statement.
- **valuation_history** — drop ~90% chart scaffolding (symbols/layouts/aichat_data/circle/part/ai_summary), strip market_cap zero-padding + empty peer ticker/growth + `<strong>` markup in desc.
- **valuation** — strip `<strong>` markup from the desc summary (non-US path).
- **business_segments / business_segments_history** — cap yoy precision (~14dp) at 6dp + drop empty (first-)period yoy.
- **warrant_list / warrant_quote** — cap decimal precision at 6 dp.
- **participants / warrant_issuers** — drop name_hk (Traditional dup of name_cn).
- **invest_relation** — drop the name triplicate (company_name_zhcn/company_name_en, unpopulated dups of company_name) + constant company_id.
- **institutional_views** — cap tlist price precision at 6 dp (upstream emits ~19 bogus digits).
- **executive** — drop the name triplicate (name_zhcn/name_en, unpopulated dups of name) + display-only photo URL.
- **fund_holder** — drop code (symbol without market suffix — derivable).
- **valuation_comparison** — cap all valuation-ratio precision at 6 dp (~16-19 bogus digits on metrics + every history row).
- **static_info** — cap eps/eps_ttm/bps/dividend_yield at 6 dp (~16 bogus digits); names + integer share counts kept.
- **ipo_detail** — cap investor capital_ratio (and any >6dp number) at 6 dp.
- **industry_valuation_dist** — cap pe/pb/ps bounds + ranking at 6 dp.
- **industry_valuation** — cap valuation ratios + per-share figures at 6 dp (~22 bogus digits on metrics + every history row across all peers); ~25% off.
- **dividend_detail** — drop the always-empty per-row symbol.
- **dividend** — drop per-row symbol (query echo) + always-empty dividend_summary object.
- **financial_report_snapshot** — drop the always-blank est_value/est_yoy/cmp/cmp_desc on every fr_* ratio object (only fo_* forecast rows use them) + strip the 4-digit zero padding on every figure; ~33% off.
- **broker_holding_detail / broker_holding** — strip fake `.0000` on integer share-count deltas (lossless; ~14% off a ~120KB HK payload).
- **short_trades** — strip `.00` padding on the HK balance (lossless).
- **trade_stats** — strip fixed-decimal padding on price-level prices + avgprice/preclose (lossless).
- **account_balance / stock_positions / fund_positions** — strip fixed-decimal padding on cash/margin amounts, cost_price, and fund NAV figures (lossless).
- **candlesticks / history_candlesticks_by_offset / history_candlesticks_by_date / intraday / trades** — strip fixed-decimal padding on OHLC/trade prices + turnover (lossless; high-volume responses, up to 1000 rows).
- **corp_action** — drop date_str (date reformatted), date_zone (constant label), security (always null), live.icon (constant badge URL).
- **finance_calendar** — drop always-empty (chart_uid, financial_market_time), constant (star, source_type), and display (icon, widget_short_display_date, empty data_kv key) fields; ~24% off a ~70KB payload. Verified across dividend AND report categories that date_type/live carry real data → kept.
- **macrodata_indicators** — drop per-indicator describe essay (directory listing).
- **history_market_temperature** — drop always-empty description (numeric-only history series; verified across markets/years).
- **industry_rank** — strip empty group-wrapper fields + value_name/value_data/prev_close columns (empty unless a value-indicator is requested).
- **ipo_listed** — drop per-entry market (implied by hk/us grouping) + icon URL.
- **ipo_subscriptions** — drop per-entry icon URL + empty stock_desc/order_method/declaration.
- **exchange_rate** — drop bid_rate/offer_rate (verified always == average_rate across all currencies; single mid-reference feed).
- **topic / topic_detail / news / news_detail / topic_replies** — strip `[st]…#Ticker[/st]` cashtag markup; news_detail/topic_replies also drop the display-only author avatar URL.

## Bespoke restructures (verified against real data, golden-tested)

- **screener_recommend_strategies / screener_user_strategies / screener_strategy** — strip the blank min/max bound on each filter condition (unbounded side is an empty string).
- **screener_search** — hoist the per-key indicator name/unit labels (repeated on every row) into a top-level legend, drop them from each row, and cap value precision at 6 dp; ~39% off a typical 20-row page. Golden-tested.
- **consensus** — hoist the per-metric name/description (repeated across ~12 periods) into a single `legend`; drop empty unreleased-period fields.
- **institution_rating_history** — collapse consecutive-unchanged rows into spans (566→~76 rows, ~87%); drop derivable total; round target prices. Verified: total==sum for all rows, fully contiguous, no change-point lost.
- **shareholder_top** — drop per-holder redundant period + empty title; **keep the "最新" segment** (verified NOT a dup of the newest quarter — percent_shares_* recompute against current shares).
- **institution_rating_detail** — drop target.list[].date (duplicates its timestamp's day; evaluate.list[] keeps date, it has no timestamp) and cap avg/min/max_target (~21dp) + prediction_accuracy (~18dp) at 6 dp; ~20% off an 80KB payload. Golden-tested.
- **institution_rating** — drop `instratings.evaluate` (a renamed, lower-detail dup of `analyst.evaluate`) + ccy_symbol; keep instratings' unique recommend/target/change.
- **ah_premium_intraday** — drop always-empty price_spread, and hoist the prior-close fields (apreclose/hpreclose, fixed all day) out of the ~240 minute bars to a single top-level copy; ~32% off a full-day response. Golden-tested.
- **signal_detail** — drop the nested verbatim `analysis.signal.summary` (~1 KB Markdown) + `title` duplicates of the top-level copies. **outlook_desc kept** (verified it is the *localized* outlook label, not a verbatim dup of the English `outlook` enum).
- **security_facts** — slim the `citations` blob embedded in each fact's `nl_info` fields. Keep every source's readable summary (news/topic `description`, web-search `content` snippet) so it survives a dead URL; drop only pure display/plumbing chrome (favicon, source_logo, domain, member_id, indices) and the full-article `body` (redundant with the description, reachable via id/url). Real data: ~23% off the citations, ~18% off a `security_facts` response, no readable summary lost.

## Correctness fixes (bundled)

Two timestamp fields returned raw unix values a model cannot interpret; now converted to RFC3339 like every other time field (slightly *larger*, but usable):
- **anomaly** — `alert_time` (was a raw unix-seconds string).
- **ipo_calendar** — per-IPO `sub_date`/`sub_end_date`/`result_date`/`mart_date`/`ipo_date` (only the top-level `timestamp` was converted before).

## Risk review (self-audit)

Reviewed the branch specifically for defects; findings and resolution:

- **round_decimals padding (fixed)** — `round_dp(6)` fixes the scale to 6 places, so a >6dp value that rounds to trailing zeros came back padded (`"35.30000001"`→`"35.300000"`). Added `.normalize()` so the rounded result carries no trailing zeros; verified it never emits scientific notation (`"5000000000.0000001"`→`"5000000000"`). Covers all round_decimals call sites. Golden-tested.
- **numeric unix conversion (fixed)** — `convert_unix_paths` only handled JSON *strings*, so the `ipo_calendar` date fields (unquoted JSON *numbers*) were silently skipped — the earlier conversion was a no-op (and this had also silently broken the pre-existing top-level `timestamp`). `walk_convert` now converts numeric unix values too; the `[2000,2100]` range guard still excludes sentinels (`0`), `yyyymmdd` ints and ids. Verified across all ~15 callers + a numeric golden test.
- **tree-wide `strip_trailing_zeros` (audited, kept)** — applied over whole response trees on quote/depth/trades/orders/account/etc. Audited 20 real saved responses for any plain-decimal string where a trailing zero is meaningful (version/code/identifier): none found — every match is money/price/count/ratio/bound. The `[-]?\d+\.\d+` whole-string guard already excludes symbols, dates, multi-dot and letter-bearing codes. Left tree-wide deliberately: narrowing to per-field paths would be verbose and risk *incomplete* coverage.
- **format changes (intentional, isolated)** — two fields change *form*, not just size: `anomaly.alert_time` and the `ipo_calendar` dates go unix→RFC3339 (fixing an inconsistency — every other timestamp is already RFC3339), and padded decimals lose trailing zeros (`"428.400"`→`"428.4"`). Harmless for an LLM consumer; the unix conversions are isolated in their own commits so a conservative rollout can revert or split them trivially.
- **`strip_empty_strings` vs output_schema** — confirmed none of the tools that gained `strip_empty_strings` declare an `output_schema`, so no required-field validation risk. Where schemas exist (screener_search etc.), only `Option`/nullable fields are dropped and the added `legend` is documented in the schema.

## Testing

`cargo test` 273 passed; `cargo clippy --all-features --all-targets` clean; `cargo +nightly fmt` no diff. Golden tests for every helper and bespoke restructure. Every trim verified against live production data (before/after diffs).
