### PR TITLE
fix(tools): executions use v3 /execution/all + document trade_id

### DIFF
--- a/locales/zh-CN/tools.json
+++ b/locales/zh-CN/tools.json
@@ -151,7 +151,7 @@
     },
     "history_executions": {
       "title": "历史成交",
-      "description": "查询指定日期区间内的历史成交记录，返回 executions[]{order_id, symbol, side, quantity, price, trade_done_at}",
+      "description": "查询指定日期区间内的全部成交记录，按成交时间（trade_done_at）筛选并自动翻页返回完整结果（不受每页 1000 条截断），trade_id 为稳定去重键。返回 executions[]{order_id, trade_id, symbol, side, quantity, price, trade_done_at}",
       "properties": {
         "symbol": "按证券筛选（可选）",
         "start_at": "起始时间（RFC3339 格式）",
@@ -179,7 +179,7 @@
     },
     "today_executions": {
       "title": "当日成交",
-      "description": "查询当日成交（filled），返回 executions[]{order_id, symbol, side, quantity, price, trade_done_at}。可按 symbol 或 order_id 筛选",
+      "description": "查询当日成交（filled），返回 executions[]{order_id, trade_id, symbol, side, quantity, price, trade_done_at}。可按 symbol 或 order_id 筛选",
       "properties": {
         "symbol": "按证券筛选，例如 `\"700.HK\"`",
         "order_id": "按指定委托单号筛选"

--- a/locales/zh-HK/tools.json
+++ b/locales/zh-HK/tools.json
@@ -151,7 +151,7 @@
     },
     "history_executions": {
       "title": "歷史成交",
-      "description": "查詢指定日期區間內的歷史成交記錄，返回 executions[]{order_id, symbol, side, quantity, price, trade_done_at}",
+      "description": "查詢指定日期區間內的全部成交記錄，按成交時間（trade_done_at）篩選並自動翻頁返回完整結果（不受每頁 1000 條截斷），trade_id 為穩定去重鍵。返回 executions[]{order_id, trade_id, symbol, side, quantity, price, trade_done_at}",
       "properties": {
         "symbol": "按證券篩選（可選）",
         "start_at": "起始時間（RFC3339 時間格式）",
@@ -179,7 +179,7 @@
     },
     "today_executions": {
       "title": "當日成交",
-      "description": "查詢當日成交（filled），返回 executions[]{order_id, symbol, side, quantity, price, trade_done_at}。可按 symbol 或 order_id 篩選",
+      "description": "查詢當日成交（filled），返回 executions[]{order_id, trade_id, symbol, side, quantity, price, trade_done_at}。可按 symbol 或 order_id 篩選",
       "properties": {
         "symbol": "按證券篩選，例如 `\"700.HK\"`",
         "order_id": "按指定委託單號篩選"

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2429,7 +2429,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        description = "Get today's trade executions (fills). Returns executions[]{order_id, symbol, side, quantity, price, trade_done_at}. Pass symbol or order_id to filter."
+        description = "Get today's trade executions (fills). Returns executions[]{order_id, trade_id, symbol, side, quantity, price, trade_done_at}. Pass symbol or order_id to filter."
     )]
     async fn today_executions(
         &self,
@@ -2475,7 +2475,7 @@ impl Longbridge {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        description = "Get historical trade executions between dates. Returns executions[]{order_id, symbol, side, quantity, price, trade_done_at}. start_at/end_at in RFC3339."
+        description = "Get every trade execution (fill) in a date range, filtered by execution time (trade_done_at) and auto-paginated to return the complete set (never truncated at the 1000-per-page cap). Returns executions[]{order_id, trade_id, symbol, side, quantity, price, trade_done_at}; trade_id is the stable dedupe key. start_at/end_at in RFC3339."
     )]
     async fn history_executions(
         &self,

--- a/src/tools/trade.rs
+++ b/src/tools/trade.rs
@@ -616,41 +616,43 @@ pub async fn history_executions(
     mctx: &crate::tools::McpContext,
     p: HistoryOrdersParam,
 ) -> Result<CallToolResult, McpError> {
-    use std::collections::HashMap;
-
     let start = parse::parse_rfc3339(&p.start_at)?;
     let end = parse::parse_rfc3339(&p.end_at)?;
 
-    let mut exec_opts = longbridge::trade::GetHistoryExecutionsOptions::new()
-        .start_at(start)
-        .end_at(end);
-    let mut order_opts = longbridge::trade::GetHistoryOrdersOptions::new()
-        .start_at(start)
-        .end_at(end);
-    if let Some(ref symbol) = p.symbol {
-        exec_opts = exec_opts.symbol(symbol.clone());
-        order_opts = order_opts.symbol(symbol.clone());
-    }
-
     let (ctx, _) = TradeContext::new(mctx.create_config());
-    let (executions, orders) = tokio::try_join!(
-        ctx.history_executions(exec_opts),
-        ctx.history_orders(order_opts),
-    )
-    .map_err(Error::longbridge)?;
-
-    let side_map: HashMap<String, String> = orders
-        .into_iter()
-        .map(|o| (o.order_id, format!("{:?}", o.side)))
-        .collect();
+    // v3 `/trade/execution/all` filters by execution time and caps each page at
+    // 1000 records; walk `page` until `has_more` is false.
+    let mut executions: Vec<longbridge::trade::Execution> = Vec::new();
+    for page in 1..=1000u64 {
+        let mut exec_opts = longbridge::trade::GetAllExecutionsOptions::new()
+            .start_at(start)
+            .end_at(end)
+            .page(page);
+        if let Some(ref symbol) = p.symbol {
+            exec_opts = exec_opts.symbol(symbol.clone());
+        }
+        let resp = ctx
+            .all_executions(exec_opts)
+            .await
+            .map_err(Error::longbridge)?;
+        if resp.trades.is_empty() {
+            break;
+        }
+        executions.extend(resp.trades);
+        if !resp.has_more {
+            break;
+        }
+    }
 
     let result: Vec<serde_json::Value> = executions
         .iter()
         .map(|e| {
             let mut v = serde_json::to_value(e).unwrap_or_default();
             if let serde_json::Value::Object(ref mut map) = v {
-                let side = side_map.get(&e.order_id).cloned().unwrap_or_default();
-                map.insert("side".to_string(), serde_json::Value::String(side));
+                map.insert(
+                    "side".to_string(),
+                    serde_json::Value::String(format!("{:?}", e.side)),
+                );
             }
             v
         })


### PR DESCRIPTION
Two changes to the `today_executions` / `history_executions` tools (addresses longbridge/longbridge-terminal#320):

**v3 pagination.** `history_executions` now queries the v3 `/v3/trade/execution/all` endpoint (filters by **execution time** — avoids the v1 history index's cross-day eventual-consistency) and walks `page` until `has_more` is false, so >1000 fills are no longer silently truncated. Dropped the extra `history_orders` lookup that only back-filled `side` — `Execution` already carries it.

**`trade_id` in descriptions.** Both tools already return `trade_id` (the response serializes the full `Execution` struct), but the descriptions omitted it — added across en / zh-CN / zh-HK.

Refs longbridge/longbridge-terminal#320